### PR TITLE
Change back to the regex we know was used in backend for kof addresses

### DIFF
--- a/src/Altinn.Profile/Models/NotificationAddressModel.cs
+++ b/src/Altinn.Profile/Models/NotificationAddressModel.cs
@@ -54,11 +54,6 @@ namespace Altinn.Profile.Models
         /// </summary>
         private bool IsValidPhoneNumber()
         {
-            if (string.IsNullOrWhiteSpace(Phone))
-            {
-                return false;
-            }
-
             var phoneNumberUtil = PhoneNumberUtil.GetInstance();
            
             bool isValidNumber;

--- a/src/Altinn.Profile/Models/NotificationAddressModel.cs
+++ b/src/Altinn.Profile/Models/NotificationAddressModel.cs
@@ -35,15 +35,17 @@ namespace Altinn.Profile.Models
             {
                 yield return new ValidationResult("Either Phone or Email must be specified.", [nameof(Phone), nameof(Email)]);
             }
-
-            if (!string.IsNullOrWhiteSpace(Email) && !string.IsNullOrWhiteSpace(Phone))
+            else
             {
-                yield return new ValidationResult("Cannot provide both Phone and Email for the same notification address.", [nameof(Phone), nameof(Email)]);
-            }
+                if (!string.IsNullOrWhiteSpace(Email) && !string.IsNullOrWhiteSpace(Phone))
+                {
+                    yield return new ValidationResult("Cannot provide both Phone and Email for the same notification address.", [nameof(Phone), nameof(Email)]);
+                }
 
-            if (Email == null && !IsValidPhoneNumber())
-            {
-                yield return new ValidationResult("Phone number is not valid.", [nameof(Phone)]);
+                if (string.IsNullOrWhiteSpace(Email) && !IsValidPhoneNumber())
+                {
+                    yield return new ValidationResult("Phone number is not valid.", [nameof(Phone)]);
+                }
             }
         }
 

--- a/src/Altinn.Profile/Models/NotificationAddressModel.cs
+++ b/src/Altinn.Profile/Models/NotificationAddressModel.cs
@@ -54,6 +54,11 @@ namespace Altinn.Profile.Models
         /// </summary>
         private bool IsValidPhoneNumber()
         {
+            if (string.IsNullOrWhiteSpace(Phone))
+            {
+                return false;
+            }
+
             var phoneNumberUtil = PhoneNumberUtil.GetInstance();
            
             bool isValidNumber;

--- a/src/Altinn.Profile/Models/NotificationAddressModel.cs
+++ b/src/Altinn.Profile/Models/NotificationAddressModel.cs
@@ -41,7 +41,7 @@ namespace Altinn.Profile.Models
                 yield return new ValidationResult("Cannot provide both Phone and Email for the same notification address.", [nameof(Phone), nameof(Email)]);
             }
 
-            if (string.IsNullOrWhiteSpace(Email) && !IsValidPhoneNumber())
+            if (Email == null && !IsValidPhoneNumber())
             {
                 yield return new ValidationResult("Phone number is not valid.", [nameof(Phone)]);
             }

