### PR TITLE
Add same validation as UI

### DIFF
--- a/src/Altinn.Profile/Altinn.Profile.csproj
+++ b/src/Altinn.Profile/Altinn.Profile.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.4.0" />
     <PackageReference Include="JWTCookieAuthentication" Version="4.0.4" />
     <PackageReference Include="Altinn.Common.PEP" Version="4.1.2" />
+    <PackageReference Include="libphonenumber-csharp" Version="9.0.5" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />

--- a/src/Altinn.Profile/Models/NotificationAddressModel.cs
+++ b/src/Altinn.Profile/Models/NotificationAddressModel.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using Altinn.Profile.Validators;
+using PhoneNumbers;
 
 namespace Altinn.Profile.Models
 {
@@ -30,15 +31,52 @@ namespace Altinn.Profile.Models
         /// <inheritdoc/>
         public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {
-            if (Email == null && Phone == null)
+            if (string.IsNullOrWhiteSpace(Email) && string.IsNullOrWhiteSpace(Phone))
             {
-               yield return new ValidationResult("Either Phone or Email must be specified.", [nameof(Phone), nameof(Email)]);
+                yield return new ValidationResult("Either Phone or Email must be specified.", [nameof(Phone), nameof(Email)]);
             }
 
-            if (Email != null && Phone != null)
+            if (!string.IsNullOrWhiteSpace(Email) && !string.IsNullOrWhiteSpace(Phone))
             {
                 yield return new ValidationResult("Cannot provide both Phone and Email for the same notification address.", [nameof(Phone), nameof(Email)]);
             }
+
+            if (string.IsNullOrWhiteSpace(Email) && !IsValidPhoneNumber())
+            {
+                yield return new ValidationResult("Phone number is not valid.", [nameof(Phone)]);
+            }
+        }
+
+        private bool IsValidPhoneNumber()
+        {
+            var phoneNumberUtil = PhoneNumberUtil.GetInstance();
+           
+            bool isValidNumber;
+
+            try
+            {
+                PhoneNumber phoneNumber = phoneNumberUtil.Parse(CountryCode + Phone, "NO");
+                isValidNumber = phoneNumberUtil.IsValidNumber(phoneNumber);
+            }
+            catch (NumberParseException)
+            {
+                isValidNumber = false;
+            }
+
+            if (CountryCode == "+47")
+            {
+                if (Phone.Length != 8)
+                {
+                    isValidNumber = false;
+                }
+
+                if (!Phone.StartsWith('9') && !Phone.StartsWith('4'))
+                {
+                    isValidNumber = false;
+                }
+            }
+
+            return isValidNumber;
         }
     }
 }

