### PR TITLE
Resolving warnings and suggestions from analyzers

### DIFF
--- a/test/Altinn.Profile.Tests/IntegrationTests/Mocks/Authentication/ConfigurationManagerStub.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/Mocks/Authentication/ConfigurationManagerStub.cs
@@ -1,8 +1,11 @@
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Microsoft.IdentityModel.Protocols;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.IdentityModel.Tokens;
@@ -20,7 +23,7 @@ public class ConfigurationManagerStub : IConfigurationManager<OpenIdConnectConfi
     {
         ICollection<SecurityKey> signingKeys = await GetSigningKeys();
 
-        OpenIdConnectConfiguration configuration = new OpenIdConnectConfiguration();
+        OpenIdConnectConfiguration configuration = new();
         foreach (var securityKey in signingKeys)
         {
             configuration.SigningKeys.Add(securityKey);
@@ -37,10 +40,10 @@ public class ConfigurationManagerStub : IConfigurationManager<OpenIdConnectConfi
 
     private static async Task<ICollection<SecurityKey>> GetSigningKeys()
     {
-        X509Certificate2 cert = new X509Certificate2("JWTValidationCert.cer");
+        X509Certificate2 cert = X509CertificateLoader.LoadCertificateFromFile("JWTValidationCert.cer");
         SecurityKey key = new X509SecurityKey(cert);
 
-        List<SecurityKey> signingKeys = new() { key };
+        List<SecurityKey> signingKeys = [key];
 
         return await Task.FromResult(signingKeys);
     }

--- a/test/Altinn.Profile.Tests/IntegrationTests/Mocks/PublicSigningKeyProviderMock.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/Mocks/PublicSigningKeyProviderMock.cs
@@ -1,8 +1,12 @@
-﻿using System.Collections.Generic;
+﻿#nullable enable
+
+using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
+
 using Altinn.Common.AccessToken.Services;
+
 using Microsoft.IdentityModel.Tokens;
 
 namespace Altinn.Profile.Tests.IntegrationTests.Mocks;
@@ -11,9 +15,9 @@ public class PublicSigningKeyProviderMock : IPublicSigningKeyProvider
 {
     public Task<IEnumerable<SecurityKey>> GetSigningKeys(string issuer)
     {
-        List<SecurityKey> signingKeys = new List<SecurityKey>();
+        List<SecurityKey> signingKeys = [];
 
-        X509Certificate2 cert = new X509Certificate2($"{issuer}-org.pem");
+        X509Certificate2 cert = X509CertificateLoader.LoadCertificateFromFile($"{issuer}-org.pem");
         SecurityKey key = new X509SecurityKey(cert);
 
         signingKeys.Add(key);

--- a/test/Altinn.Profile.Tests/IntegrationTests/Utils/JwtGenerator.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/Utils/JwtGenerator.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
@@ -37,18 +39,18 @@ public static class JwtGenerator
         return serializedToken;
     }
 
-    private static SigningCredentials GetSigningCredentials(string issuer)
+    private static X509SigningCredentials GetSigningCredentials(string issuer)
     {
         string certPath = "jwtselfsignedcert.pfx";
         if (!issuer.Equals("UnitTest"))
         {
             certPath = $"{issuer}-org.pfx";
 
-            X509Certificate2 certIssuer = new X509Certificate2(certPath);
+            X509Certificate2 certIssuer = X509CertificateLoader.LoadPkcs12FromFile(certPath, string.Empty);
             return new X509SigningCredentials(certIssuer, SecurityAlgorithms.RsaSha256);
         }
 
-        X509Certificate2 cert = new X509Certificate2(certPath, "qwer1234");
+        X509Certificate2 cert = X509CertificateLoader.LoadPkcs12FromFile(certPath, "qwer1234");
         return new X509SigningCredentials(cert, SecurityAlgorithms.RsaSha256);
     }
 }


### PR DESCRIPTION
## Description
Fixing a new things in the test project. 

- Most notable the deprecation of X509Certificate2 constructors.
- Turned on nullable in a few files and fixed any following warning. 
- Added a test to verify a theory developed during an analysis of support for system user.