### PR TITLE
Adjust migration script and code for entity framework migration

### DIFF
--- a/src/Altinn.Profile.Integrations/Altinn.Profile.Integrations.csproj
+++ b/src/Altinn.Profile.Integrations/Altinn.Profile.Integrations.csproj
@@ -10,6 +10,10 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="13.0.1" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.10">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Yuniql.AspNetCore" Version="1.2.25" />
     <PackageReference Include="Yuniql.PostgreSql" Version="1.3.15" />
   </ItemGroup>

--- a/src/Altinn.Profile.Integrations/Entities/Person.cs
+++ b/src/Altinn.Profile.Integrations/Entities/Person.cs
@@ -7,11 +7,11 @@ using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore;
 
 namespace Altinn.Profile.Integrations.Entities;
+
 /// <summary>
 /// Represents a person in the contact and reservation schema.
 /// </summary>
 [Table("person", Schema = "contact_and_reservation")]
-[Index("FnumberAk", Name = "idx_fnumber_ak")]
 [Index("FnumberAk", Name = "person_fnumber_ak_key", IsUnique = true)]
 public partial class Person
 {

--- a/src/Altinn.Profile.Integrations/Migration/v0.01/02-setup-tables.sql
+++ b/src/Altinn.Profile.Integrations/Migration/v0.01/02-setup-tables.sql
@@ -1,20 +1,23 @@
 -- Create table MailboxSupplier
 CREATE TABLE IF NOT EXISTS contact_and_reservation.mailbox_supplier (
-    mailbox_supplier_id INT GENERATED ALWAYS AS IDENTITY (START WITH 1 INCREMENT BY 1) PRIMARY KEY,
+    mailbox_supplier_id INT GENERATED ALWAYS AS IDENTITY,
     org_number_ak CHAR(9) NOT NULL,
-    CONSTRAINT unique_org_number_ak UNIQUE (org_number_ak)
+    CONSTRAINT mailbox_supplier_pkey PRIMARY KEY (mailbox_supplier_id)
 );
+
+CREATE UNIQUE INDEX IF NOT EXISTS unique_org_number_ak ON contact_and_reservation.mailbox_supplier (org_number_ak);
 
 -- Create table Metadata
 CREATE TABLE IF NOT EXISTS contact_and_reservation.metadata (
-    latest_change_number BIGINT PRIMARY KEY,
-    exported TIMESTAMPTZ
+    latest_change_number BIGINT,
+    exported TIMESTAMPTZ,
+    CONSTRAINT metadata_pkey PRIMARY KEY (latest_change_number)
 );
 
 -- Create table Person
 CREATE TABLE IF NOT EXISTS contact_and_reservation.person (
-    contact_and_reservation_user_id INT GENERATED ALWAYS AS IDENTITY (START WITH 1 INCREMENT BY 1) PRIMARY KEY,
-    fnumber_ak CHAR(11) NOT NULL UNIQUE,
+    contact_and_reservation_user_id INT GENERATED ALWAYS AS IDENTITY,
+    fnumber_ak CHAR(11) NOT NULL,
     reservation BOOLEAN,
     description VARCHAR(20),
     mobile_phone_number VARCHAR(20),
@@ -27,9 +30,8 @@ CREATE TABLE IF NOT EXISTS contact_and_reservation.person (
     mailbox_supplier_id_fk INT,
     x509_certificate TEXT,
     language_code CHAR(2) NULL,
-    CONSTRAINT fk_mailbox_supplier FOREIGN KEY (mailbox_supplier_id_fk) REFERENCES contact_and_reservation.mailbox_supplier (mailbox_supplier_id),
-    CONSTRAINT chk_language_code CHECK (language_code ~* '^[a-z]{2}$')
+    CONSTRAINT person_pkey PRIMARY KEY (contact_and_reservation_user_id),
+    CONSTRAINT fk_mailbox_supplier FOREIGN KEY (mailbox_supplier_id_fk) REFERENCES contact_and_reservation.mailbox_supplier (mailbox_supplier_id)
 );
 
--- Indexes for performance
-CREATE INDEX idx_fnumber_ak ON contact_and_reservation.person (fnumber_ak);
+CREATE UNIQUE INDEX IF NOT EXISTS person_fnumber_ak_key ON contact_and_reservation.person (fnumber_ak);

--- a/src/Altinn.Profile.Integrations/Migration/v0.03/01-ef-cleanup.sql
+++ b/src/Altinn.Profile.Integrations/Migration/v0.03/01-ef-cleanup.sql
@@ -1,0 +1,16 @@
+-- Unique index on fnumber_ak in person table instead of unique constraint
+ALTER TABLE contact_and_reservation.person DROP CONSTRAINT IF EXISTS person_fnumber_ak_key;
+
+CREATE UNIQUE INDEX IF NOT EXISTS person_fnumber_ak_key ON contact_and_reservation.person (fnumber_ak);
+
+-- Drop unnecessary/duplicate index
+DROP INDEX IF EXISTS contact_and_reservation.idx_fnumber_ak;
+
+-- Drop check constraint chk_language_code in person table
+ALTER TABLE contact_and_reservation.person DROP CONSTRAINT IF EXISTS chk_language_code
+
+-- Unique index on org_number_ak in mailbox_supplier table instead of unique constraint
+ALTER TABLE contact_and_reservation.mailbox_supplier DROP CONSTRAINT IF EXISTS unique_org_number_ak
+
+CREATE UNIQUE INDEX IF NOT EXISTS unique_org_number_ak ON contact_and_reservation.mailbox_supplier (org_number_ak);
+

--- a/src/Altinn.Profile.Integrations/Migration/v0.03/01-ef-cleanup.sql
+++ b/src/Altinn.Profile.Integrations/Migration/v0.03/01-ef-cleanup.sql
@@ -7,10 +7,10 @@ CREATE UNIQUE INDEX IF NOT EXISTS person_fnumber_ak_key ON contact_and_reservati
 DROP INDEX IF EXISTS contact_and_reservation.idx_fnumber_ak;
 
 -- Drop check constraint chk_language_code in person table
-ALTER TABLE contact_and_reservation.person DROP CONSTRAINT IF EXISTS chk_language_code
+ALTER TABLE contact_and_reservation.person DROP CONSTRAINT IF EXISTS chk_language_code;
 
 -- Unique index on org_number_ak in mailbox_supplier table instead of unique constraint
-ALTER TABLE contact_and_reservation.mailbox_supplier DROP CONSTRAINT IF EXISTS unique_org_number_ak
+ALTER TABLE contact_and_reservation.mailbox_supplier DROP CONSTRAINT IF EXISTS unique_org_number_ak;
 
 CREATE UNIQUE INDEX IF NOT EXISTS unique_org_number_ak ON contact_and_reservation.mailbox_supplier (org_number_ak);
 


### PR DESCRIPTION
## Description
I've compared the migration scripts to what I got from generated scripts from entity framework as well as from pgAdmin. There are few practical differences, but I did end up making a few changes.

- Entity framework seems to prefer an explicit unique index to unique constraint. I've added statements to change the table definitions.
- Removed a check constraint that was missing from the entity framework output.
- Added the required entity framework tooling packages for the `dotnet ef` commands.
- Removed redundant index on `fnumber`.

## Related Issue(s)
- #234 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
