### PR TITLE
First draft of external read api

### DIFF
--- a/src/Altinn.Profile.Core/OrganizationNotificationAddresses/NotificationAddress.cs
+++ b/src/Altinn.Profile.Core/OrganizationNotificationAddresses/NotificationAddress.cs
@@ -1,5 +1,7 @@
 ﻿#nullable disable
 
+using System.ComponentModel.DataAnnotations;
+
 namespace Altinn.Profile.Core.OrganizationNotificationAddresses
 {
     /// <summary>
@@ -11,6 +13,13 @@ namespace Altinn.Profile.Core.OrganizationNotificationAddresses
         /// <see cref="NotificationAddressID"/>
         /// </summary>
         public int NotificationAddressID { get; set; }
+
+        /// <summary>
+        /// Id from the registry
+        /// </summary>
+        [Required]
+        [StringLength(32)]
+        public string RegistryID { get; set; }
 
         /// <summary>
         /// The AddressType, either Email or Sms
@@ -36,5 +45,10 @@ namespace Altinn.Profile.Core.OrganizationNotificationAddresses
         /// Name of the contact point 
         /// </summary>
         public string NotificationName { get; set; }
+
+        /// <summary>
+        /// A value indicating whether the entity is deleted in Altinn.
+        /// </summary>
+        public bool? IsSoftDeleted { get; set; }
     }
 }

--- a/src/Altinn.Profile.Core/OrganizationNotificationAddresses/NotificationAddress.cs
+++ b/src/Altinn.Profile.Core/OrganizationNotificationAddresses/NotificationAddress.cs
@@ -15,13 +15,6 @@ namespace Altinn.Profile.Core.OrganizationNotificationAddresses
         public int NotificationAddressID { get; set; }
 
         /// <summary>
-        /// Id from the registry
-        /// </summary>
-        [Required]
-        [StringLength(32)]
-        public string RegistryID { get; set; }
-
-        /// <summary>
         /// The AddressType, either Email or Sms
         /// </summary>
         public AddressType AddressType { get; set; }

--- a/src/Altinn.Profile/Altinn.Profile.csproj
+++ b/src/Altinn.Profile/Altinn.Profile.csproj
@@ -37,8 +37,4 @@
     </AdditionalFiles>
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Mappers\" />
-  </ItemGroup>
-
 </Project>

--- a/src/Altinn.Profile/Altinn.Profile.csproj
+++ b/src/Altinn.Profile/Altinn.Profile.csproj
@@ -37,4 +37,8 @@
     </AdditionalFiles>
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Mappers\" />
+  </ItemGroup>
+
 </Project>

--- a/src/Altinn.Profile/Controllers/OrganizationsController.cs
+++ b/src/Altinn.Profile/Controllers/OrganizationsController.cs
@@ -7,6 +7,7 @@ using Altinn.Profile.Core;
 using Altinn.Profile.Core.OrganizationNotificationAddresses;
 using Altinn.Profile.Mappers;
 using Altinn.Profile.Models;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using static Altinn.Profile.Models.OrgNotificationAddressesResponse;
@@ -20,6 +21,7 @@ namespace Altinn.Profile.Controllers
     [ApiExplorerSettings(IgnoreApi = true)]
     [Consumes("application/json")]
     [Produces("application/json")]
+    [Authorize(Policy = "PlatformAccess")]
     public class OrganizationsController : ControllerBase
     {
         private readonly IOrganizationNotificationAddressesService _notificationAddressService;
@@ -42,9 +44,8 @@ namespace Altinn.Profile.Controllers
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<ActionResult<OrganizationResponse>> GetMandatory([FromRoute]string organizationNumber, CancellationToken cancellationToken)
         {
-            // Check user has access to org number
             var organizations = await _notificationAddressService.GetOrganizationNotificationAddresses([organizationNumber], cancellationToken);
-            if (organizations.Count() == 0)
+            if (!organizations.Any())
             {
                 return NotFound();
             }

--- a/src/Altinn.Profile/Controllers/OrganizationsController.cs
+++ b/src/Altinn.Profile/Controllers/OrganizationsController.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 
 using Altinn.Profile.Core;
 using Altinn.Profile.Core.OrganizationNotificationAddresses;
+using Altinn.Profile.Mappers;
 using Altinn.Profile.Models;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -48,47 +49,11 @@ namespace Altinn.Profile.Controllers
                 return NotFound();
             }
 
-            if (organizations.Count() > 1)
-            {
-                // We have a problem
-            }
-
-            var response = MapResponse(organizations);
-
-            return Ok(response);
-        }
-
-        private OrganizationResponse MapResponse(IEnumerable<Organization> organizations)
-        {
             var organization = organizations.First();
 
-            var result = new OrganizationResponse 
-            { 
-                OrganizationNumber = organization.OrganizationNumber,
-                NotificationAddresses = organization.NotificationAddresses.Where(n => n.IsSoftDeleted != true).Select(MapNotificationAddress).ToList()
-            };
+            var response = OrganizationResponseMapper.MapResponse(organization);
 
-            return result;
-        }
-
-        private OrganizationResponse.NotificationAddress MapNotificationAddress(NotificationAddress notificationAddress)
-        {
-            var response = new OrganizationResponse.NotificationAddress
-            {
-                RegistryID = notificationAddress.RegistryID,
-                NotificationAddressID = notificationAddress.NotificationAddressID,
-            };
-            if (notificationAddress.AddressType == AddressType.Email)
-            {
-                response.Email = notificationAddress.FullAddress;
-            }
-            else
-            {
-                response.Phone = notificationAddress.Address;
-                response.CountryCode = notificationAddress.Domain;
-            }
-
-            return response;
+            return Ok(response);
         }
     }
 }

