### PR TITLE
Add migration to make domain column nullable

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ dotnet user-secrets set "ContactAndReservationSettings:MaskinportenSettings:Enco
 
 ### Adding migrations with EF core
 1. Code the desired classes and add them to the DB context
-2. Run the following command in a terminal from src/Altinn.Profile.Integartions to add a migration. The name should be more descriptive than AddNewMigration:
+2. Run the following command in a terminal from src/Altinn.Profile.Integrations to add a migration. The name should be more descriptive than AddNewMigration:
    ```cmd
    dotnet ef migrations Add AddNewMigration --startup-project ../Altinn.Profile
    ```

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ dotnet user-secrets set "ContactAndReservationSettings:MaskinportenSettings:Enco
 
 ### Adding migrations with EF core
 1. Code the desired classes and add them to the DB context
-2. Run the following command to add a migration. The name should be more descriptive than AddNewMigration:
+2. Run the following command in a terminal from src/Altinn.Profile.Integartions to add a migration. The name should be more descriptive than AddNewMigration:
    ```cmd
    dotnet ef migrations Add AddNewMigration --startup-project ../Altinn.Profile
    ```

--- a/src/Altinn.Profile.Integrations/Entities/NotificationAddressDE.cs
+++ b/src/Altinn.Profile.Integrations/Entities/NotificationAddressDE.cs
@@ -35,7 +35,6 @@ namespace Altinn.Profile.Integrations.Entities
         /// The domain part of the Address. In case of phone numbers the country code, in case of email the domain address
         /// </summary>
         [StringLength(200)]
-        [Required]
         public string Domain { get; set; }
 
         /// <summary>

--- a/src/Altinn.Profile.Integrations/Migration/v0.05/01-alter-table.sql
+++ b/src/Altinn.Profile.Integrations/Migration/v0.05/01-alter-table.sql
@@ -1,0 +1,1 @@
+ALTER TABLE organization_notification_address.notifications_address ALTER COLUMN domain DROP NOT NULL;

--- a/test/Altinn.Profile.Tests/Profile.Integrations/OrganizationNotificationAddressTests/OrganizationNotificationAddressRepositoryTests.cs
+++ b/test/Altinn.Profile.Tests/Profile.Integrations/OrganizationNotificationAddressTests/OrganizationNotificationAddressRepositoryTests.cs
@@ -130,6 +130,31 @@ public class OrganizationNotificationAddressRepositoryTests: IDisposable
     }
 
     [Fact]
+    public async Task SyncNotificationAddressesAsync_WithProperDataWithNullablePhonePrefix_ReturnsUpdatedRows()
+    {
+        var matchedOrg1 = await _repository.GetOrganizationAsync("920254321");
+        var matchedOrg2 = await _repository.GetOrganizationAsync("920212345");
+        Assert.Null(matchedOrg1);
+        Assert.Null(matchedOrg2);
+
+        // changes_2 contains rows without phone prefix
+        var changes = await TestDataLoader.Load<NotificationAddressChangesLog>("changes_2");
+
+        // Act
+        var numberOfUpdatedRows = await _repository.SyncNotificationAddressesAsync(changes);
+        var updatedOrg1 = await _repository.GetOrganizationAsync("920254321");
+        var updatedOrg2 = await _repository.GetOrganizationAsync("920212345");
+
+        // Assert
+        Assert.NotNull(updatedOrg1);
+        Assert.Equal(2, updatedOrg1.NotificationAddresses.Count);
+        Assert.NotNull(updatedOrg2);
+        Assert.Equal(2, updatedOrg2.NotificationAddresses.Count);
+        Assert.Equal(4, numberOfUpdatedRows);
+        Assert.Null(updatedOrg1.NotificationAddresses.Last().Domain);
+    }
+
+    [Fact]
     public async Task SyncNotificationAddressesAsync_WithDeleteData_ReturnsUpdatedRows()
     {
         var matchedOrg = await _repository.GetOrganizationAsync("987654321");

--- a/test/Altinn.Profile.Tests/Testdata/NotificationAddressChangesLog/changes_2.json
+++ b/test/Altinn.Profile.Tests/Testdata/NotificationAddressChangesLog/changes_2.json
@@ -28,7 +28,7 @@
       "id": "37ab4733648c4d5b825a813c6e1ace71",
       "updated": "2025-01-16T09:07:11Z",
       "isdeleted": false,
-      "content": "{\"Kontaktinformasjon\":{\"digitalVarslingsinformasjon\":{\"mobiltelefon\":{\"navn\":\"4798765431\",\"internasjonaltPrefiks\":\"47\",\"nasjonaltNummer\":\"98765431\"}},\"identifikator\":\"37ab4733648c4d5b825a813c6e1ace70\",\"kontaktinformasjonForEnhet\":{\"enhetsidentifikator\":{\"verdi\":\"920254321\",\"type\":\"ORGANISASJONSNUMMER\"}}}}"
+      "content": "{\"Kontaktinformasjon\":{\"digitalVarslingsinformasjon\":{\"mobiltelefon\":{\"navn\":\"4798765431\",\"nasjonaltNummer\":\"98765431\"}},\"identifikator\":\"37ab4733648c4d5b825a813c6e1ace70\",\"kontaktinformasjonForEnhet\":{\"enhetsidentifikator\":{\"verdi\":\"920254321\",\"type\":\"ORGANISASJONSNUMMER\"}}}}"
     }
   ]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
A mistake in the db schema was discovered during the first dataload. The domain column should be nullable in the database. 


## Related Issue(s)
- #204 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Enhanced migration instructions by specifying the correct working directory for executing commands.
  
- **Refactor**
  - Adjusted the notification address configuration to make the domain field optional, allowing greater flexibility in data entry.

- **Tests**
  - Added a new test for the synchronization process of notification addresses, specifically addressing scenarios with nullable phone prefixes.
  - Updated existing test method names for clarity and improved database seeding across tests.

- **Chores**
  - Updated JSON test data to simplify the structure by removing unnecessary keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->