### PR TITLE
Change from 201 to 200 when trying to add existing address

### DIFF
--- a/src/Altinn.Profile.Core/OrganizationNotificationAddresses/IOrganizationNotificationAddressesService.cs
+++ b/src/Altinn.Profile.Core/OrganizationNotificationAddresses/IOrganizationNotificationAddressesService.cs
@@ -11,7 +11,7 @@ public interface IOrganizationNotificationAddressesService
     /// <param name="organizationNumber">An organization number to indicate which organization to add address for</param>
     /// <param name="notificationAddress">The new notification address</param>
     /// <param name="cancellationToken">To cancel the request before it is finished</param>
-    Task<NotificationAddress> CreateNotificationAddress(string organizationNumber, NotificationAddress notificationAddress, CancellationToken cancellationToken);
+    Task<(NotificationAddress Address, bool IsNew)> CreateNotificationAddress(string organizationNumber, NotificationAddress notificationAddress, CancellationToken cancellationToken);
 
     /// <summary>
     /// Method for updating a notification address for an organization. 

--- a/src/Altinn.Profile.Core/OrganizationNotificationAddresses/IOrganizationNotificationAddressesService.cs
+++ b/src/Altinn.Profile.Core/OrganizationNotificationAddresses/IOrganizationNotificationAddressesService.cs
@@ -19,7 +19,7 @@ public interface IOrganizationNotificationAddressesService
     /// <param name="organizationNumber">An organization number to indicate which organization to update address for</param>
     /// <param name="notificationAddress">The notification address with updated data</param>
     /// <param name="cancellationToken">To cancel the request before it is finished</param>
-    Task<NotificationAddress?> UpdateNotificationAddress(string organizationNumber, NotificationAddress notificationAddress, CancellationToken cancellationToken);
+    Task<(NotificationAddress? Address, bool IsDuplicate)> UpdateNotificationAddress(string organizationNumber, NotificationAddress notificationAddress, CancellationToken cancellationToken);
 
     /// <summary>
     /// Method for retrieving notification addresses for an organization.

--- a/src/Altinn.Profile.Core/OrganizationNotificationAddresses/OrganizationNotificationAddressesService.cs
+++ b/src/Altinn.Profile.Core/OrganizationNotificationAddresses/OrganizationNotificationAddressesService.cs
@@ -51,7 +51,7 @@ namespace Altinn.Profile.Core.OrganizationNotificationAddresses
             var existingNotificationAddress = org.NotificationAddresses?.FirstOrDefault(n => n.NotificationAddressID == notificationAddress.NotificationAddressID);
             if (existingNotificationAddress == null)
             {
-                return (existingNotificationAddress, true);
+                return (existingNotificationAddress, false);
             }
 
             var duplicateAddress = org.NotificationAddresses?.FirstOrDefault(x => x.FullAddress == notificationAddress.FullAddress && x.AddressType == notificationAddress.AddressType);

--- a/src/Altinn.Profile.Core/OrganizationNotificationAddresses/OrganizationNotificationAddressesService.cs
+++ b/src/Altinn.Profile.Core/OrganizationNotificationAddresses/OrganizationNotificationAddressesService.cs
@@ -13,7 +13,7 @@ namespace Altinn.Profile.Core.OrganizationNotificationAddresses
         private readonly IOrganizationNotificationAddressUpdateClient _updateClient = updateClient;
 
         /// <inheritdoc/>
-        public async Task<NotificationAddress> CreateNotificationAddress(string organizationNumber, NotificationAddress notificationAddress, CancellationToken cancellationToken)
+        public async Task<(NotificationAddress Address, bool IsNew)> CreateNotificationAddress(string organizationNumber, NotificationAddress notificationAddress, CancellationToken cancellationToken)
         {
             var orgs = await _orgRepository.GetOrganizationsAsync([organizationNumber], cancellationToken);
             var org = orgs.FirstOrDefault();
@@ -22,14 +22,14 @@ namespace Altinn.Profile.Core.OrganizationNotificationAddresses
             var existingAddress = org.NotificationAddresses?.FirstOrDefault(x => x.FullAddress == notificationAddress.FullAddress && x.AddressType == notificationAddress.AddressType);
             if (existingAddress != null)
             {
-                return existingAddress;
+                return (existingAddress, false);
             }
 
             var registryId = await _updateClient.CreateNewNotificationAddress(notificationAddress, organizationNumber);
 
             var updatedNotificationAddress = await _orgRepository.CreateNotificationAddressAsync(organizationNumber, notificationAddress, registryId);
 
-            return updatedNotificationAddress;
+            return (updatedNotificationAddress, true);
         }
 
         /// <summary>

--- a/src/Altinn.Profile/Controllers/OrganizationsController.cs
+++ b/src/Altinn.Profile/Controllers/OrganizationsController.cs
@@ -99,9 +99,11 @@ namespace Altinn.Profile.Controllers
         }
 
         /// <summary>
-        /// Create a new notification address for an organization
+        /// Create a new notification address for an organization. 
         /// </summary>
         /// <returns>Returns an overview of the registered notification addresses for the given organization</returns>
+        /// <response code="201">Returns the newly created notification address</response>
+        /// <response code="200">Returns the existing address if it is already registered. This means that duplicate create commands will only result in the creation one notification address.</response>
         [HttpPost("mandatory")]
         [Authorize(Policy = AuthConstants.OrgNotificationAddress_Write)]
         [ProducesResponseType(typeof(NotificationAddressResponse), StatusCodes.Status200OK)]
@@ -138,6 +140,8 @@ namespace Altinn.Profile.Controllers
         /// Update a notification address for an organization
         /// </summary>
         /// <returns>Returns the updated notification address for the given organization</returns>
