### PR TITLE
Add gitattributes file to ensure LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+# These files are text and should be normalized (convert crlf -> lf)
+*.cs      text diff=csharp
+*.yaml    text
+*.yml     text
+*.csproj  text
+*.sln     text
+*.ps1     text
+*.cmd     text
+*.msbuild text
+*.md      text diff=markdown
+
+# Images should be treated as binary ('binary' is a macro for '-text -diff', i.e. "don't normalize or diff on content")
+*.png     binary
+*.jpeg    binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,18 +1,22 @@
+# Prepend with the general automatic normalization (convert crlf -> lf) that uses Git's binary detection
 * text=auto
 
-# These files are text and should be normalized (convert crlf -> lf)
-*.cs      text diff=csharp
-*.yaml    text
-*.yml     text
-*.csproj  text
-*.sln     text
-*.ps1     text
-*.cmd     text
-*.msbuild text
-*.md      text diff=markdown
-*.json   text
+# Override with explicit specific settings for known and/or likely text files in our repo that should be normalized
+*.cmd      text
+*.cs       text diff=csharp
+*.csproj   text
+*.css      text diff=css
 Dockerfile text
+*.json     text
+*.md       text diff=markdown
+*.msbuild  text
+*.ps1      text
+*.sln      text
+*.yaml     text
+*.yml      text
 
 # Images should be treated as binary ('binary' is a macro for '-text -diff', i.e. "don't normalize or diff on content")
-*.png     binary
+*.cer     binary
 *.jpeg    binary
+*.pfx     binary
+*.png     binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,14 @@
-# Prepend with the general automatic normalization (convert crlf -> lf) that uses Git's binary detection
+# General setting that applies Git's binary detection for file-types not specified below
+# Meaning, for 'text-guessed' files:
+# use normalization (convert crlf -> lf on commit, i.e. use `text` setting) 
+# & do unspecified diff behavior (if file content is recognized as text & filesize < core.bigFileThreshold, do text diff on file changes)
 * text=auto
 
+
 # Override with explicit specific settings for known and/or likely text files in our repo that should be normalized
+# where diff{=optional_pattern} means "do text diff {with specific text pattern} and -diff means "don't do text diffs".
+# Unspecified diff behavior is decribed above
+*.cer      text -diff
 *.cmd      text
 *.cs       text diff=csharp
 *.csproj   text
@@ -10,13 +17,13 @@ Dockerfile text
 *.json     text
 *.md       text diff=markdown
 *.msbuild  text
+*.pem      text -diff
 *.ps1      text
 *.sln      text
 *.yaml     text
 *.yml      text
 
-# Images should be treated as binary ('binary' is a macro for '-text -diff', i.e. "don't normalize or diff on content")
-*.cer     binary
+# Files that should be treated as binary ('binary' is a macro for '-text -diff', i.e. "don't normalize or do text diff on content")
 *.jpeg    binary
 *.pfx     binary
 *.png     binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -4,7 +4,6 @@
 # & do unspecified diff behavior (if file content is recognized as text & filesize < core.bigFileThreshold, do text diff on file changes)
 * text=auto
 
-
 # Override with explicit specific settings for known and/or likely text files in our repo that should be normalized
 # where diff{=optional_pattern} means "do text diff {with specific text pattern} and -diff means "don't do text diffs".
 # Unspecified diff behavior is decribed above

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
+* text=auto
+
 # These files are text and should be normalized (convert crlf -> lf)
 *.cs      text diff=csharp
 *.yaml    text
@@ -8,6 +10,8 @@
 *.cmd     text
 *.msbuild text
 *.md      text diff=markdown
+*.json   text
+Dockerfile text
 
 # Images should be treated as binary ('binary' is a macro for '-text -diff', i.e. "don't normalize or diff on content")
 *.png     binary


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Enforce LF line endings using a .gitattributes file and renormalize existing files with CRLF line endings
## Related Issue(s)
https://github.com/Altinn/team-core-private/issues/233

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added configuration to standardize line endings and improve diff handling for various file types in the repository.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->