### PR TITLE
Filter out soft deleted addresses and make sure addresstype is updated

### DIFF
--- a/src/Altinn.Profile.Integrations/Entities/OrganizationDE.cs
+++ b/src/Altinn.Profile.Integrations/Entities/OrganizationDE.cs
@@ -28,6 +28,6 @@ namespace Altinn.Profile.Integrations.Entities
         /// A collection of notification addresses associated with this organization
         /// </summary>
         [InverseProperty("Organization")]
-        public List<NotificationAddressDE>? NotificationAddresses { get; set; }
+        public List<NotificationAddressDE>? NotificationAddresses { get; set; } = new List<NotificationAddressDE>();
     }
 }

--- a/src/Altinn.Profile.Integrations/Entities/OrganizationDE.cs
+++ b/src/Altinn.Profile.Integrations/Entities/OrganizationDE.cs
@@ -28,6 +28,6 @@ namespace Altinn.Profile.Integrations.Entities
         /// A collection of notification addresses associated with this organization
         /// </summary>
         [InverseProperty("Organization")]
-        public List<NotificationAddressDE>? NotificationAddresses { get; set; } = new List<NotificationAddressDE>();
+        public List<NotificationAddressDE> NotificationAddresses { get; set; } = new List<NotificationAddressDE>();
     }
 }

--- a/src/Altinn.Profile.Integrations/Repositories/OrganizationNotificationAddressRepository.cs
+++ b/src/Altinn.Profile.Integrations/Repositories/OrganizationNotificationAddressRepository.cs
@@ -149,7 +149,7 @@ public class OrganizationNotificationAddressRepository(IDbContextFactory<Profile
         using ProfileDbContext databaseContext = await _contextFactory.CreateDbContextAsync(cancellationToken);
 
         var foundOrganizations = await databaseContext.Organizations
-                .Include(o => o.NotificationAddresses)
+                .Include(o => o.NotificationAddresses.Where(a => a.IsSoftDeleted != true))
                 .Where(o => organizationNumbers.Contains(o.RegistryOrganizationNumber))
                 .ToListAsync(cancellationToken);
 
@@ -193,6 +193,7 @@ public class OrganizationNotificationAddressRepository(IDbContextFactory<Profile
 
         var notificationAddressDE = await databaseContext.NotificationAddresses.FirstAsync(n => n.NotificationAddressID == notificationAddress.NotificationAddressID);
 
+        notificationAddressDE.AddressType = notificationAddress.AddressType;
         notificationAddressDE.Address = notificationAddress.Address;
         notificationAddressDE.Domain = notificationAddress.Domain;
         notificationAddressDE.FullAddress = notificationAddress.FullAddress;

--- a/src/Altinn.Profile/Mappers/OrganizationResponseMapper.cs
+++ b/src/Altinn.Profile/Mappers/OrganizationResponseMapper.cs
@@ -30,7 +30,7 @@ namespace Altinn.Profile.Mappers
         {
             var response = new NotificationAddressResponse
             {
-                NotificationAddressID = notificationAddress.NotificationAddressID,
+                NotificationAddressId = notificationAddress.NotificationAddressID,
             };
 
             if (notificationAddress.AddressType == AddressType.Email)

--- a/src/Altinn.Profile/Models/NotificationAddressResponse.cs
+++ b/src/Altinn.Profile/Models/NotificationAddressResponse.cs
@@ -6,8 +6,8 @@
     public class NotificationAddressResponse : NotificationAddressModel
     {
         /// <summary>
-        /// <see cref="NotificationAddressID"/>
+        /// <see cref="NotificationAddressId"/>
         /// </summary>
-        public int NotificationAddressID { get; set; }
+        public int NotificationAddressId { get; set; }
     }
 }

--- a/test/Altinn.Profile.Tests/Profile.Integrations/OrganizationNotificationAddressTests/OrganizationNotificationAddressRepositoryTests.cs
+++ b/test/Altinn.Profile.Tests/Profile.Integrations/OrganizationNotificationAddressTests/OrganizationNotificationAddressRepositoryTests.cs
@@ -256,20 +256,19 @@ public class OrganizationNotificationAddressRepositoryTests : IDisposable
         var (organizations, notificationAddresses) = OrganizationNotificationAddressTestData.GetNotificationAddresses();
         SeedDatabase(organizations, notificationAddresses);
 
-        var orgNumberLookup = new List<string>() { "999999999" };
+        var testOrgWithOnlySoftDeletedAddresses = new List<string>() { "999999999" };
 
         var expectedOrg1 = organizations
             .Find(p => p.RegistryOrganizationNumber == "999999999");
 
         // Act
-        var result = await _repository.GetOrganizationsAsync(orgNumberLookup, CancellationToken.None);
+        var result = await _repository.GetOrganizationsAsync(testOrgWithOnlySoftDeletedAddresses, CancellationToken.None);
 
         // Assert
         Assert.NotEmpty(result);
         var matchedOrg1 = result.FirstOrDefault();
         Assert.IsType<Organization>(matchedOrg1);
         Assert.Empty(matchedOrg1.NotificationAddresses);
-        Assert.Equal(matchedOrg1.OrganizationNumber, expectedOrg1.RegistryOrganizationNumber);
     }
 
     [Fact]

--- a/test/Altinn.Profile.Tests/Profile.Integrations/OrganizationNotificationAddressTests/OrganizationNotificationAddressRepositoryTests.cs
+++ b/test/Altinn.Profile.Tests/Profile.Integrations/OrganizationNotificationAddressTests/OrganizationNotificationAddressRepositoryTests.cs
@@ -250,6 +250,29 @@ public class OrganizationNotificationAddressRepositoryTests : IDisposable
     }
 
     [Fact]
