### PR TITLE
Bug/fix application insights registration

### DIFF
--- a/src/Altinn.Profile/Program.cs
+++ b/src/Altinn.Profile/Program.cs
@@ -151,6 +151,8 @@ void ConfigureServices(IServiceCollection services, IConfiguration config)
 
     if (!string.IsNullOrEmpty(applicationInsightsConnectionString))
     {
+        // Note - this has to happen early due to a bug in Application Insights
+        // See: https://github.com/microsoft/ApplicationInsights-dotnet/issues/2879
         services.AddSingleton(typeof(ITelemetryChannel), new ServerTelemetryChannel { StorageFolder = "/tmp/logtelemetry" });
         services.AddApplicationInsightsTelemetry(new ApplicationInsightsServiceOptions
         {

--- a/src/Altinn.Profile/Program.cs
+++ b/src/Altinn.Profile/Program.cs
@@ -163,7 +163,7 @@ void ConfigureServices(IServiceCollection services, IConfiguration config)
         services.AddApplicationInsightsTelemetryProcessor<IdentityTelemetryFilter>();
         services.AddSingleton<ITelemetryInitializer, CustomTelemetryInitializer>();
 
-        logger.LogInformation("Program // ApplicationInsightsTelemetryKey = {applicationInsightsConnectionString}", applicationInsightsConnectionString);
+        logger.LogInformation("Program // ApplicationInsightsTelemetryKey = {ApplicationInsightsConnectionString}", applicationInsightsConnectionString);
     }
 
     services.AddControllers();

--- a/src/Altinn.Profile/Program.cs
+++ b/src/Altinn.Profile/Program.cs
@@ -149,6 +149,21 @@ void ConfigureServices(IServiceCollection services, IConfiguration config)
 {
     logger.LogInformation("Program // ConfigureServices");
 
+    if (!string.IsNullOrEmpty(applicationInsightsConnectionString))
+    {
+        services.AddSingleton(typeof(ITelemetryChannel), new ServerTelemetryChannel { StorageFolder = "/tmp/logtelemetry" });
+        services.AddApplicationInsightsTelemetry(new ApplicationInsightsServiceOptions
+        {
+            ConnectionString = applicationInsightsConnectionString
+        });
+
+        services.AddApplicationInsightsTelemetryProcessor<HealthTelemetryFilter>();
+        services.AddApplicationInsightsTelemetryProcessor<IdentityTelemetryFilter>();
+        services.AddSingleton<ITelemetryInitializer, CustomTelemetryInitializer>();
+
+        logger.LogInformation("Program // ApplicationInsightsTelemetryKey = {applicationInsightsConnectionString}", applicationInsightsConnectionString);
+    }
+
     services.AddControllers();
 
     services.AddMemoryCache();
@@ -195,21 +210,6 @@ void ConfigureServices(IServiceCollection services, IConfiguration config)
     services.AddRegisterService(config);
     services.AddSblBridgeClients(config);
     services.AddMaskinportenClient(config);
-
-    if (!string.IsNullOrEmpty(applicationInsightsConnectionString))
-    {
-        services.AddSingleton(typeof(ITelemetryChannel), new ServerTelemetryChannel { StorageFolder = "/tmp/logtelemetry" });
-        services.AddApplicationInsightsTelemetry(new ApplicationInsightsServiceOptions
-        {
-            ConnectionString = applicationInsightsConnectionString
-        });
-
-        services.AddApplicationInsightsTelemetryProcessor<HealthTelemetryFilter>();
-        services.AddApplicationInsightsTelemetryProcessor<IdentityTelemetryFilter>();
-        services.AddSingleton<ITelemetryInitializer, CustomTelemetryInitializer>();
-
-        logger.LogInformation("Program // ApplicationInsightsTelemetryKey = {applicationInsightsConnectionString}", applicationInsightsConnectionString);
-    }
 
     services.AddSwaggerGen(swaggerGenOptions => AddSwaggerGen(swaggerGenOptions));
 }

--- a/src/Altinn.Profile/Program.cs
+++ b/src/Altinn.Profile/Program.cs
@@ -234,7 +234,7 @@ void AddSwaggerGen(SwaggerGenOptions swaggerGenOptions)
 
 void Configure()
 {
-    logger.LogInformation("Program // Configure {appName}", app.Environment.ApplicationName);
+    logger.LogInformation("Program // Configure {AppName}", app.Environment.ApplicationName);
 
     if (app.Environment.IsDevelopment() || app.Environment.IsStaging())
     {


### PR DESCRIPTION
## Description
A bug in services extensions for Application Insights registration can cause the registration to silently fail if there are any existing service added "with keys".

See: https://github.com/microsoft/ApplicationInsights-dotnet/issues/2879