--- a/src/Altinn.Profile/Validators/CustomRegexForNotificationAddressesAttribute.cs
+++ b/src/Altinn.Profile/Validators/CustomRegexForNotificationAddressesAttribute.cs
@@ -9,7 +9,7 @@ namespace Altinn.Profile.Validators
     [AttributeUsage(AttributeTargets.Property)]
     public class CustomRegexForNotificationAddressesAttribute : RegularExpressionAttribute
     {
-        private const string _emailRegexPattern = @"^((([a-zA-Z0-9!#$%&amp;'*+\-=?\^_`{}~])+(\.([a-zA-Z0-9!#$%&amp;'*+\-=?\^_`{}~])+)*)@(((([a-zA-Z0-9æøåÆØÅ]([a-zA-Z0-9\-æøåÆØÅ]{0,61})[a-zA-Z0-9æøåÆØÅ]\.)|[a-zA-Z0-9æøåÆØÅ]\.){1,9})([a-zA-Z]{2,14})))$";
+        private const string _emailRegexPattern = @"^((([a-zA-Z0-9!#$%&'*+\-=?\^_`{}~])+(\.([a-zA-Z0-9!#$%&'*+\-=?\^_`{}~])+)*)@(((([a-zA-Z0-9æøåÆØÅ]([a-zA-Z0-9\-æøåÆØÅ]{0,61})[a-zA-Z0-9æøåÆØÅ]\.)|[a-zA-Z0-9æøåÆØÅ]\.){1,9})([a-zA-Z]{2,14})))$";
         private const string _phoneRegexPattern = @"(^[0-9]+$)";
         private const string _countryCodeRegexPattern = @"(^\+([0-9]{1,3}))";
 

--- a/src/Altinn.Profile/Validators/CustomRegexForNotificationAddressesAttribute.cs
+++ b/src/Altinn.Profile/Validators/CustomRegexForNotificationAddressesAttribute.cs
@@ -9,8 +9,8 @@ namespace Altinn.Profile.Validators
     [AttributeUsage(AttributeTargets.Property)]
     public class CustomRegexForNotificationAddressesAttribute : RegularExpressionAttribute
     {
-        private const string _emailRegexPattern = @"((&quot;[^&quot;]+&quot;)|(([a-zA-Z0-9!#$%&amp;'*+\-=?\^_`{|}~])+(\.([a-zA-Z0-9!#$%&amp;'*+\-=?\^_`{|}~])+)*))@((((([a-zA-Z0-9æøåÆØÅ]([a-zA-Z0-9\-æøåÆØÅ]{0,61})[a-zA-Z0-9æøåÆØÅ]\.)|[a-zA-Z0-9æøåÆØÅ]\.){1,9})([a-zA-Z]{2,14}))|((\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})))";
-        private const string _phoneRegexPattern = @"(([0-9]{5})|([0-9]{8})|((00[0-9]{2})[0-9]+)|((\+[0-9]{2})[0-9]+))$";
+        private const string _emailRegexPattern = @"^((([a-zA-Z0-9!#$%&amp;'*+\-=?\^_`{}~])+(\.([a-zA-Z0-9!#$%&amp;'*+\-=?\^_`{}~])+)*)@(((([a-zA-Z0-9æøåÆØÅ]([a-zA-Z0-9\-æøåÆØÅ]{0,61})[a-zA-Z0-9æøåÆØÅ]\.)|[a-zA-Z0-9æøåÆØÅ]\.){1,9})([a-zA-Z]{2,14})))$";
+        private const string _phoneRegexPattern = @"(^[0-9]+$)";
         private const string _countryCodeRegexPattern = @"(^\+([0-9]{1,3}))";
 
         /// <summary>

--- a/test/Altinn.Profile.Tests/Profile/Validators/NotificationAddressModelTests.cs
+++ b/test/Altinn.Profile.Tests/Profile/Validators/NotificationAddressModelTests.cs
@@ -90,6 +90,23 @@ namespace Altinn.Profile.Tests.Profile.Validators
             Assert.NotEmpty(validationResult);
         }
 
+        [Theory]
+        [InlineData("+46", "798765432")] // Valid Swedish phone number
+        [InlineData("+45", "81987654")] // Valid Danish phone number
+        [InlineData("+49", "3098765432")] // Valid German phone number
+        [InlineData("+48", "229876543")] // Valid Polish phone number
+        [InlineData("+44", "07198765432")] // Valid UK phone number
+        [InlineData("+1", "2125554567")] // Valid US phone number
+        public void NotificationAddressModel_WhenValidInternationalNumber_ReturnsNoValidationResults(string countryCode, string phone)
+        {
+            var model = new NotificationAddressModel { CountryCode = countryCode, Phone = phone };
+            var validationContext = new ValidationContext(model);
+
+            var validationResult = model.Validate(validationContext);
+
+            Assert.Empty(validationResult);
+        }
+
         [Fact]
         public void NotificationAddressModel_WhenValidInternationalPhoneIsGiven_ReturnsNoValidationResults()
         {

--- a/test/Altinn.Profile.Tests/Profile/Validators/NotificationAddressModelTests.cs
+++ b/test/Altinn.Profile.Tests/Profile/Validators/NotificationAddressModelTests.cs
@@ -117,5 +117,16 @@ namespace Altinn.Profile.Tests.Profile.Validators
 
             Assert.Empty(validationResult);
         }
+
+        [Fact]
+        public void NotificationAddressModel_WhenOnlyCountryCodeIsGiven_ReturnsValidationResults()
+        {
+            var model = new NotificationAddressModel { CountryCode = "+47" };
+            var validationContext = new ValidationContext(model);
+
+            var validationResult = model.Validate(validationContext);
+
+            Assert.NotEmpty(validationResult);
+        }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
There is found that the regex did not behave as expected. To be on the safe side, we change back to the old regex we know was used on the backend. 

## Related Issue(s)
- #[259 (team-core-private)](https://github.com/Altinn/team-core-private/issues/259)
https://github.com/Altinn/altinn-profile/issues/398
https://github.com/Altinn/altinn-profile/issues/399

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved validation for email and phone number inputs with stricter formatting rules.
	- Enhanced support for international phone numbers, ensuring valid formats are accepted without errors.
	- Added checks to prevent empty or incomplete phone number entries from passing validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->