+    public async Task GetOrganizations_WhenFoundButAddressSoftDeleted_ReturnsWithoutNotificationAddresses()
+    {
+        // Arrange
+        var (organizations, notificationAddresses) = OrganizationNotificationAddressTestData.GetNotificationAddresses();
+        SeedDatabase(organizations, notificationAddresses);
+
+        var orgNumberLookup = new List<string>() { "999999999" };
+
+        var expectedOrg1 = organizations
+            .Find(p => p.RegistryOrganizationNumber == "999999999");
+
+        // Act
+        var result = await _repository.GetOrganizationsAsync(orgNumberLookup, CancellationToken.None);
+
+        // Assert
+        Assert.NotEmpty(result);
+        var matchedOrg1 = result.FirstOrDefault();
+        Assert.IsType<Organization>(matchedOrg1);
+        Assert.Empty(matchedOrg1.NotificationAddresses);
+        Assert.Equal(matchedOrg1.OrganizationNumber, expectedOrg1.RegistryOrganizationNumber);
+    }
+
+    [Fact]
     public async Task GetOrganizations_WhenNoneFound_ReturnsEmptyList()
     {
         // Arrange
@@ -317,7 +340,31 @@ public class OrganizationNotificationAddressRepositoryTests : IDisposable
         Assert.NotEqual(existingAddress.Domain, updatedAddress.Domain);
         Assert.NotEqual(existingAddress.RegistryID, updatedAddress.RegistryID);
     }
-    
+
+    [Fact]
+    public async Task UpdateNotificationAddressAsync_WhenFoundAndChangingAddressType_ReturnsUpdatedNotificationAddress()
+    {
+        // Arrange
+        var (organizations, notificationAddresses) = OrganizationNotificationAddressTestData.GetNotificationAddresses();
+        SeedDatabase(organizations, notificationAddresses);
+
+        var notificationAddressId = 1;
+
+        var existingAddress = notificationAddresses
+            .Find(p => p.NotificationAddressID == 1);
+
+        // Act
+        var updatedAddress = await _repository.UpdateNotificationAddressAsync(new NotificationAddress { AddressType = AddressType.SMS, FullAddress = "+4712345678", Address = "12345678", Domain = "+47", NotificationAddressID = notificationAddressId }, "2");
+
+        // Assert
+        Assert.IsType<NotificationAddress>(updatedAddress);
+        Assert.NotNull(updatedAddress.RegistryID);
+        Assert.NotEqual(existingAddress.Address, updatedAddress.Address);
+        Assert.NotEqual(existingAddress.Domain, updatedAddress.Domain);
+        Assert.NotEqual(existingAddress.RegistryID, updatedAddress.RegistryID);
+        Assert.NotEqual(existingAddress.AddressType, updatedAddress.AddressType);
+    }
+
     [Fact]
     public async Task DeleteNotificationAddressAsync_WhenFound_ReturnsSoftDeletedNotificationAddress()
     {

--- a/test/Altinn.Profile.Tests/Testdata/OrganizationNotificationAddressTestData.cs
+++ b/test/Altinn.Profile.Tests/Testdata/OrganizationNotificationAddressTestData.cs
@@ -27,6 +27,11 @@ public static class OrganizationNotificationAddressTestData
             {
                 RegistryOrganizationNumber = "987654321",
                 RegistryOrganizationId = 2
+            },
+            new()
+            {
+                RegistryOrganizationNumber = "999999999",
+                RegistryOrganizationId = 3
             }
         };
         var notificationAddresses = new List<NotificationAddressDE>()
@@ -100,6 +105,20 @@ public static class OrganizationNotificationAddressTestData
                 RegistryID = "27ae0c8bea1f4f02a974c10429c32758",
                 RegistryOrganizationId = 2,
                 NotificationAddressID = 5
+            },
+            new()
+            {
+                AddressType = AddressType.SMS,
+                Address = "98765434",
+                Domain = "+47",
+                FullAddress = "+4798765434",
+                IsSoftDeleted = true,
+                HasRegistryAccepted = true,
+                UpdateSource = UpdateSource.KoFuVi,
+                RegistryUpdatedDateTime = DateTime.Now.AddDays(-25),
+                RegistryID = "27ae0c8bea1f4f02a974c10429c32759",
+                RegistryOrganizationId = 3,
+                NotificationAddressID = 6
             },
         };
             


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
* [Testing have found](https://github.com/Altinn/altinn-profile/issues/177#issuecomment-2885820440) that we should filter out soft deleted addresses for GET, PUT and DELETE
* When changing address type in PUT, the new address type was not stored

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
	- Ensured notification addresses for organizations are never null by default, providing an empty list instead.
	- Updated filtering to show only active (non-deleted) notification addresses for organizations.
	- Fixed issue where the address type was not updated when modifying a notification address.

- **Style**
	- Standardized property naming from NotificationAddressID to NotificationAddressId for consistency in responses and documentation.

- **Tests**
	- Added tests verifying handling of soft-deleted notification addresses and updating address types.
	- Extended test data with new soft-deleted notification address entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->