### PR TITLE
Disable HTTP metrics for health endpoint

### DIFF
--- a/src/Altinn.Profile/Program.cs
+++ b/src/Altinn.Profile/Program.cs
@@ -270,7 +270,7 @@ void Configure()
     app.UseAuthorization();
 
     app.MapControllers();
-    app.MapHealthChecks("/health").DisableHttpMetrics();
+    app.MapHealthChecks("/health");
 }
 
 /// <summary>


### PR DESCRIPTION
## Description
POC to see if this oneliner is a low-hanging fruit to exclude health check logging (refer to the related issue for further details).
⚠️ Currently under test in AT

## Related Issue(s)
- [#206 (team-core-private)](https://github.com/Altinn/team-core-private/issues/206)

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

Release Notes:  
We have updated the application's health monitoring configuration to improve performance and efficiency. These improvements help reduce unnecessary overhead in the monitoring process, ensuring a smoother and more reliable experience.

- **Chores**
  - Adjusted the health check endpoint to streamline metrics collection, enhancing overall monitoring without impacting core functionality.
  - Introduced a new logging configuration for OpenTelemetry, setting a warning log level for Microsoft.AspNetCore.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->