### PR TITLE
Simplify the conditional space of the validation method

### DIFF
--- a/src/Altinn.Profile/Models/NotificationAddressModel.cs
+++ b/src/Altinn.Profile/Models/NotificationAddressModel.cs
@@ -31,31 +31,36 @@ namespace Altinn.Profile.Models
         /// <inheritdoc/>
         public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {
-            if (string.IsNullOrWhiteSpace(Email) && string.IsNullOrWhiteSpace(Phone))
+            bool hasEmailValue = !string.IsNullOrWhiteSpace(Email);
+            bool hasPhoneValue = !string.IsNullOrWhiteSpace(Phone);
+            bool hasCountryCodeValue = !string.IsNullOrWhiteSpace(CountryCode);
+
+            if (!hasEmailValue && !hasPhoneValue)
             {
                 yield return new ValidationResult("Either Phone or Email must be specified.", [nameof(Phone), nameof(Email)]);
             }
-            else
+            else if (hasEmailValue && hasPhoneValue)
             {
-                if (!string.IsNullOrWhiteSpace(Email) && !string.IsNullOrWhiteSpace(Phone))
-                {
-                    yield return new ValidationResult("Cannot provide both Phone and Email for the same notification address.", [nameof(Phone), nameof(Email)]);
-                }
-
-                if (!string.IsNullOrWhiteSpace(Phone) && string.IsNullOrWhiteSpace(CountryCode))
+                yield return new ValidationResult("Cannot provide both Phone and Email for the same notification address.", [nameof(Phone), nameof(Email)]);
+            }
+            else if (hasPhoneValue)
+            {
+                if (!hasCountryCodeValue)
                 {
                     yield return new ValidationResult("CountryCode is required with Phone.", [nameof(CountryCode)]);
                 }
 
-                if (!string.IsNullOrWhiteSpace(Email) && !string.IsNullOrWhiteSpace(CountryCode))
-                {
-                    yield return new ValidationResult("CountryCode cannot be provided with Email.", [nameof(CountryCode)]);
-                }
-
-                if (string.IsNullOrWhiteSpace(Email) && !IsValidPhoneNumber())
+                if (!IsValidPhoneNumber())
                 {
                     yield return new ValidationResult("Phone number is not valid.", [nameof(Phone)]);
                 }
+            }
+            else
+            {
+                if (hasCountryCodeValue)
+                {
+                    yield return new ValidationResult("CountryCode cannot be provided with Email.", [nameof(CountryCode)]);
+                } 
             }
         }
 

--- a/src/Altinn.Profile/Models/NotificationAddressModel.cs
+++ b/src/Altinn.Profile/Models/NotificationAddressModel.cs
@@ -49,8 +49,7 @@ namespace Altinn.Profile.Models
                 {
                     yield return new ValidationResult("CountryCode is required with Phone.", [nameof(CountryCode)]);
                 }
-
-                if (!IsValidPhoneNumber())
+                else if (!IsValidPhoneNumber())
                 {
                     yield return new ValidationResult("Phone number is not valid.", [nameof(Phone)]);
                 }


### PR DESCRIPTION
I wanted to try and make the logical conditions easier to understand and control. The automated tests are still passing, so the validation rules should work as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the validation logic for notification addresses to provide clearer and more consistent error handling when entering email, phone, and country code information. No changes to existing validation rules or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->