+        /// <response code="200">Returns the updated address if it is already registered</response>
+        /// <response code="409">Returns problem details with a reference to the conflicting address in the instance parameter</response>
         [HttpPut("mandatory/{notificationAddressId}")]
         [Authorize(Policy = AuthConstants.OrgNotificationAddress_Write)]
         [ProducesResponseType(typeof(NotificationAddressResponse), StatusCodes.Status200OK)]

--- a/src/Altinn.Profile/Controllers/OrganizationsController.cs
+++ b/src/Altinn.Profile/Controllers/OrganizationsController.cs
@@ -121,11 +121,16 @@ namespace Altinn.Profile.Controllers
 
             var notificationAddress = NotificationAddressRequestMapper.ToInternalModel(request);
 
-            var newNotificationAddress = await _notificationAddressService.CreateNotificationAddress(organizationNumber, notificationAddress, cancellationToken);
+            var (newNotificationAddress, isNew) = await _notificationAddressService.CreateNotificationAddress(organizationNumber, notificationAddress, cancellationToken);
 
             var response = OrganizationResponseMapper.ToNotificationAddressResponse(newNotificationAddress);
 
-            return CreatedAtAction(nameof(GetMandatoryNotificationAddress), new { organizationNumber, newNotificationAddress.NotificationAddressID }, response);
+            if (isNew)
+            {
+                return CreatedAtAction(nameof(GetMandatoryNotificationAddress), new { organizationNumber, newNotificationAddress.NotificationAddressID }, response);
+            }
+
+            return Ok(response);
         }
 
         /// <summary>

--- a/src/Altinn.Profile/Controllers/OrganizationsController.cs
+++ b/src/Altinn.Profile/Controllers/OrganizationsController.cs
@@ -104,6 +104,7 @@ namespace Altinn.Profile.Controllers
         /// <returns>Returns an overview of the registered notification addresses for the given organization</returns>
         [HttpPost("mandatory")]
         [Authorize(Policy = AuthConstants.OrgNotificationAddress_Write)]
+        [ProducesResponseType(typeof(NotificationAddressResponse), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(NotificationAddressResponse), StatusCodes.Status201Created)]
         [ProducesResponseType(typeof(ValidationProblemDetails), StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]

--- a/src/Altinn.Profile/Controllers/OrganizationsController.cs
+++ b/src/Altinn.Profile/Controllers/OrganizationsController.cs
@@ -148,6 +148,7 @@ namespace Altinn.Profile.Controllers
         [ProducesResponseType(typeof(ValidationProblemDetails), StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
         public async Task<ActionResult<NotificationAddressResponse>> UpdateNotificationAddress([FromRoute] string organizationNumber, [FromRoute] int notificationAddressId, [FromBody] NotificationAddressModel request, CancellationToken cancellationToken)
         {
             if (!ModelState.IsValid)

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/OrganizationsControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/OrganizationsControllerTests.cs
@@ -517,6 +517,34 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
         }
 
         [Fact]
+        public async Task UpdateMandatory_WhenNoOrgFound_ReturnsNotFound()
+        {
+            // Arrange
+            var orgNo = "1";
+            const int UserId = 2516356;
+            Mock<IPDP> pdpMock = GetPDPMockWithResponse("Permit");
+
+            _webApplicationFactorySetup.OrganizationNotificationAddressRepositoryMock
+                .Setup(r => r.GetOrganizationsAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync([new Organization { NotificationAddresses = [], OrganizationNumber = orgNo }]);
+
+            HttpClient client = _webApplicationFactorySetup.GetTestServerClient(pdpMock.Object);
+
+            var input = new NotificationAddressModel { Email = "test@test.com" };
+            HttpRequestMessage httpRequestMessage = new(HttpMethod.Put, $"/profile/api/v1/organizations/{orgNo}/notificationaddresses/mandatory/100")
+            {
+                Content = new StringContent(JsonSerializer.Serialize(input, _serializerOptions), System.Text.Encoding.UTF8, "application/json")
+            };
+            httpRequestMessage = CreateAuthorizedRequest(UserId, httpRequestMessage);
+
+            // Act
+            HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        }
+
+        [Fact]
         public async Task UpdateMandatory_WhenNoAddressFound_ReturnsNotFound()
         {
             // Arrange

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/OrganizationsControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/OrganizationsControllerTests.cs
@@ -461,7 +461,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
                 .ReturnsAsync("2");
             HttpClient client = _webApplicationFactorySetup.GetTestServerClient(pdpMock.Object);
 
-            var input = new NotificationAddressModel { Email = "test@test.com" };
+            var input = new NotificationAddressModel { Email = "unique@test.com" };
             HttpRequestMessage httpRequestMessage = new(HttpMethod.Put, $"/profile/api/v1/organizations/{orgNo}/notificationaddresses/mandatory/1")
             {
                 Content = new StringContent(JsonSerializer.Serialize(input, _serializerOptions), System.Text.Encoding.UTF8, "application/json")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When adding a notification address to an organization that is identical to an existing address, we should return 200 OK instead of 201 Created.

For update we now return 409 conflict. This is a change from altinn 2
For reference: breg returns OK with the ID of the duplicate address. Altinn 2 deletes the duplicate address.

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **New Features**
	- The system now clearly indicates when a notification address is newly created or already exists.
	- API responses differentiate between newly created addresses (HTTP 201) and existing ones (HTTP 200).
- **Bug Fixes**
	- Enhanced conflict detection to prevent duplicate notification addresses, returning HTTP 409 with detailed error information.
- **Tests**
	- Added tests to verify correct handling of existing addresses during creation and update operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->