### PR TITLE
Add org and notification address in same operation when bothnew

### DIFF
--- a/src/Altinn.Profile.Integrations/Repositories/OrganizationNotificationAddressRepository.cs
+++ b/src/Altinn.Profile.Integrations/Repositories/OrganizationNotificationAddressRepository.cs
@@ -28,7 +28,7 @@ public class OrganizationNotificationAddressRepository(IDbContextFactory<Profile
             }
             else
             {
-                updates += await UpdateNotificationAddressAsync(address);
+                updates += await InsertOrUpdateNotificationAddressAsync(address);
             }
         }
 
@@ -57,12 +57,12 @@ public class OrganizationNotificationAddressRepository(IDbContextFactory<Profile
     }
 
     /// <summary>
-    /// Updates or creates notification addresses in the DB for organizations
+    /// Updates notification addresses in the DB for organizations
     /// </summary>
     /// <returns>
     /// A task that represents the asynchronous operation.
     /// </returns>
-    private async Task<int> UpdateNotificationAddressAsync(Entry address)
+    private async Task<int> InsertOrUpdateNotificationAddressAsync(Entry address)
     {
         var orgNumber = address?.Content?.ContactPoint?.UnitContactInfo?.UnitIdentifier?.Value;
         if (orgNumber == null || address?.Content?.ContactPoint?.UnitContactInfo?.UnitIdentifier?.Type != _organizationNumberConst)
@@ -71,8 +71,22 @@ public class OrganizationNotificationAddressRepository(IDbContextFactory<Profile
         }
 
         var organization = await GetOrganizationAsync(orgNumber);
-        organization ??= await CreateOrganization(orgNumber);
+        if (organization is null)
+        {
+            return await CreateOrganizationWithNotificationAddress(orgNumber, address);
+        }
 
+        return await UpdateNotificationAddressAsync(address, organization);
+    }
+
+    /// <summary>
+    /// Updates or creates notification addresses in the DB for organizations
+    /// </summary>
+    /// <returns>
+    /// A task that represents the asynchronous operation.
+    /// </returns>
+    private async Task<int> UpdateNotificationAddressAsync(Entry address, OrganizationDE organization)
+    {
         using ProfileDbContext databaseContext = await _contextFactory.CreateDbContextAsync();
 
         var organizationNotificationAddress = DataMapper.MapOrganizationNotificationAddress(address, organization);
@@ -112,7 +126,7 @@ public class OrganizationNotificationAddressRepository(IDbContextFactory<Profile
                 .FirstOrDefaultAsync(o => o.RegistryOrganizationNumber == orgNumber);
     }
     
-    private async Task<OrganizationDE> CreateOrganization(string orgNumber)
+    private async Task<int> CreateOrganizationWithNotificationAddress(string orgNumber, Entry address)
     {
         using ProfileDbContext databaseContext = await _contextFactory.CreateDbContextAsync();
 
@@ -121,11 +135,11 @@ public class OrganizationNotificationAddressRepository(IDbContextFactory<Profile
             RegistryOrganizationNumber = orgNumber,
             NotificationAddresses = [],
         };
-        
-        await databaseContext.Organizations.AddAsync(organization);
-        await databaseContext.SaveChangesAsync();
+        organization.NotificationAddresses.Add(DataMapper.MapOrganizationNotificationAddress(address, organization));
 
-        return organization;
+        await databaseContext.Organizations.AddAsync(organization);
+        
+        return await databaseContext.SaveChangesAsync();
     }
 
     /// <inheritdoc/>

--- a/test/Altinn.Profile.Tests/Profile.Integrations/OrganizationNotificationAddressTests/OrganizationNotificationAddressRepositoryTests.cs
+++ b/test/Altinn.Profile.Tests/Profile.Integrations/OrganizationNotificationAddressTests/OrganizationNotificationAddressRepositoryTests.cs
@@ -117,7 +117,7 @@ public class OrganizationNotificationAddressRepositoryTests: IDisposable
         var changes = await TestDataLoader.Load<NotificationAddressChangesLog>("changes_1");
 
         // Act
-        var numberOfUpdatedAddresses = await _repository.SyncNotificationAddressesAsync(changes);
+        var numberOfUpdatedRows = await _repository.SyncNotificationAddressesAsync(changes);
         var updatedOrg1 = await _repository.GetOrganizationAsync("123456789");
         var updatedOrg2 = await _repository.GetOrganizationAsync("920212345");
 
@@ -126,7 +126,7 @@ public class OrganizationNotificationAddressRepositoryTests: IDisposable
         Assert.Equal(4, updatedOrg1.NotificationAddresses.Count);
         Assert.NotNull(updatedOrg2);
         Assert.Single(updatedOrg2.NotificationAddresses);
-        Assert.Equal(2, numberOfUpdatedAddresses);
+        Assert.Equal(3, numberOfUpdatedRows);
     }
 
     [Fact]


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
As a part of initial dataload we will insert a lot of notification addresses and organizations into the db tables. When both are new, we can let EF handle the insert as one operation. 

## Related Issue(s)
- #240 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
