### PR TITLE
Support delete notification addresses

### DIFF
--- a/src/Altinn.Profile.Core/Integrations/IOrganizationNotificationAddressRepository.cs
+++ b/src/Altinn.Profile.Core/Integrations/IOrganizationNotificationAddressRepository.cs
@@ -18,4 +18,10 @@ public interface IOrganizationNotificationAddressRepository
     /// </summary>
     /// <returns>A <see cref="Task{TResult}"/> with an organization as value.</returns>
     Task<NotificationAddress> CreateNotificationAddressAsync(string organizationNumber, NotificationAddress notificationAddress, string registryId);
+
+    /// <summary>
+    /// Delete a notification address for an organization
+    /// </summary>
+    /// <returns>A <see cref="Task{TResult}"/> with the notification address as value.</returns>
+    Task<NotificationAddress> DeleteNotificationAddressAsync(int notificationAddressId);
 }

--- a/src/Altinn.Profile.Core/OrganizationNotificationAddresses/IOrganizationNotificationAddressesService.cs
+++ b/src/Altinn.Profile.Core/OrganizationNotificationAddresses/IOrganizationNotificationAddressesService.cs
@@ -1,6 +1,4 @@
-﻿using Altinn.Profile.Core.Integrations;
-
-namespace Altinn.Profile.Core.OrganizationNotificationAddresses;
+﻿namespace Altinn.Profile.Core.OrganizationNotificationAddresses;
 
 /// <summary>
 /// Defines a service which handles notification addresses for organizations
@@ -22,4 +20,12 @@ public interface IOrganizationNotificationAddressesService
     /// <param name="cancellationToken">To cancel the request before it is finished</param>
     /// <returns>The notification addresses or a boolean if failure.</returns>
     Task<IEnumerable<Organization>> GetOrganizationNotificationAddresses(List<string> organizationNumbers, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Method for deleting a notification addresses for an organization
+    /// </summary>
+    /// <param name="organizationNumber">An organization number to indicate which organization to update addresses for</param>
+    /// <param name="notificationAddressId">The new notification address</param>
+    /// <param name="cancellationToken">To cancel the request before it is finished</param>
+    Task<NotificationAddress?> DeleteNotificationAddress(string organizationNumber, int notificationAddressId, CancellationToken cancellationToken);
 }

--- a/src/Altinn.Profile.Core/OrganizationNotificationAddresses/OrganizationNotificationAddressesService.cs
+++ b/src/Altinn.Profile.Core/OrganizationNotificationAddresses/OrganizationNotificationAddressesService.cs
@@ -55,9 +55,14 @@ namespace Altinn.Profile.Core.OrganizationNotificationAddresses
             }
 
             var notificationAddress = org.NotificationAddresses?.FirstOrDefault(n => n.NotificationAddressID == notificationAddressId);
-            if (notificationAddress == null || org.NotificationAddresses?.Count == 1)
+            if (notificationAddress == null)
             {
                 return null;
+            }
+
+            if (org.NotificationAddresses?.Count == 1)
+            {
+                throw new InvalidOperationException("Cannot delete the last notification address");
             }
 
             await _updateClient.DeleteNotificationAddress(notificationAddress.RegistryID);

--- a/src/Altinn.Profile.Core/OrganizationNotificationAddresses/OrganizationNotificationAddressesService.cs
+++ b/src/Altinn.Profile.Core/OrganizationNotificationAddresses/OrganizationNotificationAddressesService.cs
@@ -38,6 +38,35 @@ namespace Altinn.Profile.Core.OrganizationNotificationAddresses
             return updatedNotificationAddress;
         }
 
