### PR TITLE
Log brreg page and include more detail in since timestamp

### DIFF
--- a/src/Altinn.Profile.Integrations/OrganizationNotificationAddressRegistry/OrganizationNotificationAddressUpdateJob.cs
+++ b/src/Altinn.Profile.Integrations/OrganizationNotificationAddressRegistry/OrganizationNotificationAddressUpdateJob.cs
@@ -30,10 +30,14 @@ public class OrganizationNotificationAddressUpdateJob(
     /// <exception cref="InvalidOperationException">Thrown when the endpoint URL is null or empty.</exception>
     public async Task SyncNotificationAddressesAsync()
     {
-        DateTime lastUpdated = await _metadataRepository.GetLatestSyncTimestampAsync();
+        DateTime? lastUpdated = await _metadataRepository.GetLatestSyncTimestampAsync();
 
         // Time should be in iso8601 format. Example: 2018-02-15T11:07:12Z
-        string? fullUrl = _organizationNotificationAddressSettings.ChangesLogEndpoint + $"?since={lastUpdated:yyyy-MM-ddTHH\\:mm\\:ss.fffffffZ}&pageSize={_organizationNotificationAddressSettings.ChangesLogPageSize}";
+        string? fullUrl = _organizationNotificationAddressSettings.ChangesLogEndpoint + $"?pageSize={_organizationNotificationAddressSettings.ChangesLogPageSize}";
+        if (lastUpdated != null)
+        {
+            fullUrl += $"&since={lastUpdated:yyyy-MM-ddTHH\\:mm\\:ss.fffffffZ}";
+        }
 
         do
         {

--- a/src/Altinn.Profile.Integrations/OrganizationNotificationAddressRegistry/OrganizationNotificationAddressUpdateJob.cs
+++ b/src/Altinn.Profile.Integrations/OrganizationNotificationAddressRegistry/OrganizationNotificationAddressUpdateJob.cs
@@ -1,6 +1,4 @@
 ﻿using Altinn.Profile.Integrations.Repositories;
-using Altinn.Profile.Integrations.SblBridge.Unit.Profile;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
 namespace Altinn.Profile.Integrations.OrganizationNotificationAddressRegistry;
@@ -35,7 +33,7 @@ public class OrganizationNotificationAddressUpdateJob(
         DateTime lastUpdated = await _metadataRepository.GetLatestSyncTimestampAsync();
 
         // Time should be in iso8601 format. Example: 2018-02-15T11:07:12Z
-        string? fullUrl = _organizationNotificationAddressSettings.ChangesLogEndpoint + $"?since={lastUpdated.ToString("yyyy-MM-ddTHH\\:mm\\:ss.fffffffZ")}&pageSize={_organizationNotificationAddressSettings.ChangesLogPageSize}";
+        string? fullUrl = _organizationNotificationAddressSettings.ChangesLogEndpoint + $"?since={lastUpdated:yyyy-MM-ddTHH\\:mm\\:ss.fffffffZ}&pageSize={_organizationNotificationAddressSettings.ChangesLogPageSize}";
 
         do
         {

--- a/src/Altinn.Profile.Integrations/OrganizationNotificationAddressRegistry/OrganizationNotificationAddressUpdateJob.cs
+++ b/src/Altinn.Profile.Integrations/OrganizationNotificationAddressRegistry/OrganizationNotificationAddressUpdateJob.cs
@@ -1,4 +1,7 @@
 ﻿using Altinn.Profile.Integrations.Repositories;
+using Altinn.Profile.Integrations.SblBridge.Unit.Profile;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 
 namespace Altinn.Profile.Integrations.OrganizationNotificationAddressRegistry;
 
@@ -10,17 +13,20 @@ namespace Altinn.Profile.Integrations.OrganizationNotificationAddressRegistry;
 /// <param name="organizationNotificationAddressHttpClient">A HTTP client that can be used to retrieve contact details changes</param>
 /// <param name="metadataRepository">A repository implementation for managing persistence of the job status between runs</param>
 /// <param name="notificationAddressUpdater">A repository implementation for managing persistence for the local contact information</param>
+/// <param name="logger">A logger to log detailed information.</param>
 public class OrganizationNotificationAddressUpdateJob(
     OrganizationNotificationAddressSettings organizationNotificationAddressSettings,
     IOrganizationNotificationAddressHttpClient organizationNotificationAddressHttpClient,
     IRegistrySyncMetadataRepository metadataRepository,
-    IOrganizationNotificationAddressUpdater notificationAddressUpdater)
+    IOrganizationNotificationAddressUpdater notificationAddressUpdater,
+    ILogger<OrganizationNotificationAddressUpdateJob> logger)
     : IOrganizationNotificationAddressUpdateJob
 {
     private readonly OrganizationNotificationAddressSettings _organizationNotificationAddressSettings = organizationNotificationAddressSettings;
     private readonly IOrganizationNotificationAddressHttpClient _organizationNotificationAddressHttpClient = organizationNotificationAddressHttpClient;
     private readonly IRegistrySyncMetadataRepository _metadataRepository = metadataRepository;
     private readonly IOrganizationNotificationAddressUpdater _notificationAddressUpdater = notificationAddressUpdater;
+    private readonly ILogger<OrganizationNotificationAddressUpdateJob> _logger = logger;
 
     /// <inheritdoc/>
     /// <exception cref="InvalidOperationException">Thrown when the endpoint URL is null or empty.</exception>
@@ -29,10 +35,12 @@ public class OrganizationNotificationAddressUpdateJob(
         DateTime lastUpdated = await _metadataRepository.GetLatestSyncTimestampAsync();
 
         // Time should be in iso8601 format. Example: 2018-02-15T11:07:12Z
-        string? fullUrl = _organizationNotificationAddressSettings.ChangesLogEndpoint + $"?since={lastUpdated.ToString("yyyy-MM-ddTHH\\:mm\\:ssZ")}&pageSize={_organizationNotificationAddressSettings.ChangesLogPageSize}";
+        string? fullUrl = _organizationNotificationAddressSettings.ChangesLogEndpoint + $"?since={lastUpdated.ToString("yyyy-MM-ddTHH\\:mm\\:ss.fffffffZ")}&pageSize={_organizationNotificationAddressSettings.ChangesLogPageSize}";
 
         do
         {
+            _logger.LogInformation("Fetch data from brreg at url: {fullUrl}", fullUrl);
+
             NotificationAddressChangesLog changesLog = await _organizationNotificationAddressHttpClient.GetAddressChangesAsync(fullUrl);
 
             var noChangesSinceLastCheck = changesLog.OrganizationNotificationAddressList == null || changesLog.OrganizationNotificationAddressList?.Count == 0;
@@ -41,7 +49,7 @@ public class OrganizationNotificationAddressUpdateJob(
                 break;
             }
 
-            int updatedRowsCount = await _notificationAddressUpdater.SyncNotificationAddressesAsync(changesLog);
+            var updatedRowsCount = await _notificationAddressUpdater.SyncNotificationAddressesAsync(changesLog);
 
             if (updatedRowsCount > 0)
             {

--- a/src/Altinn.Profile.Integrations/OrganizationNotificationAddressRegistry/OrganizationNotificationAddressUpdateJob.cs
+++ b/src/Altinn.Profile.Integrations/OrganizationNotificationAddressRegistry/OrganizationNotificationAddressUpdateJob.cs
@@ -49,7 +49,7 @@ public class OrganizationNotificationAddressUpdateJob(
                 break;
             }
 
-            var updatedRowsCount = await _notificationAddressUpdater.SyncNotificationAddressesAsync(changesLog);
+            int updatedRowsCount = await _notificationAddressUpdater.SyncNotificationAddressesAsync(changesLog);
 
             if (updatedRowsCount > 0)
             {

--- a/src/Altinn.Profile.Integrations/OrganizationNotificationAddressRegistry/OrganizationNotificationAddressUpdateJob.cs
+++ b/src/Altinn.Profile.Integrations/OrganizationNotificationAddressRegistry/OrganizationNotificationAddressUpdateJob.cs
@@ -37,7 +37,7 @@ public class OrganizationNotificationAddressUpdateJob(
 
         do
         {
-            _logger.LogInformation("Fetch data from brreg at url: {fullUrl}", fullUrl);
+            _logger.LogInformation("Fetch data from brreg at url: {FullUrl}", fullUrl);
 
             NotificationAddressChangesLog changesLog = await _organizationNotificationAddressHttpClient.GetAddressChangesAsync(fullUrl);
 

--- a/src/Altinn.Profile.Integrations/Repositories/IRegistrySyncMetadataRepository.cs
+++ b/src/Altinn.Profile.Integrations/Repositories/IRegistrySyncMetadataRepository.cs
@@ -11,7 +11,7 @@ public interface IRegistrySyncMetadataRepository
     /// <returns>
     /// A task that represents the asynchronous operation.
     /// </returns>
-    Task<DateTime> GetLatestSyncTimestampAsync();
+    Task<DateTime?> GetLatestSyncTimestampAsync();
 
     /// <summary>
     /// Asynchronously updates the latest sync timestamp in the metadata repository.

--- a/src/Altinn.Profile.Integrations/Repositories/RegistrySyncMetadataRepository.cs
+++ b/src/Altinn.Profile.Integrations/Repositories/RegistrySyncMetadataRepository.cs
@@ -11,14 +11,14 @@ public class RegistrySyncMetadataRepository(IDbContextFactory<ProfileDbContext> 
     private readonly IDbContextFactory<ProfileDbContext> _contextFactory = contextFactory;
 
     /// <inheritdoc />
-    public async Task<DateTime> GetLatestSyncTimestampAsync()
+    public async Task<DateTime?> GetLatestSyncTimestampAsync()
     {
         using ProfileDbContext databaseContext = await _contextFactory.CreateDbContextAsync();
 
         var lastSync = await databaseContext.RegistrySyncMetadata.FirstOrDefaultAsync();
         if (lastSync == null)
         {
-            return DateTime.MinValue;
+            return null;
         }
 
         return lastSync.LastChangedDateTime;

--- a/test/Altinn.Profile.Tests/Profile.Integrations/OrganizationNotificationAddressTests/OrganizationNotificationAddressUpdateJobTests.cs
+++ b/test/Altinn.Profile.Tests/Profile.Integrations/OrganizationNotificationAddressTests/OrganizationNotificationAddressUpdateJobTests.cs
@@ -2,7 +2,9 @@
 using System.Threading.Tasks;
 using Altinn.Profile.Integrations.OrganizationNotificationAddressRegistry;
 using Altinn.Profile.Integrations.Repositories;
+using Altinn.Profile.Integrations.SblBridge.Unit.Profile;
 using Altinn.Profile.Tests.Testdata;
+using Microsoft.Extensions.Logging;
 using Moq;
 
 using Xunit;
@@ -15,6 +17,7 @@ public class OrganizationNotificationAddressUpdateJobTests()
     private readonly Mock<IRegistrySyncMetadataRepository> _metadataRepository = new();
     private readonly Mock<IOrganizationNotificationAddressUpdater> _organizationNotificationAddressUpdater = new();
     private readonly Mock<IOrganizationNotificationAddressHttpClient> _httpClient = new();
+    private readonly Mock<ILogger<OrganizationNotificationAddressUpdateJob>> _logger = new();
 
     [Fact]
     public async Task SyncNotificationAddressesAsync_IfNoEntries_DoNothing()
@@ -27,7 +30,7 @@ public class OrganizationNotificationAddressUpdateJobTests()
             .ReturnsAsync(await TestDataLoader.Load<NotificationAddressChangesLog>("changes_0_faulty"));
 
         OrganizationNotificationAddressUpdateJob target =
-            new(_settings, _httpClient.Object, _metadataRepository.Object, _organizationNotificationAddressUpdater.Object);
+            new(_settings, _httpClient.Object, _metadataRepository.Object, _organizationNotificationAddressUpdater.Object, _logger.Object);
 
         // Act
         await target.SyncNotificationAddressesAsync();
@@ -49,7 +52,7 @@ public class OrganizationNotificationAddressUpdateJobTests()
             .ReturnsAsync(await TestDataLoader.Load<NotificationAddressChangesLog>("changes_0"));
 
         OrganizationNotificationAddressUpdateJob target =
-            new(_settings, _httpClient.Object, _metadataRepository.Object, _organizationNotificationAddressUpdater.Object);
+            new(_settings, _httpClient.Object, _metadataRepository.Object, _organizationNotificationAddressUpdater.Object, _logger.Object);
 
         // Act
         await target.SyncNotificationAddressesAsync();
@@ -78,7 +81,7 @@ public class OrganizationNotificationAddressUpdateJobTests()
         _metadataRepository.Setup(m => m.UpdateLatestChangeTimestampAsync(It.IsAny<DateTime>()));
 
         OrganizationNotificationAddressUpdateJob target =
-            new(_settings, _httpClient.Object, _metadataRepository.Object, _organizationNotificationAddressUpdater.Object);
+            new(_settings, _httpClient.Object, _metadataRepository.Object, _organizationNotificationAddressUpdater.Object, _logger.Object);
 
         // Act
         await target.SyncNotificationAddressesAsync();
@@ -103,7 +106,7 @@ public class OrganizationNotificationAddressUpdateJobTests()
             .ReturnsAsync(2);
 
         OrganizationNotificationAddressUpdateJob target =
-            new(_settings, _httpClient.Object, _metadataRepository.Object, _organizationNotificationAddressUpdater.Object);
+            new(_settings, _httpClient.Object, _metadataRepository.Object, _organizationNotificationAddressUpdater.Object, _logger.Object);
 
         // Act
         await target.SyncNotificationAddressesAsync();
@@ -130,7 +133,7 @@ public class OrganizationNotificationAddressUpdateJobTests()
             .ReturnsAsync(0);
 
         OrganizationNotificationAddressUpdateJob target =
-            new(_settings, _httpClient.Object, _metadataRepository.Object, _organizationNotificationAddressUpdater.Object);
+            new(_settings, _httpClient.Object, _metadataRepository.Object, _organizationNotificationAddressUpdater.Object, _logger.Object);
 
         // Act
         await target.SyncNotificationAddressesAsync();

--- a/test/Altinn.Profile.Tests/Profile.Integrations/OrganizationNotificationAddressTests/OrganizationNotificationAddressUpdateJobTests.cs
+++ b/test/Altinn.Profile.Tests/Profile.Integrations/OrganizationNotificationAddressTests/OrganizationNotificationAddressUpdateJobTests.cs
@@ -2,7 +2,6 @@
 using System.Threading.Tasks;
 using Altinn.Profile.Integrations.OrganizationNotificationAddressRegistry;
 using Altinn.Profile.Integrations.Repositories;
-using Altinn.Profile.Integrations.SblBridge.Unit.Profile;
 using Altinn.Profile.Tests.Testdata;
 using Microsoft.Extensions.Logging;
 using Moq;

--- a/test/Altinn.Profile.Tests/Profile.Integrations/OrganizationNotificationAddressTests/OrganizationNotificationAddressUpdateJobTests.cs
+++ b/test/Altinn.Profile.Tests/Profile.Integrations/OrganizationNotificationAddressTests/OrganizationNotificationAddressUpdateJobTests.cs
@@ -92,7 +92,7 @@ public class OrganizationNotificationAddressUpdateJobTests()
     }
 
     [Fact]
-    public async Task SyncNotificationAddressesAsyncTest_WhenNoLatestSyncDate_GetsFrom2001()
+    public async Task SyncNotificationAddressesAsyncTest_WhenNoLatestSyncDate_GetsWithoutSinceParam()
     {
         // Arrange
         _metadataRepository.SetupSequence(m => m.GetLatestSyncTimestampAsync())

--- a/test/Altinn.Profile.Tests/Profile.Integrations/OrganizationNotificationAddressTests/RegistrySyncMetadataRepositoryTests.cs
+++ b/test/Altinn.Profile.Tests/Profile.Integrations/OrganizationNotificationAddressTests/RegistrySyncMetadataRepositoryTests.cs
@@ -77,13 +77,13 @@ public class RegistrySyncMetadataRepositoryTests : IDisposable
     }
 
     [Fact]
-    public async Task GetLatestSyncTimestampAsync_WhenNoEntries_ReturnsEarliestDate()
+    public async Task GetLatestSyncTimestampAsync_WhenNoEntries_ReturnsNull()
     {
         // Act
         var timestamp = await _repository.GetLatestSyncTimestampAsync();
 
         // Assert
-        Assert.Equal(DateTime.MinValue, timestamp);
+        Assert.Null(timestamp);
     }
 
     [Fact]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We would like to log information about the update job. The url contains information about scrollID and since timestamp that contains information about how far we got. I cannot find query params in application insights today and i don't think we would like to log this for all calls as this could possibly contain sensitive data.

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced logging now provides more detailed information during data fetch operations.
  - Improved timestamp precision in API requests ensures more accurate time tracking.
  - Updated handling of sync timestamps to allow for nullable values, enhancing clarity on data availability.

- **Tests**
  - Updated test routines to accommodate the enhanced logging features.
  - Adjusted tests to reflect new expected behavior for sync timestamp retrieval, now returning null when no entries are found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->