### PR TITLE
Filter out deleted or new org addresses

### DIFF
--- a/src/Altinn.Profile.Core/OrganizationNotificationAddresses/NotificationAddress.cs
+++ b/src/Altinn.Profile.Core/OrganizationNotificationAddresses/NotificationAddress.cs
@@ -46,5 +46,10 @@ namespace Altinn.Profile.Core.OrganizationNotificationAddresses
         /// A value indicating whether the entity is deleted in Altinn.
         /// </summary>
         public bool? IsSoftDeleted { get; init; }
+
+        /// <summary>
+        /// A value indicating whether the endpoint has been accepted and received from kofuvi registry 
+        /// </summary>
+        public bool? HasRegistryAccepted { get; set; }
     }
 }

--- a/src/Altinn.Profile.Core/OrganizationNotificationAddresses/NotificationAddress.cs
+++ b/src/Altinn.Profile.Core/OrganizationNotificationAddresses/NotificationAddress.cs
@@ -50,6 +50,6 @@ namespace Altinn.Profile.Core.OrganizationNotificationAddresses
         /// <summary>
         /// A value indicating whether the endpoint has been accepted and received from kofuvi registry 
         /// </summary>
-        public bool? HasRegistryAccepted { get; set; }
+        public bool? HasRegistryAccepted { get; init; }
     }
 }

--- a/src/Altinn.Profile/Controllers/OrgNotificationAddressController.cs
+++ b/src/Altinn.Profile/Controllers/OrgNotificationAddressController.cs
@@ -64,6 +64,11 @@ namespace Altinn.Profile.Controllers
                 {
                     foreach (var notificationAddress in organization.NotificationAddresses)
                     {
+                        if (notificationAddress.IsSoftDeleted == true || notificationAddress.HasRegistryAccepted == false)
+                        {
+                            continue;
+                        }
+
                         switch (notificationAddress.AddressType)
                         {
                             case AddressType.Email:

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/OrgNotificationAddressesControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/OrgNotificationAddressesControllerTests.cs
@@ -64,7 +64,32 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
                             AddressType = AddressType.SMS,
                         }
                     ]
+                },
+                new()
+                {
+                    OrganizationNumber = "222222222",
+                    NotificationAddresses =
+                    [
+                        new()
+                        {
+                            FullAddress = "test@test.com",
+                            AddressType = AddressType.Email,
+                            IsSoftDeleted = true,
+                        },
+                        new()
+                        {
+                            FullAddress = "+4798765432",
+                            AddressType = AddressType.SMS,
+                            HasRegistryAccepted = false,
+                        },
+                        new()
+                        {
+                            FullAddress = "+4747765432",
+                            AddressType = AddressType.SMS,
+                        }
+                    ]
                 }
+
                 ];
         }
 
@@ -131,6 +156,37 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
             Assert.Equal("123456789", actual.ContactPointsList[1].OrganizationNumber);
             Assert.Single(actual.ContactPointsList[1].EmailList);
             Assert.Equal(2, actual.ContactPointsList[1].MobileNumberList.Count);
+        }
+
+        [Fact]
+        public async Task PostLookup_WhenOneOrganizationFoundWithDeletedAddress_ReturnsOkWithSingleItemListWithFilteredAddresses()
+        {
+            // Arrange
+            OrgNotificationAddressRequest input = new()
+            {
+                OrganizationNumbers = ["222222222"],
+            };
+
+            _webApplicationFactorySetup.OrganizationNotificationAddressRepositoryMock
+                .Setup(r => r.GetOrganizationsAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(_testdata.Where(o => input.OrganizationNumbers.Contains(o.OrganizationNumber)));
+            HttpClient client = _webApplicationFactorySetup.GetTestServerClient();
+            HttpRequestMessage httpRequestMessage = new(HttpMethod.Post, "/profile/api/v1/organizations/notificationaddresses/lookup")
+            {
+                Content = new StringContent(JsonSerializer.Serialize(input, _serializerOptions), System.Text.Encoding.UTF8, "application/json")
+            };
+
+            // Act
+            HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            string responseContent = await response.Content.ReadAsStringAsync();
+            var actual = JsonSerializer.Deserialize<OrgNotificationAddressesResponse>(responseContent, _serializerOptions);
+            Assert.Single(actual.ContactPointsList);
+            Assert.Equal("222222222", actual.ContactPointsList[0].OrganizationNumber);
+            Assert.Empty(actual.ContactPointsList[0].EmailList);
+            Assert.Single(actual.ContactPointsList[0].MobileNumberList);
         }
 
         [Fact]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Altinn 2 filters out addresses that are soft deleted (to be deleted in brreg) and addresses not yet accepted by brreg. Altinn 3 should do the same to ensure consistent behavior.

## Related Issue(s)
- #361 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced filtering of notification addresses to exclude those that are soft deleted or not accepted by the registry in organization contact point lookups.
  - Added a new property indicating registry acceptance status for notification addresses.

- **Bug Fixes**
  - Improved the accuracy of organization contact information by ensuring only valid, accepted notification addresses are returned.

- **Tests**
  - Added integration tests to verify that soft-deleted and non-accepted notification addresses are correctly excluded from API responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->