+        /// <summary>
+        /// Method for deleting a notification addresses for an organization. Data is written primarily to an <see cref="IOrganizationNotificationAddressUpdateClient"/> and lastly to the <see cref="IOrganizationNotificationAddressRepository"/>.
+        /// </summary>
+        /// <param name="organizationNumber">An organization number to indicate which organization to update addresses for</param>
+        /// <param name="notificationAddressId">The new notification address</param>
+        /// <param name="cancellationToken">To cancel the request before it is finished</param>
+        public async Task<NotificationAddress?> DeleteNotificationAddress(string organizationNumber, int notificationAddressId, CancellationToken cancellationToken)
+        {
+            var orgs = await _orgRepository.GetOrganizationsAsync([organizationNumber], cancellationToken);
+            var org = orgs.FirstOrDefault();
+
+            if (org == null)
+            {
+                return null;
+            }
+
+            var notificationAddress = org.NotificationAddresses?.FirstOrDefault(n => n.NotificationAddressID == notificationAddressId);
+            if (notificationAddress == null || org.NotificationAddresses?.Count == 1)
+            {
+                return null;
+            }
+
+            await _updateClient.DeleteNotificationAddress(notificationAddress.RegistryID);
+
+            var updatedNotificationAddress = await _orgRepository.DeleteNotificationAddressAsync(notificationAddress.NotificationAddressID);
+
+            return updatedNotificationAddress;
+        }
+
         /// <inheritdoc/>
         public async Task<IEnumerable<Organization>> GetOrganizationNotificationAddresses(List<string> organizationNumbers, CancellationToken cancellationToken)
         {

--- a/src/Altinn.Profile.Integrations/Repositories/OrganizationNotificationAddressRepository.cs
+++ b/src/Altinn.Profile.Integrations/Repositories/OrganizationNotificationAddressRepository.cs
@@ -185,4 +185,20 @@ public class OrganizationNotificationAddressRepository(IDbContextFactory<Profile
 
         return _mapper.Map<NotificationAddress>(organizationNotificationAddress);
     }
+
+    /// <inheritdoc/>
+    public async Task<NotificationAddress> DeleteNotificationAddressAsync(int notificationAddressId)
+    {
+        using ProfileDbContext databaseContext = await _contextFactory.CreateDbContextAsync();
+
+        var notificationAddressDE = await databaseContext.NotificationAddresses.FirstAsync(n => n.NotificationAddressID == notificationAddressId);
+
+        notificationAddressDE.IsSoftDeleted = true;
+
+        databaseContext.NotificationAddresses.Update(notificationAddressDE);
+
+        await databaseContext.SaveChangesAsync();
+
+        return _mapper.Map<NotificationAddress>(notificationAddressDE);
+    }
 }

--- a/src/Altinn.Profile/Controllers/OrganizationsController.cs
+++ b/src/Altinn.Profile/Controllers/OrganizationsController.cs
@@ -127,5 +127,38 @@ namespace Altinn.Profile.Controllers
 
             return CreatedAtAction(nameof(GetMandatoryNotificationAddress), new { organizationNumber, newNotificationAddress.NotificationAddressID }, response);
         }
+
+        /// <summary>
+        /// Delete a notification address for an organization
+        /// </summary>
+        /// <returns>Returns an overview of the registered notification addresses for the given organization</returns>
+        [HttpDelete("mandatory/{notificationAddressId}")]
+        [Authorize(Policy = AuthConstants.OrgNotificationAddress_Write)]
+        [ProducesResponseType(typeof(NotificationAddressResponse), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<ActionResult<NotificationAddressResponse>> DeleteNotificationAddress([FromRoute] string organizationNumber, [FromRoute] int notificationAddressId, CancellationToken cancellationToken)
+        {
+            if (!ModelState.IsValid)
+            {
+                return ValidationProblem(ModelState);
+            }
+
+            if (string.IsNullOrWhiteSpace(organizationNumber))
+            {
+                return BadRequest("Organization number is required");
+            }
+
+            var updatedNotificationAddress = await _notificationAddressService.DeleteNotificationAddress(organizationNumber, notificationAddressId, cancellationToken);
+
+            if (updatedNotificationAddress == null)
+            {
+                return NotFound();
+            }
+
+            var response = OrganizationResponseMapper.ToNotificationAddressResponse(updatedNotificationAddress);
+
+            return Ok(response);
+        }
     }
 }

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/OrganizationsControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/OrganizationsControllerTests.cs
@@ -436,7 +436,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
         }
 
         [Fact]
-        public async Task DeleteMandatory_WhenTryingToDeleteLastAddress_ReturnsDeletedResult()
+        public async Task DeleteMandatory_WhenTryingToDeleteLastAddress_ReturnsConflict()
         {
             // Arrange
             var orgNo = "987654321";

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/OrganizationsControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/OrganizationsControllerTests.cs
@@ -15,6 +15,7 @@ using Altinn.Profile.Models;
 using Altinn.Profile.Tests.IntegrationTests.Utils;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Moq;
 using Xunit;
@@ -45,6 +46,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
                         {
                             FullAddress = "test@example.com",
                             AddressType = AddressType.Email,
+                            NotificationAddressID = 9
                         },
                     ]
                 }, new()