--- a/src/Altinn.Profile/Controllers/OrganizationsController.cs
+++ b/src/Altinn.Profile/Controllers/OrganizationsController.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -32,9 +33,9 @@ namespace Altinn.Profile.Controllers
         }
 
         /// <summary>
-        /// Endpoint looking up the notification addresses for the organization provided in the lookup object in the request body
+        /// Endpoint looking up the notification addresses for the given organization
         /// </summary>
-        /// <returns>Returns an overview of the user registered notification addresses for the provided organization</returns>
+        /// <returns>Returns an overview of the registered notification addresses for the provided organization</returns>
         [HttpGet("mandatory")]
         [Authorize(Policy = "PlatformAccess")]
         [ProducesResponseType(StatusCodes.Status200OK)]
@@ -43,9 +44,16 @@ namespace Altinn.Profile.Controllers
         public async Task<ActionResult<OrganizationResponse>> GetMandatory([FromRoute]string organizationNumber, CancellationToken cancellationToken)
         {
             var organizations = await _notificationAddressService.GetOrganizationNotificationAddresses([organizationNumber], cancellationToken);
-            if (!organizations.Any())
+
+            var orgCount = organizations.Count();
+
+            if (orgCount == 0)
             {
                 return NotFound();
+            }
+            else if (orgCount > 1)
+            {
+                throw new InvalidOperationException("Indecisive organization result");
             }
 
             var organization = organizations.First();

--- a/src/Altinn.Profile/Controllers/OrganizationsController.cs
+++ b/src/Altinn.Profile/Controllers/OrganizationsController.cs
@@ -1,0 +1,94 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Altinn.Profile.Core;
+using Altinn.Profile.Core.OrganizationNotificationAddresses;
+using Altinn.Profile.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using static Altinn.Profile.Models.OrgNotificationAddressesResponse;
+
+namespace Altinn.Profile.Controllers
+{
+    /// <summary>
+    /// Controller for organization notifications address API endpoints for external usage
+    /// </summary>
+    [Route("profile/api/v1/organizations/{organizationNumber}/notificationaddresses")]
+    [ApiExplorerSettings(IgnoreApi = true)]
+    [Consumes("application/json")]
+    [Produces("application/json")]
+    public class OrganizationsController : ControllerBase
+    {
+        private readonly IOrganizationNotificationAddressesService _notificationAddressService;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OrganizationsController"/> class.
+        /// </summary>
+        public OrganizationsController(IOrganizationNotificationAddressesService notificationAddressService)
+        {
+            _notificationAddressService = notificationAddressService;
+        }
+
+        /// <summary>
+        /// Endpoint looking up the notification addresses for the organization provided in the lookup object in the request body
+        /// </summary>
+        /// <returns>Returns an overview of the user registered notification addresses for the provided organization</returns>
+        [HttpGet("mandatory")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<ActionResult<OrganizationResponse>> GetMandatory([FromRoute]string organizationNumber, CancellationToken cancellationToken)
+        {
+            // Check user has access to org number
+            var organizations = await _notificationAddressService.GetOrganizationNotificationAddresses([organizationNumber], cancellationToken);
+            if (organizations.Count() == 0)
+            {
+                return NotFound();
+            }
+
+            if (organizations.Count() > 1)
+            {
+                // We have a problem
+            }
+
+            var response = MapResponse(organizations);
+
+            return Ok(response);
+        }
+
+        private OrganizationResponse MapResponse(IEnumerable<Organization> organizations)
+        {
+            var organization = organizations.First();
+
+            var result = new OrganizationResponse 
+            { 
+                OrganizationNumber = organization.OrganizationNumber,
+                NotificationAddresses = organization.NotificationAddresses.Where(n => n.IsSoftDeleted != true).Select(MapNotificationAddress).ToList()
+            };
+
+            return result;
+        }
+
+        private OrganizationResponse.NotificationAddress MapNotificationAddress(NotificationAddress notificationAddress)
+        {
+            var response = new OrganizationResponse.NotificationAddress
+            {
+                RegistryID = notificationAddress.RegistryID,
+                NotificationAddressID = notificationAddress.NotificationAddressID,
+            };
+            if (notificationAddress.AddressType == AddressType.Email)
+            {
+                response.Email = notificationAddress.FullAddress;
+            }
+            else
+            {
+                response.Phone = notificationAddress.Address;
+                response.CountryCode = notificationAddress.Domain;
+            }
+
+            return response;
+        }
+    }
+}

--- a/src/Altinn.Profile/Controllers/OrganizationsController.cs
+++ b/src/Altinn.Profile/Controllers/OrganizationsController.cs
@@ -1,16 +1,13 @@
-﻿using System.Collections.Generic;
-using System.Linq;
+﻿using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Altinn.Profile.Core;
 using Altinn.Profile.Core.OrganizationNotificationAddresses;
 using Altinn.Profile.Mappers;
 using Altinn.Profile.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using static Altinn.Profile.Models.OrgNotificationAddressesResponse;
 
 namespace Altinn.Profile.Controllers
 {
@@ -21,7 +18,7 @@ namespace Altinn.Profile.Controllers
     [ApiExplorerSettings(IgnoreApi = true)]
     [Consumes("application/json")]
     [Produces("application/json")]
-    [Authorize(Policy = "PlatformAccess")]
+    [Authorize]
     public class OrganizationsController : ControllerBase
     {
         private readonly IOrganizationNotificationAddressesService _notificationAddressService;
@@ -39,6 +36,7 @@ namespace Altinn.Profile.Controllers
         /// </summary>
         /// <returns>Returns an overview of the user registered notification addresses for the provided organization</returns>
         [HttpGet("mandatory")]
+        [Authorize(Policy = "PlatformAccess")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]

--- a/src/Altinn.Profile/Mappers/OrganizationResponseMapper.cs
+++ b/src/Altinn.Profile/Mappers/OrganizationResponseMapper.cs
@@ -24,9 +24,9 @@ namespace Altinn.Profile.Mappers
             return result;
         }
 
-        private static OrganizationResponse.NotificationAddress MapNotificationAddress(NotificationAddress notificationAddress)
+        private static NotificationAddressModel MapNotificationAddress(NotificationAddress notificationAddress)
         {
-            var response = new OrganizationResponse.NotificationAddress
+            var response = new NotificationAddressModel
             {
                 RegistryID = notificationAddress.RegistryID,
                 NotificationAddressID = notificationAddress.NotificationAddressID,

--- a/src/Altinn.Profile/Mappers/OrganizationResponseMapper.cs
+++ b/src/Altinn.Profile/Mappers/OrganizationResponseMapper.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Altinn.Profile.Core.OrganizationNotificationAddresses;
+using Altinn.Profile.Models;
+
+namespace Altinn.Profile.Mappers
+{
+    /// <summary>
+    /// Maps from an organization to an organization reponse
+    /// </summary>
+    public static class OrganizationResponseMapper
+    {
+        /// <summary>
+        /// Maps from an organization to an organization reponse
+        /// </summary>
+        public static OrganizationResponse MapResponse(Organization organization)
+        {
+            var result = new OrganizationResponse
+            {
+                OrganizationNumber = organization.OrganizationNumber,
+                NotificationAddresses = organization.NotificationAddresses.Where(n => n.IsSoftDeleted != true).Select(MapNotificationAddress).ToList()
+            };
+
+            return result;
+        }
+
+        private static OrganizationResponse.NotificationAddress MapNotificationAddress(NotificationAddress notificationAddress)
+        {
+            var response = new OrganizationResponse.NotificationAddress
+            {
+                RegistryID = notificationAddress.RegistryID,
+                NotificationAddressID = notificationAddress.NotificationAddressID,
+            };
+            if (notificationAddress.AddressType == AddressType.Email)
+            {
+                response.Email = notificationAddress.FullAddress;
+            }
+            else
+            {
+                response.Phone = notificationAddress.Address;
+                response.CountryCode = notificationAddress.Domain;
+            }
+
+            return response;
+        }
+    }
+}

--- a/src/Altinn.Profile/Mappers/OrganizationResponseMapper.cs
+++ b/src/Altinn.Profile/Mappers/OrganizationResponseMapper.cs
@@ -28,7 +28,6 @@ namespace Altinn.Profile.Mappers
         {
             var response = new NotificationAddressModel
             {
-                RegistryID = notificationAddress.RegistryID,
                 NotificationAddressID = notificationAddress.NotificationAddressID,
             };
             if (notificationAddress.AddressType == AddressType.Email)

--- a/src/Altinn.Profile/Models/NotificationAddressModel.cs
+++ b/src/Altinn.Profile/Models/NotificationAddressModel.cs
@@ -28,6 +28,7 @@ namespace Altinn.Profile.Models
         /// <summary>
         /// Phone number
         /// </summary>
+        [CustomRegexForNotificationAddresses("Phone")]
         public string Phone { get; set; }
 
         /// <summary>

--- a/src/Altinn.Profile/Models/NotificationAddressModel.cs
+++ b/src/Altinn.Profile/Models/NotificationAddressModel.cs
@@ -1,0 +1,45 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Altinn.Profile.Validators;
+
+namespace Altinn.Profile.Models
+{
+    /// <summary>
+    /// Represents a notification address
+    /// </summary>
+    public class NotificationAddressModel
+    {
+        /// <summary>
+        /// <see cref="NotificationAddressID"/>
+        /// </summary>
+        public int NotificationAddressID { get; set; }
+
+        /// <summary>
+        /// Country code for phone number
+        /// </summary>
+        [CustomRegexForNotificationAddresses("CountryCode")]
+        public string CountryCode { get; set; }
+
+        /// <summary>
+        /// Email address
+        /// </summary>
+        [CustomRegexForNotificationAddresses("Email")]
+        public string Email { get; set; }
+
+        /// <summary>
+        /// Phone number
+        /// </summary>
+        public string Phone { get; set; }
+
+        /// <summary>
+        /// A value indicating whether the entity is deleted in Altinn.
+        /// </summary>
+        public bool? IsDeleted { get; set; }
+
+        /// <summary>
+        /// Id from the registry
+        /// </summary>
+        [Required]
+        [StringLength(32)]
+        public string RegistryID { get; set; }
+    }
+}

--- a/src/Altinn.Profile/Models/NotificationAddressModel.cs
+++ b/src/Altinn.Profile/Models/NotificationAddressModel.cs
@@ -35,12 +35,5 @@ namespace Altinn.Profile.Models
         /// A value indicating whether the entity is deleted in Altinn.
         /// </summary>
         public bool? IsDeleted { get; set; }
-
-        /// <summary>
-        /// Id from the registry
-        /// </summary>
-        [Required]
-        [StringLength(32)]
-        public string RegistryID { get; set; }
     }
 }

--- a/src/Altinn.Profile/Models/OrganizationResponse.cs
+++ b/src/Altinn.Profile/Models/OrganizationResponse.cs
@@ -1,7 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using Altinn.Profile.Core.OrganizationNotificationAddresses;
-using Altinn.Profile.Validators;
 
 namespace Altinn.Profile.Models
 {    
@@ -18,46 +15,6 @@ namespace Altinn.Profile.Models
         /// <summary>
         /// Represents a list of mandatory notification address
         /// </summary>
-        public List<NotificationAddress> NotificationAddresses { get; set; }
-
-        /// <summary>
-        /// Represents a notification address
-        /// </summary>
-        public class NotificationAddress
-        {
-            /// <summary>
-            /// <see cref="NotificationAddressID"/>
-            /// </summary>
-            public int NotificationAddressID { get; set; }
-
-            /// <summary>
-            /// Country code for phone number//TODO 
-            /// </summary>
-            [CustomRegexForNotificationAddresses("CountryCode", ErrorMessage = "AltinnII.SBL.UserProfile.Regex.CountryCode")]
-            public string CountryCode { get; set; }
-
-            /// <summary>
-            /// Email address
-            /// </summary>
-            [CustomRegexForNotificationAddresses("Email", ErrorMessage = "AltinnII.SBL.UserProfile.Regex.Email")]
-            public string Email { get; set; }
-
-            /// <summary>
-            /// Phone number
-            /// </summary>
-            public string Phone { get; set; }
-
-            /// <summary>
-            /// A value indicating whether the entity is deleted in Altinn.
-            /// </summary>
-            public bool? IsDeleted { get; set; }
-
-            /// <summary>
-            /// Id from the registry
-            /// </summary>
-            [Required]
-            [StringLength(32)]
-            public string RegistryID { get; set; }
-        }
+        public List<NotificationAddressModel> NotificationAddresses { get; set; }
     }
 }

--- a/src/Altinn.Profile/Models/OrganizationResponse.cs
+++ b/src/Altinn.Profile/Models/OrganizationResponse.cs
@@ -1,0 +1,63 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using Altinn.Profile.Core.OrganizationNotificationAddresses;
+using Altinn.Profile.Validators;
+
+namespace Altinn.Profile.Models
+{    
+    /// <summary>
+     /// Represents a on organization with  notification addresses
+     /// </summary>
+    public class OrganizationResponse
+    {
+        /// <summary>
+        /// The organizations organization number
+        /// </summary>
+        public string OrganizationNumber { get; set; }
+
+        /// <summary>
+        /// Represents a list of mandatory notification address
+        /// </summary>
+        public List<NotificationAddress> NotificationAddresses { get; set; }
+
+        /// <summary>
+        /// Represents a notification address
+        /// </summary>
+        public class NotificationAddress
+        {
+            /// <summary>
+            /// <see cref="NotificationAddressID"/>
+            /// </summary>
+            public int NotificationAddressID { get; set; }
+
+            /// <summary>
+            /// Country code for phone number//TODO 
+            /// </summary>
+            [CustomRegexForNotificationAddresses("CountryCode", ErrorMessage = "AltinnII.SBL.UserProfile.Regex.CountryCode")]
+            public string CountryCode { get; set; }
+
+            /// <summary>
+            /// Email address
+            /// </summary>
+            [CustomRegexForNotificationAddresses("Email", ErrorMessage = "AltinnII.SBL.UserProfile.Regex.Email")]
+            public string Email { get; set; }
+
+            /// <summary>
+            /// Phone number
+            /// </summary>
+            public string Phone { get; set; }
+
+            /// <summary>
+            /// A value indicating whether the entity is deleted in Altinn.
+            /// </summary>
+            public bool? IsDeleted { get; set; }
+
+            /// <summary>
+            /// Id from the registry
+            /// </summary>
+            [Required]
+            [StringLength(32)]
+            public string RegistryID { get; set; }
+        }
+    }
+}

--- a/src/Altinn.Profile/Validators/CustomRegexForNotificationAddressesAttribute.cs
+++ b/src/Altinn.Profile/Validators/CustomRegexForNotificationAddressesAttribute.cs
@@ -1,10 +1,12 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using System;
+using System.ComponentModel.DataAnnotations;
 
 namespace Altinn.Profile.Validators
 {
     /// <summary>
     /// Custom regex attribute for Kofuvi  using the kofuvi regex from config
     /// </summary>
+    [AttributeUsage(AttributeTargets.Field)]
     public class CustomRegexForNotificationAddressesAttribute : RegularExpressionAttribute
     {
         private const string _emailRegexPattern = @"^((([a-zA-Z0-9!#$%&amp;'*+\-=?\^_`{}~])+(\.([a-zA-Z0-9!#$%&amp;'*+\-=?\^_`{}~])+)*)@(((([a-zA-Z0-9æøåÆØÅ]([a-zA-Z0-9\-æøåÆØÅ]{0,61})[a-zA-Z0-9æøåÆØÅ]\.)|[a-zA-Z0-9æøåÆØÅ]\.){1,9})([a-zA-Z]{2,14})))$";

--- a/src/Altinn.Profile/Validators/CustomRegexForNotificationAddressesAttribute.cs
+++ b/src/Altinn.Profile/Validators/CustomRegexForNotificationAddressesAttribute.cs
@@ -6,7 +6,7 @@ namespace Altinn.Profile.Validators
     /// <summary>
     /// Custom regex attribute for Kofuvi  using the kofuvi regex from config
     /// </summary>
-    [AttributeUsage(AttributeTargets.Field)]
+    [AttributeUsage(AttributeTargets.Property)]
     public class CustomRegexForNotificationAddressesAttribute : RegularExpressionAttribute
     {
         private const string _emailRegexPattern = @"^((([a-zA-Z0-9!#$%&amp;'*+\-=?\^_`{}~])+(\.([a-zA-Z0-9!#$%&amp;'*+\-=?\^_`{}~])+)*)@(((([a-zA-Z0-9æøåÆØÅ]([a-zA-Z0-9\-æøåÆØÅ]{0,61})[a-zA-Z0-9æøåÆØÅ]\.)|[a-zA-Z0-9æøåÆØÅ]\.){1,9})([a-zA-Z]{2,14})))$";

--- a/src/Altinn.Profile/Validators/CustomRegexForNotificationAddressesAttribute.cs
+++ b/src/Altinn.Profile/Validators/CustomRegexForNotificationAddressesAttribute.cs
@@ -1,0 +1,34 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace Altinn.Profile.Validators
+{
+    /// <summary>
+    /// Custom regex attribute for Kofuvi  using the kofuvi regex from config
+    /// </summary>
+    public class CustomRegexForNotificationAddressesAttribute : RegularExpressionAttribute
+    {
+        private const string _emailRegexPattern = @"^((([a-zA-Z0-9!#$%&amp;'*+\-=?\^_`{}~])+(\.([a-zA-Z0-9!#$%&amp;'*+\-=?\^_`{}~])+)*)@(((([a-zA-Z0-9æøåÆØÅ]([a-zA-Z0-9\-æøåÆØÅ]{0,61})[a-zA-Z0-9æøåÆØÅ]\.)|[a-zA-Z0-9æøåÆØÅ]\.){1,9})([a-zA-Z]{2,14})))$";
+        private const string _phoneRegexPattern = @"(^[0-9]+$)";
+        private const string _countryCodeRegexPattern = @"(^\+([0-9]{1,3}))";
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CustomRegexForNotificationAddressesAttribute"/> class
+        /// </summary>
+        /// <param name="inputType">the type of input</param>
+        public CustomRegexForNotificationAddressesAttribute(string inputType)
+            : base(GetRegex(inputType))
+        {
+        }
+
+        private static string GetRegex(string inputType)
+        {
+            return inputType switch
+            {
+                "Email" => _emailRegexPattern,
+                "Phone" => _phoneRegexPattern,
+                "CountryCode" => _countryCodeRegexPattern,
+                _ => string.Empty
+            };
+        }
+    }
+}

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/OrganizationsControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/OrganizationsControllerTests.cs
@@ -1,0 +1,168 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Altinn.Profile.Controllers;
+using Altinn.Profile.Core.OrganizationNotificationAddresses;
+using Altinn.Profile.Models;
+using Altinn.Profile.Tests.IntegrationTests.Utils;
+
+using Microsoft.AspNetCore.Mvc.Testing;
+using Moq;
+using Xunit;
+
+namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
+{
+    public class OrganizationsControllerTests : IClassFixture<WebApplicationFactory<OrganizationsController>>
+    {
+        private readonly WebApplicationFactorySetup<OrganizationsController> _webApplicationFactorySetup;
+
+        private readonly JsonSerializerOptions _serializerOptions = new()
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        };
+
+        private readonly List<Organization> _testdata;
+
+        public OrganizationsControllerTests(WebApplicationFactory<OrganizationsController> factory)
+        {
+            _webApplicationFactorySetup = new WebApplicationFactorySetup<OrganizationsController>(factory);
+            _testdata = [
+                new()
+                {
+                    OrganizationNumber = "987654321",
+                    NotificationAddresses =
+                    [
+                        new()
+                        {
+                            FullAddress = "test@example.com",
+                            AddressType = AddressType.Email,
+                        },
+                    ]
+                }, new()
+                {
+                    OrganizationNumber = "123456789",
+                    NotificationAddresses =
+                    [
+                        new()
+                        {
+                            FullAddress = "test@test.com",
+                            Address = "test",
+                            Domain = "test.com",
+                            AddressType = AddressType.Email,
+                        },
+                        new()
+                        {
+                            FullAddress = "+4798765432",
+                            Address = "98765432",
+                            Domain = "+47",
+                            AddressType = AddressType.SMS,
+                        },
+                        new()
+                        {
+                            FullAddress = "+4747765432",
+                            Address = "47765432",
+                            Domain = "+47",
+                            AddressType = AddressType.SMS,
+                        }
+                    ]
+                }
+                ];
+        }
+
+        [Fact]
+        public async Task GetMandatory_WhenOneOrganizationFound_ReturnsOkWithSingleItemList()
+        {
+            // Arrange
+            var orgNo = "123456789";
+
+            _webApplicationFactorySetup.OrganizationNotificationAddressRepositoryMock
+                .Setup(r => r.GetOrganizationsAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(_testdata.Where(o => o.OrganizationNumber == orgNo));
+            HttpClient client = _webApplicationFactorySetup.GetTestServerClient();
+            HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, $"/profile/api/v1/organizations/{orgNo}/notificationaddresses/mandatory");
+            httpRequestMessage = CreateAutorizedRequest(orgNo, httpRequestMessage);
+
+            // Act
+            HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            string responseContent = await response.Content.ReadAsStringAsync();
+            var actual = JsonSerializer.Deserialize<OrganizationResponse>(responseContent, _serializerOptions);
+            Assert.Equal("123456789", actual.OrganizationNumber);
+            Assert.Equal(3, actual.NotificationAddresses.Count);
+            Assert.Equal("test@test.com", actual.NotificationAddresses[0].Email);
+            Assert.Null(actual.NotificationAddresses[0].Phone);
+            Assert.Equal("98765432", actual.NotificationAddresses[1].Phone);
+            Assert.Equal("+47", actual.NotificationAddresses[1].CountryCode);
+            Assert.Null(actual.NotificationAddresses[1].Email);
+        }
+
+        [Fact]
+        public async Task GetMandatory_WhenNoMatchingOrganization_ReturnsNotFound()
+        {
+            // Arrange
+            var orgNo = "error-org";
+
+            HttpClient client = _webApplicationFactorySetup.GetTestServerClient();
+            HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, $"/profile/api/v1/organizations/{orgNo}/notificationaddresses/mandatory");
+            httpRequestMessage = CreateAutorizedRequest(orgNo, httpRequestMessage);
+
+            // Act
+            HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task GetMandatory_WhenNoAuth_ReturnsUnautorized()
+        {
+            // Arrange
+            var orgNo = "123456789";
+
+            HttpClient client = _webApplicationFactorySetup.GetTestServerClient();
+            HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, $"/profile/api/v1/organizations/{orgNo}/notificationaddresses/mandatory");
+
+            // Act
+            HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task GetMandatory_WhenInvalidAuth_ReturnsForbidden()
+        {
+            // Arrange
+            var orgNo = "123456789";
+
+            HttpClient client = _webApplicationFactorySetup.GetTestServerClient();
+            HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, $"/profile/api/v1/organizations/{orgNo}/notificationaddresses/mandatory");
+            string token = PrincipalUtil.GetOrgToken(orgNo);
+            httpRequestMessage.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+            // Act
+            HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        }
+
+        private static HttpRequestMessage CreateAutorizedRequest(string orgNo, HttpRequestMessage httpRequestMessage)
+        {
+            string token = PrincipalUtil.GetOrgToken(orgNo);
+            httpRequestMessage.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            httpRequestMessage.Headers.Add("PlatformAccessToken", PrincipalUtil.GetAccessToken("ttd", "unittest"));
+
+            return httpRequestMessage;
+        }
+    }
+}

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/OrganizationsControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/OrganizationsControllerTests.cs
@@ -139,7 +139,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
         }
 
         [Fact]
-        public async Task GetMandatory_WhenInvalidAuth_ReturnsForbidden()
+        public async Task GetMandatory_WhenMissingPlatformAccessToken_ReturnsForbidden()
         {
             // Arrange
             var orgNo = "123456789";

--- a/test/Altinn.Profile.Tests/Profile/Validators/CustomRegexForNotificationAddressesTests.cs
+++ b/test/Altinn.Profile.Tests/Profile/Validators/CustomRegexForNotificationAddressesTests.cs
@@ -83,6 +83,5 @@ namespace Altinn.Profile.Tests.Profile.Validators
 
             Assert.False(validationResult);
         }
-
     }
 }

--- a/test/Altinn.Profile.Tests/Profile/Validators/CustomRegexForNotificationAddressesTests.cs
+++ b/test/Altinn.Profile.Tests/Profile/Validators/CustomRegexForNotificationAddressesTests.cs
@@ -1,0 +1,86 @@
+﻿using Altinn.Profile.Models;
+using Altinn.Profile.Validators;
+using Microsoft.VisualBasic;
+using Xunit;
+
+namespace Altinn.Profile.Tests.Profile.Validators
+{
+    public class CustomRegexForNotificationAddressesTests
+    {
+        [Theory]
+        [InlineData("98765432")]
+        public void CustomRegex_WhenPhone_IsValid(string input)
+        {
+            var attribute = new CustomRegexForNotificationAddressesAttribute("Phone");
+
+            var validationResult = attribute.IsValid(input);
+
+            Assert.True(validationResult);
+        }
+
+        [Theory]
+        [InlineData("error")]
+        public void CustomRegex_WhenPhone_IsInvalid(string input)
+        {
+            var attribute = new CustomRegexForNotificationAddressesAttribute("Phone");
+
+            var validationResult = attribute.IsValid(input);
+
+            Assert.False(validationResult);
+        }
+
+        [Theory]
+        [InlineData("+47")]
+        [InlineData("+385")]
+        [InlineData("")]
+        public void CustomRegex_WhenCountryCode_IsValid(string input)
+        {
+            var attribute = new CustomRegexForNotificationAddressesAttribute("CountryCode");
+
+            var validationResult = attribute.IsValid(input);
+
+            Assert.True(validationResult);
+        }
+
+        [Theory]
+        [InlineData("++47")]
+        [InlineData("47")]
+        [InlineData("+4777")]
+        [InlineData("0047")]
+        public void CustomRegex_WhenCountryCode_IsInvalid(string input)
+        {
+            var attribute = new CustomRegexForNotificationAddressesAttribute("CountryCode");
+
+            var validationResult = attribute.IsValid(input);
+
+            Assert.False(validationResult);
+        }
+
+        [Theory]
+        [InlineData("test@test.com")]
+        [InlineData("test-test@test.com")]
+        [InlineData("test.test@test.com")]
+        public void CustomRegex_WhenEmail_IsValid(string input)
+        {
+            var attribute = new CustomRegexForNotificationAddressesAttribute("Email");
+
+            var validationResult = attribute.IsValid(input);
+
+            Assert.True(validationResult);
+        }
+
+        [Theory]
+        [InlineData("98765432")]
+        [InlineData("test-test@@test.com")]
+        [InlineData("test@test..com")]
+        public void CustomRegex_WhenEmail_IsInvalid(string input)
+        {
+            var attribute = new CustomRegexForNotificationAddressesAttribute("Email");
+
+            var validationResult = attribute.IsValid(input);
+
+            Assert.False(validationResult);
+        }
+
+    }
+}

--- a/test/Altinn.Profile.Tests/Profile/Validators/CustomRegexForNotificationAddressesTests.cs
+++ b/test/Altinn.Profile.Tests/Profile/Validators/CustomRegexForNotificationAddressesTests.cs
@@ -9,6 +9,7 @@ namespace Altinn.Profile.Tests.Profile.Validators
     {
         [Theory]
         [InlineData("98765432")]
+        [InlineData("9876543200")]
         public void CustomRegex_WhenPhone_IsValid(string input)
         {
             var attribute = new CustomRegexForNotificationAddressesAttribute("Phone");
@@ -20,6 +21,7 @@ namespace Altinn.Profile.Tests.Profile.Validators
 
         [Theory]
         [InlineData("error")]
+        [InlineData("+47987654321")]
         public void CustomRegex_WhenPhone_IsInvalid(string input)
         {
             var attribute = new CustomRegexForNotificationAddressesAttribute("Phone");

--- a/test/Altinn.Profile.Tests/Profile/Validators/CustomRegexForNotificationAddressesTests.cs
+++ b/test/Altinn.Profile.Tests/Profile/Validators/CustomRegexForNotificationAddressesTests.cs
@@ -12,7 +12,7 @@ namespace Altinn.Profile.Tests.Profile.Validators
         [InlineData("9876543200")]
         [InlineData("")]
         [InlineData(null)]
-        public void CustomRegex_WhenPhone_IsValid(string input)
+        public void CustomRegex_WhenPhoneHasAllowedValues_ReturnsValidResult(string input)
         {
             var attribute = new CustomRegexForNotificationAddressesAttribute("Phone");
 
@@ -24,7 +24,7 @@ namespace Altinn.Profile.Tests.Profile.Validators
         [Theory]
         [InlineData("error")]
         [InlineData("+47987654321")]
-        public void CustomRegex_WhenPhone_IsInvalid(string input)
+        public void CustomRegex_WhenPhoneHasInvalidValues_IsInvalid(string input)
         {
             var attribute = new CustomRegexForNotificationAddressesAttribute("Phone");
 
@@ -38,7 +38,7 @@ namespace Altinn.Profile.Tests.Profile.Validators
         [InlineData("+385")]
         [InlineData("")]
         [InlineData(null)]
-        public void CustomRegex_WhenCountryCode_IsValid(string input)
+        public void CustomRegex_WhenCountryCodeHasAllowedValues_IsValid(string input)
         {
             var attribute = new CustomRegexForNotificationAddressesAttribute("CountryCode");
 
@@ -52,7 +52,7 @@ namespace Altinn.Profile.Tests.Profile.Validators
         [InlineData("47")]
         [InlineData("+4777")]
         [InlineData("0047")]
-        public void CustomRegex_WhenCountryCode_IsInvalid(string input)
+        public void CustomRegex_WhenCountryCodeHasWrongFormat_IsInvalid(string input)
         {
             var attribute = new CustomRegexForNotificationAddressesAttribute("CountryCode");
 
@@ -67,7 +67,7 @@ namespace Altinn.Profile.Tests.Profile.Validators
         [InlineData("test.test@test.com")]
         [InlineData("")]
         [InlineData(null)]
-        public void CustomRegex_WhenEmail_IsValid(string input)
+        public void CustomRegex_WhenEmailHasAllowedValues_IsValid(string input)
         {
             var attribute = new CustomRegexForNotificationAddressesAttribute("Email");
 
@@ -80,7 +80,7 @@ namespace Altinn.Profile.Tests.Profile.Validators
         [InlineData("98765432")]
         [InlineData("test-test@@test.com")]
         [InlineData("test@test..com")]
-        public void CustomRegex_WhenEmail_IsInvalid(string input)
+        public void CustomRegex_WhenEmailHasWrongFormat_IsInvalid(string input)
         {
             var attribute = new CustomRegexForNotificationAddressesAttribute("Email");
 

--- a/test/Altinn.Profile.Tests/Profile/Validators/CustomRegexForNotificationAddressesTests.cs
+++ b/test/Altinn.Profile.Tests/Profile/Validators/CustomRegexForNotificationAddressesTests.cs
@@ -10,6 +10,8 @@ namespace Altinn.Profile.Tests.Profile.Validators
         [Theory]
         [InlineData("98765432")]
         [InlineData("9876543200")]
+        [InlineData("")]
+        [InlineData(null)]
         public void CustomRegex_WhenPhone_IsValid(string input)
         {
             var attribute = new CustomRegexForNotificationAddressesAttribute("Phone");
@@ -35,6 +37,7 @@ namespace Altinn.Profile.Tests.Profile.Validators
         [InlineData("+47")]
         [InlineData("+385")]
         [InlineData("")]
+        [InlineData(null)]
         public void CustomRegex_WhenCountryCode_IsValid(string input)
         {
             var attribute = new CustomRegexForNotificationAddressesAttribute("CountryCode");
@@ -62,6 +65,8 @@ namespace Altinn.Profile.Tests.Profile.Validators
         [InlineData("test@test.com")]
         [InlineData("test-test@test.com")]
         [InlineData("test.test@test.com")]
+        [InlineData("")]
+        [InlineData(null)]
         public void CustomRegex_WhenEmail_IsValid(string input)
         {
             var attribute = new CustomRegexForNotificationAddressesAttribute("Email");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add a new controller and models in order to read an organizations notificationAddresses. 
Authorization of this resoirce is handled in a separate issue #314 

## Related Issue(s)
- #317 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced organization notification functionality with an additional property for tracking deletion status.
	- Launched a new API endpoint to retrieve organization notification addresses by organization number, returning active results or appropriate error statuses.
	- Implemented data mapping to ensure the response presents only valid notification addresses.
	- Improved input validation for email, phone, and country code fields to maintain data consistency.
	- Introduced a structured model for notification addresses to streamline data handling.

- **Tests**
	- Added integration tests to validate the functionality of the new API endpoint under various scenarios.
	- Introduced unit tests for the input validation logic associated with notification addresses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->