### PR TITLE
User contact point lookup returns 0 for UserId

### DIFF
--- a/src/Altinn.Profile.Core/User.ContactPoints/UserContactPoints.cs
+++ b/src/Altinn.Profile.Core/User.ContactPoints/UserContactPoints.cs
@@ -8,10 +8,10 @@ public class UserContactPoints
     /// <summary>
     /// Gets or sets the ID of the user
     /// </summary>
-    public int? UserId { get; set; }
+    public int UserId { get; set; } = 0;
 
     /// <summary>
-    /// Gets or sets the national identityt number of the user
+    /// Gets or sets the national identity number of the user
     /// </summary>
     public string? NationalIdentityNumber { get; set; }
 

--- a/test/Altinn.Profile.Tests/Profile.Core/User/UserContactPointServiceTest.cs
+++ b/test/Altinn.Profile.Tests/Profile.Core/User/UserContactPointServiceTest.cs
@@ -229,7 +229,7 @@ public class UserContactPointServiceTest
         result.Match(
             actual =>
             {
-                Assert.DoesNotContain(actual.ContactPointsList, contactPoint => contactPoint.UserId != null);
+                Assert.DoesNotContain(actual.ContactPointsList, contactPoint => contactPoint.UserId != 0);
             },
             _ => { });
     }
@@ -253,7 +253,7 @@ public class UserContactPointServiceTest
         result.Match(
             actual =>
             {
-                Assert.DoesNotContain(actual.ContactPointsList, contactPoint => contactPoint.UserId != null);
+                Assert.DoesNotContain(actual.ContactPointsList, contactPoint => contactPoint.UserId != 0);
             },
             _ => { });
     }


### PR DESCRIPTION
## Description
Revert to the original 'int' return type for UserId, and set 0 as defult. Patch the test to reflect this change

## Related Issue(s)
- #252 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