@@ -420,11 +422,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
                 .ReturnsAsync("2");
             HttpClient client = _webApplicationFactorySetup.GetTestServerClient(pdpMock.Object);
 
-            var input = new NotificationAddressModel { Email = "test@test.com" };
-            HttpRequestMessage httpRequestMessage = new(HttpMethod.Delete, $"/profile/api/v1/organizations/{orgNo}/notificationaddresses/mandatory/1")
-            {
-                Content = new StringContent(JsonSerializer.Serialize(input, _serializerOptions), System.Text.Encoding.UTF8, "application/json")
-            };
+            HttpRequestMessage httpRequestMessage = new(HttpMethod.Delete, $"/profile/api/v1/organizations/{orgNo}/notificationaddresses/mandatory/1");
             httpRequestMessage = CreateAuthorizedRequest(UserId, httpRequestMessage);
 
             // Act
@@ -435,6 +433,39 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
             string responseContent = await response.Content.ReadAsStringAsync();
             var actual = JsonSerializer.Deserialize<NotificationAddressResponse>(responseContent, _serializerOptions);
             Assert.IsType<NotificationAddressResponse>(actual);
+        }
+
+        [Fact]
+        public async Task DeleteMandatory_WhenTryingToDeleteLastAddress_ReturnsDeletedResult()
+        {
+            // Arrange
+            var orgNo = "987654321";
+            const int UserId = 2516356;
+            Mock<IPDP> pdpMock = GetPDPMockWithResponse("Permit");
+
+            _webApplicationFactorySetup.OrganizationNotificationAddressRepositoryMock
+                .Setup(r => r.GetOrganizationsAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(_testdata.Where(o => o.OrganizationNumber == orgNo));
+            _webApplicationFactorySetup.OrganizationNotificationAddressRepositoryMock
+            .Setup(r => r.DeleteNotificationAddressAsync(It.IsAny<int>()))
+            .ReturnsAsync(_testdata.First(o => o.OrganizationNumber == orgNo).NotificationAddresses.First());
+
+            _webApplicationFactorySetup.OrganizationNotificationAddressUpdateClientMock.Setup(
+                c => c.DeleteNotificationAddress(It.IsAny<string>()))
+                .ReturnsAsync("2");
+            HttpClient client = _webApplicationFactorySetup.GetTestServerClient(pdpMock.Object);
+
+            HttpRequestMessage httpRequestMessage = new(HttpMethod.Delete, $"/profile/api/v1/organizations/{orgNo}/notificationaddresses/mandatory/9");
+            httpRequestMessage = CreateAuthorizedRequest(UserId, httpRequestMessage);
+
+            // Act
+            HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+            string responseContent = await response.Content.ReadAsStringAsync();
+            var actual = JsonSerializer.Deserialize<ProblemDetails>(responseContent, _serializerOptions);
+            Assert.IsType<ProblemDetails>(actual);
         }
 
         [Fact]

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/OrganizationsControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/OrganizationsControllerTests.cs
@@ -400,6 +400,71 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
             Assert.Contains("The field Phone must match the regular expression", phoneMessage[0]);
         }
 