--- a/src/Altinn.Profile/Validators/CustomRegexForNotificationAddressesAttribute.cs
+++ b/src/Altinn.Profile/Validators/CustomRegexForNotificationAddressesAttribute.cs
@@ -10,7 +10,9 @@ namespace Altinn.Profile.Validators
     public class CustomRegexForNotificationAddressesAttribute : RegularExpressionAttribute
     {
         private const string _emailRegexPattern = @"^((([a-zA-Z0-9!#$%&amp;'*+\-=?\^_`{}~])+(\.([a-zA-Z0-9!#$%&amp;'*+\-=?\^_`{}~])+)*)@(((([a-zA-Z0-9æøåÆØÅ]([a-zA-Z0-9\-æøåÆØÅ]{0,61})[a-zA-Z0-9æøåÆØÅ]\.)|[a-zA-Z0-9æøåÆØÅ]\.){1,9})([a-zA-Z]{2,14})))$";
+        private const string _updatedEmailRegexPattern = @"((&quot;[^&quot;]+&quot;)|(([a-zA-Z0-9!#$%&amp;'*+\-=?\^_`{|}~])+(\.([a-zA-Z0-9!#$%&amp;'*+\-=?\^_`{|}~])+)*))@((((([a-zA-Z0-9æøåÆØÅ]([a-zA-Z0-9\-æøåÆØÅ]{0,61})[a-zA-Z0-9æøåÆØÅ]\.)|[a-zA-Z0-9æøåÆØÅ]\.){1,9})([a-zA-Z]{2,14}))|((\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})))";
         private const string _phoneRegexPattern = @"(^[0-9]+$)";
+        private const string _updatedPhoneRegexPattern = @"(([0-9]{5})|([0-9]{8})|((00[0-9]{2})[0-9]+)|((\+[0-9]{2})[0-9]+))$";
         private const string _countryCodeRegexPattern = @"(^\+([0-9]{1,3}))";
 
         /// <summary>
@@ -26,8 +28,8 @@ namespace Altinn.Profile.Validators
         {
             return inputType switch
             {
-                "Email" => _emailRegexPattern,
-                "Phone" => _phoneRegexPattern,
+                "Email" => _updatedEmailRegexPattern,
+                "Phone" => _updatedPhoneRegexPattern,
                 "CountryCode" => _countryCodeRegexPattern,
                 _ => string.Empty
             };

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/OrganizationsControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/OrganizationsControllerTests.cs
@@ -304,7 +304,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
                 .ReturnsAsync("123456789");
             HttpClient client = _webApplicationFactorySetup.GetTestServerClient(pdpMock.Object);
 
-            var input = new NotificationAddressModel { Phone = "912345678", CountryCode = "+47" };
+            var input = new NotificationAddressModel { Phone = "91234567", CountryCode = "+47" };
             HttpRequestMessage httpRequestMessage = new(HttpMethod.Post, $"/profile/api/v1/organizations/{orgNo}/notificationaddresses/mandatory")
             {
                 Content = new StringContent(JsonSerializer.Serialize(input, _serializerOptions), System.Text.Encoding.UTF8, "application/json")

--- a/test/Altinn.Profile.Tests/Profile/Validators/CustomRegexForNotificationAddressesTests.cs
+++ b/test/Altinn.Profile.Tests/Profile/Validators/CustomRegexForNotificationAddressesTests.cs
@@ -7,7 +7,7 @@ namespace Altinn.Profile.Tests.Profile.Validators
     {
         [Theory]
         [InlineData("98765432")]
-        [InlineData("9876543200")]
+        [InlineData("98765")]
         [InlineData("")]
         [InlineData(null)]
         public void CustomRegex_WhenPhoneHasAllowedValues_ReturnsValidResult(string input)
@@ -20,8 +20,9 @@ namespace Altinn.Profile.Tests.Profile.Validators
         }
 
         [Theory]
+        [InlineData(" ")]
         [InlineData("error")]
-        [InlineData("+47987654321")]
+        [InlineData("+47")]
         public void CustomRegex_WhenPhoneHasInvalidValues_IsInvalid(string input)
         {
             var attribute = new CustomRegexForNotificationAddressesAttribute("Phone");
@@ -75,6 +76,7 @@ namespace Altinn.Profile.Tests.Profile.Validators
         }
 
         [Theory]
+        [InlineData(" ")]
         [InlineData("98765432")]
         [InlineData("test-test@@test.com")]
         [InlineData("test@test..com")]

--- a/test/Altinn.Profile.Tests/Profile/Validators/NotificationAddressModelTests.cs
+++ b/test/Altinn.Profile.Tests/Profile/Validators/NotificationAddressModelTests.cs
@@ -29,6 +29,17 @@ namespace Altinn.Profile.Tests.Profile.Validators
         }
 
         [Fact]
+        public void NotificationAddressModel_WhenEmailAndPhoneIsEmptyOrWhiteSpace_ReturnsValidationResults()
+        {
+            var model = new NotificationAddressModel { Email = string.Empty, Phone = " " };
+            var validationContext = new ValidationContext(model);
+
+            var validationResult = model.Validate(validationContext);
+
+            Assert.NotEmpty(validationResult);
+        }
+
+        [Fact]
         public void NotificationAddressModel_WhenOnlyValidationEmailIsGiven_ReturnsNoValidationResults()
         {
             var model = new NotificationAddressModel { Email = "test@test.com" };
@@ -42,7 +53,7 @@ namespace Altinn.Profile.Tests.Profile.Validators
         [Fact]
         public void NotificationAddressModel_WhenOnlyValidPhoneIsGiven_ReturnsNoValidationResults()
         {
-            var model = new NotificationAddressModel { Phone = "98765432" };
+            var model = new NotificationAddressModel { Phone = "98765432", Email = string.Empty };
             var validationContext = new ValidationContext(model);
 
             var validationResult = model.Validate(validationContext);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
In order to stop users from creating unusable notification addresses we have added more validation to the API. Now it is matching the validation from the GUI in altinn2. 

## Related Issue(s)
- #380 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
