### PR TITLE
Add new index to notificationAddresses table, as annotations

### DIFF
--- a/src/Altinn.Profile.Integrations/Entities/NotificationAddressDE.cs
+++ b/src/Altinn.Profile.Integrations/Entities/NotificationAddressDE.cs
@@ -3,6 +3,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using Altinn.Profile.Core.OrganizationNotificationAddresses;
+using Microsoft.EntityFrameworkCore;
 
 namespace Altinn.Profile.Integrations.Entities
 {
@@ -10,6 +11,7 @@ namespace Altinn.Profile.Integrations.Entities
     /// class for notifications addresses for organizations 
     /// </summary>
     [Table("notifications_address", Schema = "organization_notification_address")]
+    [Index(nameof(RegistryID), IsUnique = true)]
     public class NotificationAddressDE
     {
         /// <summary>

--- a/src/Altinn.Profile.Integrations/Entities/OrganizationDE.cs
+++ b/src/Altinn.Profile.Integrations/Entities/OrganizationDE.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 namespace Altinn.Profile.Integrations.Entities
 {
@@ -7,7 +8,7 @@ namespace Altinn.Profile.Integrations.Entities
     /// Class for organizations connection id and orgNumber
     /// </summary>
     [Table("organizations", Schema = "organization_notification_address")]
-
+    [Index(nameof(RegistryOrganizationNumber), IsUnique = true)]
     public class OrganizationDE
     {
         /// <summary>

--- a/src/Altinn.Profile.Integrations/Migration/v0.06/01-add-index.sql
+++ b/src/Altinn.Profile.Integrations/Migration/v0.06/01-add-index.sql
@@ -1,1 +1,1 @@
-CREATE UNIQUE INDEX ix_notifications_address_registry_id ON organization_notification_address.notifications_address (registry_id);
+CREATE UNIQUE INDEX IF NOT EXISTS ix_notifications_address_registry_id ON organization_notification_address.notifications_address (registry_id);

--- a/src/Altinn.Profile.Integrations/Migration/v0.06/01-add-index.sql
+++ b/src/Altinn.Profile.Integrations/Migration/v0.06/01-add-index.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX ix_notifications_address_registry_id ON organization_notification_address.notifications_address (registry_id);

--- a/src/Altinn.Profile.Integrations/Persistence/ProfiledbContext.cs
+++ b/src/Altinn.Profile.Integrations/Persistence/ProfiledbContext.cs
@@ -98,7 +98,6 @@ public partial class ProfileDbContext : DbContext
                     .WithOne(n => n.Organization)
                     .HasForeignKey(e => e.RegistryOrganizationId)
                     .HasConstraintName("fk_organization_id");
-            entity.HasIndex(d => d.RegistryOrganizationNumber).IsUnique();
         });
         modelBuilder.Entity<RegistrySyncMetadata>(entity =>
         {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adding an index to NotificationAddresses-tabled to mitigate slow query
```
Executed DbCommand (249ms) [Parameters=[@__addressId_0='?'], CommandType='Text', CommandTimeout='30']
SELECT n.notification_address_id, n.address, n.address_type, n.created_date_time, n.domain, n.full_address, n.has_registry_accepted, n.is_soft_deleted, n.notification_name, n.registry_id, n.fk_registry_organization_id, n.registry_updated_date_time, n.update_source
FROM organization_notification_address.notifications_address AS n
WHERE n.registry_id = @__addressId_0
LIMIT 1
```

## Related Issue(s)
- #240 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved data integrity by enforcing unique identifiers for notifications and organizations.
  
- **Chores**
  - Updated the database schema with refined indexing strategies.
  - Transitioned from legacy uniqueness configuration to attribute-driven constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->