+        [Fact]
+        public async Task DeleteMandatory_WhenSuccessWithEmail_ReturnsDeletedResult()
+        {
+            // Arrange
+            var orgNo = "123456789";
+            const int UserId = 2516356;
+            Mock<IPDP> pdpMock = GetPDPMockWithResponse("Permit");
+
+            _webApplicationFactorySetup.OrganizationNotificationAddressRepositoryMock
+                .Setup(r => r.GetOrganizationsAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(_testdata.Where(o => o.OrganizationNumber == orgNo));
+            _webApplicationFactorySetup.OrganizationNotificationAddressRepositoryMock
+            .Setup(r => r.DeleteNotificationAddressAsync(It.IsAny<int>()))
+            .ReturnsAsync(_testdata.First(o => o.OrganizationNumber == orgNo).NotificationAddresses.First());
+
+            _webApplicationFactorySetup.OrganizationNotificationAddressUpdateClientMock.Setup(
+                c => c.DeleteNotificationAddress(It.IsAny<string>()))
+                .ReturnsAsync("2");
+            HttpClient client = _webApplicationFactorySetup.GetTestServerClient(pdpMock.Object);
+
+            var input = new NotificationAddressModel { Email = "test@test.com" };
+            HttpRequestMessage httpRequestMessage = new(HttpMethod.Delete, $"/profile/api/v1/organizations/{orgNo}/notificationaddresses/mandatory/1")
+            {
+                Content = new StringContent(JsonSerializer.Serialize(input, _serializerOptions), System.Text.Encoding.UTF8, "application/json")
+            };
+            httpRequestMessage = CreateAuthorizedRequest(UserId, httpRequestMessage);
+
+            // Act
+            HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            string responseContent = await response.Content.ReadAsStringAsync();
+            var actual = JsonSerializer.Deserialize<NotificationAddressResponse>(responseContent, _serializerOptions);
+            Assert.IsType<NotificationAddressResponse>(actual);
+        }
+
+        [Fact]
+        public async Task DeleteMandatory_WhenNotFound_ReturnsNotFound()
+        {
+            // Arrange
+            var orgNo = "123456789";
+            const int UserId = 2516356;
+            Mock<IPDP> pdpMock = GetPDPMockWithResponse("Permit");
+
+            _webApplicationFactorySetup.OrganizationNotificationAddressRepositoryMock
+                .Setup(r => r.GetOrganizationsAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync([new Organization { OrganizationNumber = orgNo, NotificationAddresses = [] }]);
+
+            HttpClient client = _webApplicationFactorySetup.GetTestServerClient(pdpMock.Object);
+
+            var input = new NotificationAddressModel { Email = "test@test.com" };
+            HttpRequestMessage httpRequestMessage = new(HttpMethod.Delete, $"/profile/api/v1/organizations/{orgNo}/notificationaddresses/mandatory/1")
+            {
+                Content = new StringContent(JsonSerializer.Serialize(input, _serializerOptions), System.Text.Encoding.UTF8, "application/json")
+            };
+            httpRequestMessage = CreateAuthorizedRequest(UserId, httpRequestMessage);
+
+            // Act
+            HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        }
+
         private static HttpRequestMessage CreateAuthorizedRequest(int userId, HttpRequestMessage httpRequestMessage)
         {
             string token = PrincipalUtil.GetToken(userId);

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/OrganizationsControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/OrganizationsControllerTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Net.Http.Json;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -417,8 +418,8 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
             .Setup(r => r.DeleteNotificationAddressAsync(It.IsAny<int>()))
             .ReturnsAsync(_testdata.First(o => o.OrganizationNumber == orgNo).NotificationAddresses.First());
 
-            _webApplicationFactorySetup.OrganizationNotificationAddressUpdateClientMock.Setup(
-                c => c.DeleteNotificationAddress(It.IsAny<string>()))
+            _webApplicationFactorySetup.OrganizationNotificationAddressUpdateClientMock
+                .Setup(c => c.DeleteNotificationAddress(It.IsAny<string>()))
                 .ReturnsAsync("2");
             HttpClient client = _webApplicationFactorySetup.GetTestServerClient(pdpMock.Object);
 
@@ -450,8 +451,8 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
             .Setup(r => r.DeleteNotificationAddressAsync(It.IsAny<int>()))
             .ReturnsAsync(_testdata.First(o => o.OrganizationNumber == orgNo).NotificationAddresses.First());
 
-            _webApplicationFactorySetup.OrganizationNotificationAddressUpdateClientMock.Setup(
-                c => c.DeleteNotificationAddress(It.IsAny<string>()))
+            _webApplicationFactorySetup.OrganizationNotificationAddressUpdateClientMock
+                .Setup(c => c.DeleteNotificationAddress(It.IsAny<string>()))
                 .ReturnsAsync("2");
             HttpClient client = _webApplicationFactorySetup.GetTestServerClient(pdpMock.Object);
 
@@ -485,7 +486,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
             var input = new NotificationAddressModel { Email = "test@test.com" };
             HttpRequestMessage httpRequestMessage = new(HttpMethod.Delete, $"/profile/api/v1/organizations/{orgNo}/notificationaddresses/mandatory/1")
             {
-                Content = new StringContent(JsonSerializer.Serialize(input, _serializerOptions), System.Text.Encoding.UTF8, "application/json")
+                Content = JsonContent.Create(input, options: _serializerOptions)
             };
             httpRequestMessage = CreateAuthorizedRequest(UserId, httpRequestMessage);
 

--- a/test/Altinn.Profile.Tests/Profile.Core/OrganizationNotificationAddresses/OrganizationNotificationAddressesServiceTests.cs
+++ b/test/Altinn.Profile.Tests/Profile.Core/OrganizationNotificationAddresses/OrganizationNotificationAddressesServiceTests.cs
@@ -168,7 +168,7 @@ namespace Altinn.Profile.Tests.Profile.Core.OrganizationNotificationAddresses
         {
             // Arrange
             _repository.Setup(r => r.GetOrganizationsAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync([new Organization { OrganizationNumber = "123456789", NotificationAddresses = [new NotificationAddress { NotificationAddressID = 1}] }]);
+                .ReturnsAsync([new Organization { OrganizationNumber = "123456789", NotificationAddresses = [new NotificationAddress { NotificationAddressID = 1 }] }]);
 
             // Act
             var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => _service.DeleteNotificationAddress("123456789", 1, CancellationToken.None));

--- a/test/Altinn.Profile.Tests/Profile.Core/OrganizationNotificationAddresses/OrganizationNotificationAddressesServiceTests.cs
+++ b/test/Altinn.Profile.Tests/Profile.Core/OrganizationNotificationAddresses/OrganizationNotificationAddressesServiceTests.cs
@@ -30,6 +30,7 @@ namespace Altinn.Profile.Tests.Profile.Core.OrganizationNotificationAddresses
                         {
                             FullAddress = "test@test.com",
                             AddressType = AddressType.Email,
+                            NotificationAddressID = 1,
                         },
                         new()
                         {
@@ -143,6 +144,23 @@ namespace Altinn.Profile.Tests.Profile.Core.OrganizationNotificationAddresses
             Assert.Contains("Something went wrong", ex.Message);
             _repository.Verify(r => r.GetOrganizationsAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()), Times.Once);
             _repository.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task DeleteNotificationAddress_SuccessfulDeletion_ReturnsDeletedAddress()
+        {
+            // Arrange
+            _updateClient.Setup(c => c.DeleteNotificationAddress(It.IsAny<string>()))
+                .ReturnsAsync("registry-id");
+
+            _repository.Setup(r => r.DeleteNotificationAddressAsync(It.IsAny<int>()))
+                .ReturnsAsync(new NotificationAddress { IsSoftDeleted = true });
+
+            // Act
+            var result = await _service.DeleteNotificationAddress("123456789", 1, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(result);
         }
     }
 }

--- a/test/Altinn.Profile.Tests/Profile.Core/OrganizationNotificationAddresses/OrganizationNotificationAddressesServiceTests.cs
+++ b/test/Altinn.Profile.Tests/Profile.Core/OrganizationNotificationAddresses/OrganizationNotificationAddressesServiceTests.cs
@@ -162,5 +162,29 @@ namespace Altinn.Profile.Tests.Profile.Core.OrganizationNotificationAddresses
             // Assert
             Assert.NotNull(result);
         }
+
+        [Fact]
+        public async Task DeleteNotificationAddress_WhenNoAddressFound_ReturnsNull()
+        {
+            // Act
+            var result = await _service.DeleteNotificationAddress("123456789", 10000, CancellationToken.None);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task DeleteNotificationAddress_WhenNoOrganizationFound_ReturnsNull()
+        {
+            // Arrange
+            _repository.Setup(r => r.GetOrganizationsAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync([]);
+
+            // Act
+            var result = await _service.DeleteNotificationAddress("1", 1, CancellationToken.None);
+
+            // Assert
+            Assert.Null(result);
+        }
     }
 }

--- a/test/Altinn.Profile.Tests/Profile.Core/OrganizationNotificationAddresses/OrganizationNotificationAddressesServiceTests.cs
+++ b/test/Altinn.Profile.Tests/Profile.Core/OrganizationNotificationAddresses/OrganizationNotificationAddressesServiceTests.cs
@@ -164,6 +164,20 @@ namespace Altinn.Profile.Tests.Profile.Core.OrganizationNotificationAddresses
         }
 
         [Fact]
+        public async Task DeleteNotificationAddress_WhenTryingToDeleteLastAddress_ThrowsInvalidOperationException()
+        {
+            // Arrange
+            _repository.Setup(r => r.GetOrganizationsAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync([new Organization { OrganizationNumber = "123456789", NotificationAddresses = [new NotificationAddress { NotificationAddressID = 1}] }]);
+
+            // Act
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => _service.DeleteNotificationAddress("123456789", 1, CancellationToken.None));
+
+            // Assert
+            Assert.Contains("Cannot delete the last notification address", ex.Message);
+        }
+
+        [Fact]
         public async Task DeleteNotificationAddress_WhenNoAddressFound_ReturnsNull()
         {
             // Act

--- a/test/Altinn.Profile.Tests/Profile.Integrations/OrganizationNotificationAddressTests/OrganizationNotificationAddressRepositoryTests.cs
+++ b/test/Altinn.Profile.Tests/Profile.Integrations/OrganizationNotificationAddressTests/OrganizationNotificationAddressRepositoryTests.cs
@@ -318,7 +318,7 @@ public class OrganizationNotificationAddressRepositoryTests : IDisposable
         Assert.NotEqual(existingAddress.RegistryID, updatedAddress.RegistryID);
     }
     
-        [Fact]
+    [Fact]
     public async Task DeleteNotificationAddressAsync_WhenFound_ReturnsSoftDeletedNotificationAddress()
     {
         // Arrange

--- a/test/Altinn.Profile.Tests/Profile.Integrations/OrganizationNotificationAddressTests/OrganizationNotificationAddressRepositoryTests.cs
+++ b/test/Altinn.Profile.Tests/Profile.Integrations/OrganizationNotificationAddressTests/OrganizationNotificationAddressRepositoryTests.cs
@@ -286,9 +286,6 @@ public class OrganizationNotificationAddressRepositoryTests : IDisposable
 
         var orgNumber = "123456789";
 
-        var expectedOrg1 = organizations
-            .Find(p => p.RegistryOrganizationNumber == orgNumber);
-
         // Act
         var na = await _repository.CreateNotificationAddressAsync(orgNumber, new NotificationAddress { AddressType = AddressType.Email, FullAddress = "test@test.com", Address = "test" }, "1");
 
@@ -306,9 +303,6 @@ public class OrganizationNotificationAddressRepositoryTests : IDisposable
         SeedDatabase(organizations, notificationAddresses);
 
         var notificationAddressId = 1;
-
-        var existingAddress = notificationAddresses
-            .Find(p => p.NotificationAddressID == 1);
 
         // Act
         var updatedAddress = await _repository.DeleteNotificationAddressAsync(notificationAddressId);

--- a/test/Altinn.Profile.Tests/Profile.Integrations/OrganizationNotificationAddressTests/OrganizationNotificationAddressRepositoryTests.cs
+++ b/test/Altinn.Profile.Tests/Profile.Integrations/OrganizationNotificationAddressTests/OrganizationNotificationAddressRepositoryTests.cs
@@ -298,6 +298,26 @@ public class OrganizationNotificationAddressRepositoryTests : IDisposable
         Assert.NotEqual(default, na.NotificationAddressID);
     }
 
+    [Fact]
+    public async Task DeleteNotificationAddressAsync_WhenFound_ReturnsSoftDeletedNotificationAddress()
+    {
+        // Arrange
+        var (organizations, notificationAddresses) = OrganizationNotificationAddressTestData.GetNotificationAddresses();
+        SeedDatabase(organizations, notificationAddresses);
+
+        var notificationAddressId = 1;
+
+        var existingAddress = notificationAddresses
+            .Find(p => p.NotificationAddressID == 1);
+
+        // Act
+        var updatedAddress = await _repository.DeleteNotificationAddressAsync(notificationAddressId);
+
+        // Assert
+        Assert.IsType<NotificationAddress>(updatedAddress);
+        Assert.True(updatedAddress.IsSoftDeleted);
+    }
+
     private static void AssertRegisterProperties(OrganizationDE expected, OrganizationDE actual)
     {
         Assert.Equal(expected.RegistryOrganizationNumber, actual.RegistryOrganizationNumber);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
A user must be able to delete old notification addresses.

## Related Issue(s)
- #341 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to delete a notification address for an organization via a new API endpoint. Deleted addresses are soft deleted and the deleted address is returned in the response.

- **Bug Fixes**
  - Improved validation and error handling for deleting notification addresses, including appropriate responses for not found, invalid requests, and preventing deletion of the last notification address.

- **Tests**
  - Introduced new integration and unit tests to verify successful deletion, not found scenarios, prevention of deleting the last address, and soft delete behavior for notification addresses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->