### PR TITLE
Feature/297 main unit lookup

### DIFF
--- a/src/Altinn.Profile.Core/Integrations/IOrganizationNotificationAddressRepository.cs
+++ b/src/Altinn.Profile.Core/Integrations/IOrganizationNotificationAddressRepository.cs
@@ -8,6 +8,12 @@ namespace Altinn.Profile.Core.Integrations;
 public interface IOrganizationNotificationAddressRepository
 {
     /// <summary>
+    /// Fetches a single organization's notification addresses
+    /// </summary>
+    /// <returns>A <see cref="Task{TResult}"/> with an organization as value.</returns>
+    Task<Organization?> GetOrganizationAsync(string organizationNumbers, CancellationToken cancellationToken);
+
+    /// <summary>
     /// Fetches organizations notification addresses
     /// </summary>
     /// <returns>A <see cref="Task{TResult}"/> with a collection of organizations as value.</returns>

--- a/src/Altinn.Profile.Core/Integrations/IOrganizationNotificationAddressRepository.cs
+++ b/src/Altinn.Profile.Core/Integrations/IOrganizationNotificationAddressRepository.cs
@@ -11,7 +11,7 @@ public interface IOrganizationNotificationAddressRepository
     /// Fetches a single organization's notification addresses
     /// </summary>
     /// <returns>A <see cref="Task{TResult}"/> with an organization as value.</returns>
-    Task<Organization?> GetOrganizationAsync(string organizationNumbers, CancellationToken cancellationToken);
+    Task<Organization?> GetOrganizationAsync(string organizationNumber, CancellationToken cancellationToken);
 
     /// <summary>
     /// Fetches organizations notification addresses

--- a/src/Altinn.Profile.Core/Integrations/IRegisterClient.cs
+++ b/src/Altinn.Profile.Core/Integrations/IRegisterClient.cs
@@ -1,4 +1,4 @@
-﻿namespace Altinn.Profile.Integrations.Register
+﻿namespace Altinn.Profile.Core.Integrations
 {
     /// <summary>
     /// A http client for interactions with altinn-register

--- a/src/Altinn.Profile.Core/Integrations/IRegisterClient.cs
+++ b/src/Altinn.Profile.Core/Integrations/IRegisterClient.cs
@@ -9,7 +9,8 @@
         /// Optimistically get the main unit for an organization based on its organization number.
         /// </summary>
         /// <param name="orgNumber">Org number for the current organization</param>
+        /// <param name="cancellationToken">Cancel the current request</param>
         /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
-        Task<string> GetMainUnit(string orgNumber, CancellationToken cancellationToken);
+        Task<string?> GetMainUnit(string orgNumber, CancellationToken cancellationToken);
     }
 }

--- a/src/Altinn.Profile.Core/Integrations/IRegisterClient.cs
+++ b/src/Altinn.Profile.Core/Integrations/IRegisterClient.cs
@@ -8,7 +8,7 @@
         /// <summary>
         /// Optimistically get the main unit for an organization based on its organization number.
         /// </summary>
-        /// <param name="orgNumber">Org number for the current organization</param>
+        /// <param name="orgNumber">Org number for the organization to look up a potential main unit for.</param>
         /// <param name="cancellationToken">Cancel the current request</param>
         /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
         Task<string?> GetMainUnit(string orgNumber, CancellationToken cancellationToken);

--- a/src/Altinn.Profile.Core/Integrations/IRegisterClient.cs
+++ b/src/Altinn.Profile.Core/Integrations/IRegisterClient.cs
@@ -1,0 +1,15 @@
+﻿namespace Altinn.Profile.Integrations.Register
+{
+    /// <summary>
+    /// A http client for interactions with altinn-register
+    /// </summary>
+    public interface IRegisterClient
+    {
+        /// <summary>
+        /// Optimistically get the main unit for an organization based on its organization number.
+        /// </summary>
+        /// <param name="orgNumber">Org number for the current organization</param>
+        /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
+        Task<string> GetMainUnit(string orgNumber, CancellationToken cancellationToken);
+    }
+}

--- a/src/Altinn.Profile.Core/OrganizationNotificationAddresses/IOrganizationNotificationAddressesService.cs
+++ b/src/Altinn.Profile.Core/OrganizationNotificationAddresses/IOrganizationNotificationAddressesService.cs
@@ -26,8 +26,9 @@ public interface IOrganizationNotificationAddressesService
     /// </summary>
     /// <param name="organizationNumbers">A list of organization numbers to lookup contact points for</param>
     /// <param name="cancellationToken">To cancel the request before it is finished</param>
+    /// <param name="useAddressFromMainUnitIfEmpty">Indicates whether to use the address from the main unit if no addresses are registered for the organization</param>
     /// <returns>The notification addresses or a boolean if failure.</returns>
-    Task<IEnumerable<Organization>> GetOrganizationNotificationAddresses(List<string> organizationNumbers, CancellationToken cancellationToken);
+    Task<IEnumerable<Organization>> GetOrganizationNotificationAddresses(List<string> organizationNumbers, CancellationToken cancellationToken, bool useAddressFromMainUnitIfEmpty = false);
 
     /// <summary>
     /// Method for deleting a notification addresses for an organization

--- a/src/Altinn.Profile.Core/OrganizationNotificationAddresses/Organization.cs
+++ b/src/Altinn.Profile.Core/OrganizationNotificationAddresses/Organization.cs
@@ -11,8 +11,18 @@
         public required string OrganizationNumber { get; set; }
 
         /// <summary>
+        /// OrganizationNumber of the organization where the address was found
+        /// </summary>
+        public string? AddressOrigin { get; set; }
+
+        /// <summary>
         /// A collection of notification addresses associated with this organization
         /// </summary>
         public List<NotificationAddress>? NotificationAddresses { get; set; }
+
+        /// <summary>
+        /// OrganizationNumber of the organization where the address was found
+        /// </summary>
+        public string GetAddressOrigin() => AddressOrigin ?? OrganizationNumber;
     }
 }

--- a/src/Altinn.Profile.Core/OrganizationNotificationAddresses/Organization.cs
+++ b/src/Altinn.Profile.Core/OrganizationNotificationAddresses/Organization.cs
@@ -11,18 +11,19 @@
         public required string OrganizationNumber { get; set; }
 
         /// <summary>
-        /// OrganizationNumber of the organization where the address was found
-        /// </summary>
-        public string? AddressOrigin { get; set; }
-
-        /// <summary>
         /// A collection of notification addresses associated with this organization
         /// </summary>
         public List<NotificationAddress>? NotificationAddresses { get; set; }
 
+        private string _addressOrigin = string.Empty;
+
         /// <summary>
         /// OrganizationNumber of the organization where the address was found
         /// </summary>
-        public string GetAddressOrigin() => AddressOrigin ?? OrganizationNumber;
+        public string AddressOrigin
+        {
+            get => string.IsNullOrEmpty(_addressOrigin) ? OrganizationNumber : _addressOrigin;
+            init => _addressOrigin = value;
+        }
     }
 }

--- a/src/Altinn.Profile.Core/OrganizationNotificationAddresses/OrganizationNotificationAddressesService.cs
+++ b/src/Altinn.Profile.Core/OrganizationNotificationAddresses/OrganizationNotificationAddressesService.cs
@@ -122,7 +122,7 @@ namespace Altinn.Profile.Core.OrganizationNotificationAddresses
 
                 if (mainUnit == null)
                 {
-                    break;  // No main unit found, skip to next organization
+                    continue;  // No main unit found, skip to next organization
                 }
 
                 var mainUnitResult = await _orgRepository.GetOrganizationAsync(mainUnit, cancellationToken);

--- a/src/Altinn.Profile.Core/OrganizationNotificationAddresses/OrganizationNotificationAddressesService.cs
+++ b/src/Altinn.Profile.Core/OrganizationNotificationAddresses/OrganizationNotificationAddressesService.cs
@@ -17,8 +17,7 @@ namespace Altinn.Profile.Core.OrganizationNotificationAddresses
         /// <inheritdoc/>
         public async Task<(NotificationAddress Address, bool IsNew)> CreateNotificationAddress(string organizationNumber, NotificationAddress notificationAddress, CancellationToken cancellationToken)
         {
-            var orgs = await _orgRepository.GetOrganizationsAsync([organizationNumber], cancellationToken);
-            var org = orgs.FirstOrDefault();
+            var org = await _orgRepository.GetOrganizationAsync(organizationNumber, cancellationToken);
             org ??= new Organization { OrganizationNumber = organizationNumber, NotificationAddresses = [] };
 
             var existingAddress = org.NotificationAddresses?.FirstOrDefault(x => x.FullAddress == notificationAddress.FullAddress && x.AddressType == notificationAddress.AddressType);
@@ -42,8 +41,7 @@ namespace Altinn.Profile.Core.OrganizationNotificationAddresses
         /// <param name="cancellationToken">To cancel the request before it is finished</param>
         public async Task<(NotificationAddress? Address, bool IsDuplicate)> UpdateNotificationAddress(string organizationNumber, NotificationAddress notificationAddress, CancellationToken cancellationToken)
         {
-            var orgs = await _orgRepository.GetOrganizationsAsync([organizationNumber], cancellationToken);
-            var org = orgs.FirstOrDefault();
+            var org = await _orgRepository.GetOrganizationAsync(organizationNumber, cancellationToken);
 
             if (org == null)
             {
@@ -77,8 +75,7 @@ namespace Altinn.Profile.Core.OrganizationNotificationAddresses
         /// <param name="cancellationToken">To cancel the request before it is finished</param>
         public async Task<NotificationAddress?> DeleteNotificationAddress(string organizationNumber, int notificationAddressId, CancellationToken cancellationToken)
         {
-            var orgs = await _orgRepository.GetOrganizationsAsync([organizationNumber], cancellationToken);
-            var org = orgs.FirstOrDefault();
+            var org = await _orgRepository.GetOrganizationAsync(organizationNumber, cancellationToken);
 
             if (org == null)
             {
@@ -128,21 +125,17 @@ namespace Altinn.Profile.Core.OrganizationNotificationAddresses
                     break;  // No main unit found, skip to next organization
                 }
 
-                var mainUnitResult = await _orgRepository.GetOrganizationsAsync([mainUnit], cancellationToken);
-                if (mainUnitResult.Any())
+                var mainUnitResult = await _orgRepository.GetOrganizationAsync(mainUnit, cancellationToken);
+                if (mainUnitResult != null)
                 {
-                    // Should in theory only return one organization, but handling as a list for consistency
-                    foreach (var item in mainUnitResult)
+                    var orgWithMainUnitAddress = new Organization
                     {
-                        var orgWithMainUnitAddress = new Organization
-                        {
-                            OrganizationNumber = organization,
-                            AddressOrigin = item.OrganizationNumber,
-                            NotificationAddresses = item.NotificationAddresses
-                        };
+                        OrganizationNumber = organization,
+                        AddressOrigin = mainUnitResult.OrganizationNumber,
+                        NotificationAddresses = mainUnitResult.NotificationAddresses
+                    };
 
-                        organizationList.Add(orgWithMainUnitAddress);
-                    }
+                    organizationList.Add(orgWithMainUnitAddress);
                 }
             }
 

--- a/src/Altinn.Profile.Integrations/Altinn.Profile.Integrations.csproj
+++ b/src/Altinn.Profile.Integrations/Altinn.Profile.Integrations.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Altinn.Common.AccessTokenClient" Version="3.0.14" />
     <PackageReference Include="AutoMapper" Version="14.0.0" />
     <PackageReference Include="EFCore.NamingConventions" Version="9.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.5">

--- a/src/Altinn.Profile.Integrations/Register/LookupMainUnitRequest.cs
+++ b/src/Altinn.Profile.Integrations/Register/LookupMainUnitRequest.cs
@@ -19,11 +19,6 @@ namespace Altinn.Profile.Integrations.Register
         /// <param name="orgNumber">Organization Number of the organization to lookup parent units for</param>
         public static LookupMainUnitRequest Create(string orgNumber)
         {
-            if (string.IsNullOrWhiteSpace(orgNumber))
-            {
-                throw new ArgumentException("Organization number cannot be null or empty.", nameof(orgNumber));
-            }
-
             var request = new LookupMainUnitRequest
             {
                 Data = $"urn:altinn:organization:identifier-no:{orgNumber}"

--- a/src/Altinn.Profile.Integrations/Register/LookupMainUnitRequest.cs
+++ b/src/Altinn.Profile.Integrations/Register/LookupMainUnitRequest.cs
@@ -5,12 +5,31 @@ namespace Altinn.Profile.Integrations.Register
     /// <summary>
     /// Request model for the lookup resource for main units
     /// </summary>
-    public class LookupMainUnitRequest(string orgNumber)
+    public class LookupMainUnitRequest
     {
         /// <summary>
         /// Data containing the urn of the organization with either orgNumber, partyId or PartyUuid.
         /// </summary>
         [JsonPropertyName("data")]
-        public string Data { get; init; } = $"urn:altinn:organization:identifier-no:{orgNumber}";
+        public string Data { get; set; }
+
+        /// <summary>
+        /// Set the ORgNumber in the Data property of the request.
+        /// </summary>
+        /// <param name="orgNumber">Organization Number of the organization to lookup parent units for</param>
+        public static LookupMainUnitRequest Create(string orgNumber)
+        {
+            if (string.IsNullOrWhiteSpace(orgNumber))
+            {
+                throw new ArgumentException("Organization number cannot be null or empty.", nameof(orgNumber));
+            }
+
+            var request = new LookupMainUnitRequest
+            {
+                Data = $"urn:altinn:organization:identifier-no:{orgNumber}"
+            };
+
+            return request;
+        }
     }
 }

--- a/src/Altinn.Profile.Integrations/Register/LookupMainUnitRequest.cs
+++ b/src/Altinn.Profile.Integrations/Register/LookupMainUnitRequest.cs
@@ -5,26 +5,16 @@ namespace Altinn.Profile.Integrations.Register
     /// <summary>
     /// Request model for the lookup resource for main units
     /// </summary>
-    public class LookupMainUnitRequest
+    /// <remarks>
+    /// Initializes a new instance of the <see cref="LookupMainUnitRequest"/> class.
+    /// </remarks>
+    /// <param name="orgNumber">Organization Number of the organization to lookup parent units for</param>
+    public class LookupMainUnitRequest(string orgNumber)
     {
         /// <summary>
         /// Data containing the urn of the organization with either orgNumber, partyId or PartyUuid.
         /// </summary>
         [JsonPropertyName("data")]
-        public string? Data { get; init; }
-
-        /// <summary>
-        /// Set the OrgNumber in the Data property of the request.
-        /// </summary>
-        /// <param name="orgNumber">Organization Number of the organization to lookup parent units for</param>
-        public static LookupMainUnitRequest Create(string orgNumber)
-        {
-            var request = new LookupMainUnitRequest
-            {
-                Data = $"urn:altinn:organization:identifier-no:{orgNumber}"
-            };
-
-            return request;
-        }
+        public string Data { get; init; } = $"urn:altinn:organization:identifier-no:{orgNumber}";
     }
 }

--- a/src/Altinn.Profile.Integrations/Register/LookupMainUnitRequest.cs
+++ b/src/Altinn.Profile.Integrations/Register/LookupMainUnitRequest.cs
@@ -14,7 +14,7 @@ namespace Altinn.Profile.Integrations.Register
         public string? Data { get; init; }
 
         /// <summary>
-        /// Set the ORgNumber in the Data property of the request.
+        /// Set the OrgNumber in the Data property of the request.
         /// </summary>
         /// <param name="orgNumber">Organization Number of the organization to lookup parent units for</param>
         public static LookupMainUnitRequest Create(string orgNumber)

--- a/src/Altinn.Profile.Integrations/Register/LookupMainUnitRequest.cs
+++ b/src/Altinn.Profile.Integrations/Register/LookupMainUnitRequest.cs
@@ -1,0 +1,16 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Altinn.Profile.Integrations.Register
+{
+    /// <summary>
+    /// Request model for the lookup resource for main units
+    /// </summary>
+    public class LookupMainUnitRequest(string orgNumber)
+    {
+        /// <summary>
+        /// Data containing the urn of the organization with either orgNumber, partyId or PartyUuid.
+        /// </summary>
+        [JsonPropertyName("data")]
+        public string Data { get; init; } = $"urn:altinn:organization:identifier-no:{orgNumber}";
+    }
+}

--- a/src/Altinn.Profile.Integrations/Register/LookupMainUnitRequest.cs
+++ b/src/Altinn.Profile.Integrations/Register/LookupMainUnitRequest.cs
@@ -11,7 +11,7 @@ namespace Altinn.Profile.Integrations.Register
         /// Data containing the urn of the organization with either orgNumber, partyId or PartyUuid.
         /// </summary>
         [JsonPropertyName("data")]
-        public string Data { get; set; }
+        public string? Data { get; init; }
 
         /// <summary>
         /// Set the ORgNumber in the Data property of the request.

--- a/src/Altinn.Profile.Integrations/Register/LookupMainUnitResponse.cs
+++ b/src/Altinn.Profile.Integrations/Register/LookupMainUnitResponse.cs
@@ -1,0 +1,16 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Altinn.Profile.Integrations.Register
+{
+    /// <summary>
+    /// Response model for the lookup resource for main units
+    /// </summary>
+    public class LookupMainUnitResponse()
+    {
+        /// <summary>
+        /// Data containing the urn of the organization with either orgNumber, partyId or PartyUuid.
+        /// </summary>
+        [JsonPropertyName("data")]
+        public List<OrganizationRecord> Data { get; init; } = new List<OrganizationRecord>(); 
+    }
+}

--- a/src/Altinn.Profile.Integrations/Register/LookupMainUnitResponse.cs
+++ b/src/Altinn.Profile.Integrations/Register/LookupMainUnitResponse.cs
@@ -11,6 +11,6 @@ namespace Altinn.Profile.Integrations.Register
         /// Data containing the urn of the organization with either orgNumber, partyId or PartyUuid.
         /// </summary>
         [JsonPropertyName("data")]
-        public List<OrganizationRecord> Data { get; init; } = new List<OrganizationRecord>(); 
+        public List<OrganizationRecord> Data { get; init; } = []; 
     }
 }

--- a/src/Altinn.Profile.Integrations/Register/OrganizationRecord.cs
+++ b/src/Altinn.Profile.Integrations/Register/OrganizationRecord.cs
@@ -11,6 +11,6 @@ namespace Altinn.Profile.Integrations.Register
         /// Gets the organization identifier of the party, or <see langword="null"/> if the party is not an organization.
         /// </summary>
         [JsonPropertyName("organizationIdentifier")]
-        public string OrganizationIdentifier { get; set; }
+        public string? OrganizationIdentifier { get; set; }
     }
 }

--- a/src/Altinn.Profile.Integrations/Register/OrganizationRecord.cs
+++ b/src/Altinn.Profile.Integrations/Register/OrganizationRecord.cs
@@ -1,0 +1,16 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Altinn.Profile.Integrations.Register
+{
+    /// <summary>
+    /// A record for an organization.
+    /// </summary>
+    public record OrganizationRecord
+    {
+        /// <summary>
+        /// Gets the organization identifier of the party, or <see langword="null"/> if the party is not an organization.
+        /// </summary>
+        [JsonPropertyName("organizationIdentifier")]
+        public string OrganizationIdentifier { get; set; }
+    }
+}

--- a/src/Altinn.Profile.Integrations/Register/RegisterClient.cs
+++ b/src/Altinn.Profile.Integrations/Register/RegisterClient.cs
@@ -33,8 +33,8 @@ public class RegisterClient : IRegisterClient
     /// <param name="accessTokenGenerator">The access token generator.</param>
     public RegisterClient(HttpClient httpClient, IOptions<RegisterSettings> settings, IAccessTokenGenerator accessTokenGenerator, ILogger<RegisterClient> logger)
     {
-        _httpClient = httpClient;
-        _accessTokenGenerator = accessTokenGenerator;
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _accessTokenGenerator = accessTokenGenerator ?? throw new ArgumentNullException(nameof(accessTokenGenerator));
         _httpClient.BaseAddress = new Uri(settings.Value.ApiRegisterEndpoint);
         _logger = logger ?? throw new ArgumentNullException(nameof(logger), "Logger cannot be null.");
     }

--- a/src/Altinn.Profile.Integrations/Register/RegisterClient.cs
+++ b/src/Altinn.Profile.Integrations/Register/RegisterClient.cs
@@ -38,7 +38,7 @@ public class RegisterClient : IRegisterClient
     }
 
     /// <inheritdoc/>
-    public async Task<string> GetMainUnit(string orgNumber, CancellationToken cancellationToken)
+    public async Task<string?> GetMainUnit(string orgNumber, CancellationToken cancellationToken)
     {
         var request = new LookupMainUnitRequest(orgNumber);
         var json = JsonSerializer.Serialize(request, _options);
@@ -64,8 +64,20 @@ public class RegisterClient : IRegisterClient
 
         var responseData = await response.Content.ReadAsStringAsync(cancellationToken);
 
-        ////var responseObject = JsonSerializer.Deserialize<Object>(responseData);
+        var responseObject = JsonSerializer.Deserialize<LookupMainUnitResponse>(responseData);
 
-        return responseData;
+        if (responseObject == null)
+        {
+            throw new NotImplementedException("Failed to deserialize response from Register API.");
+        }
+
+        if (!(responseObject.Data?.Count > 0))
+        {
+            return null;
+        }
+
+        // The response is a list, but assuming the list contains only one item in all cases
+        var mainUnitOrgNumber = responseObject.Data[0].OrganizationIdentifier;
+        return mainUnitOrgNumber;
     }
 }

--- a/src/Altinn.Profile.Integrations/Register/RegisterClient.cs
+++ b/src/Altinn.Profile.Integrations/Register/RegisterClient.cs
@@ -36,6 +36,7 @@ public class RegisterClient : IRegisterClient
     {
         _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         _accessTokenGenerator = accessTokenGenerator ?? throw new ArgumentNullException(nameof(accessTokenGenerator));
+        ArgumentNullException.ThrowIfNull(settings);
         _httpClient.BaseAddress = new Uri(settings.Value.ApiRegisterEndpoint);
         _logger = logger ?? throw new ArgumentNullException(nameof(logger), "Logger cannot be null.");
     }
@@ -67,7 +68,7 @@ public class RegisterClient : IRegisterClient
 
         if (!response.IsSuccessStatusCode)
         {
-            _logger.LogError("Failed to get main unit for organization {OrgNumber}. Status code: {StatusCode}", orgNumber, response.StatusCode);
+            _logger.LogError("Failed to get main unit for organization. Status code: {StatusCode}", response.StatusCode);
             return null;
         }
 
@@ -82,7 +83,7 @@ public class RegisterClient : IRegisterClient
         // The response is a list, but assuming the list contains only one item in all cases
         if (responseObject.Data.Count > 1)
         {
-            _logger.LogWarning("Get main units for organization {OrgNumber} returned multiple results. Using the first one.", orgNumber);
+            _logger.LogWarning("Get main units for organization returned multiple results. Using the first one.");
         }
 
         var mainUnitOrgNumber = responseObject.Data[0].OrganizationIdentifier;

--- a/src/Altinn.Profile.Integrations/Register/RegisterClient.cs
+++ b/src/Altinn.Profile.Integrations/Register/RegisterClient.cs
@@ -1,0 +1,71 @@
+﻿using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Altinn.Common.AccessTokenClient.Services;
+
+using Microsoft.Extensions.Options;
+
+namespace Altinn.Profile.Integrations.Register;
+
+/// <summary>
+/// An HTTP client to interact with a source registry for organizational notification addresses.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="IRegisterClient"/> class.
+/// </remarks>
+public class RegisterClient : IRegisterClient
+{
+    private readonly HttpClient _httpClient;
+    private readonly IAccessTokenGenerator _accessTokenGenerator;
+
+    private readonly JsonSerializerOptions _options = new()
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RegisterClient"/> class.
+    /// </summary>
+    /// <param name="httpClient">The HTTP client used to make requests to the register service.</param>
+    /// <param name="settings">The register settings containing the API endpoint.</param>
+    /// <param name="accessTokenGenerator">The access token generator.</param>
+    public RegisterClient(HttpClient httpClient, IOptions<RegisterSettings> settings, IAccessTokenGenerator accessTokenGenerator)
+    {
+        _httpClient = httpClient;
+        _accessTokenGenerator = accessTokenGenerator;
+        _httpClient.BaseAddress = new Uri(settings.Value.ApiRegisterEndpoint);
+
+    }
+
+    /// <inheritdoc/>
+    public async Task<string> GetMainUnit(string orgNumber, CancellationToken cancellationToken)
+    {
+        var request = new LookupMainUnitRequest(orgNumber);
+        var json = JsonSerializer.Serialize(request, _options);
+        var stringContent = new StringContent(json, Encoding.UTF8, "application/json");
+
+        var requestMessage = new HttpRequestMessage(HttpMethod.Post, "v2/internal/parties/main-units")
+        {
+            Content = stringContent
+        };
+
+        var accessToken = _accessTokenGenerator.GenerateAccessToken("platform", "profile");
+        if (!string.IsNullOrEmpty(accessToken))
+        {
+            requestMessage.Headers.Add("PlatformAccessToken", accessToken);
+        }
+
+        var response = await _httpClient.SendAsync(requestMessage, cancellationToken);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new NotImplementedException($"Failed to retrieve main unit. StatusCode: {response.StatusCode}");
+        }
+
+        var responseData = await response.Content.ReadAsStringAsync(cancellationToken);
+
+        ////var responseObject = JsonSerializer.Deserialize<Object>(responseData);
+
+        return responseData;
+    }
+}

--- a/src/Altinn.Profile.Integrations/Register/RegisterClient.cs
+++ b/src/Altinn.Profile.Integrations/Register/RegisterClient.cs
@@ -42,6 +42,11 @@ public class RegisterClient : IRegisterClient
     /// <inheritdoc/>
     public async Task<string?> GetMainUnit(string orgNumber, CancellationToken cancellationToken)
     {
+        if (string.IsNullOrWhiteSpace(orgNumber))
+        {
+            throw new ArgumentException("Organization number cannot be null or empty.", nameof(orgNumber));
+        }
+
         var request = new LookupMainUnitRequest(orgNumber);
         var json = JsonSerializer.Serialize(request, _options);
         var stringContent = new StringContent(json, Encoding.UTF8, "application/json");

--- a/src/Altinn.Profile.Integrations/Register/RegisterClient.cs
+++ b/src/Altinn.Profile.Integrations/Register/RegisterClient.cs
@@ -50,7 +50,7 @@ public class RegisterClient : IRegisterClient
             return null;
         }
 
-        var request = LookupMainUnitRequest.Create(orgNumber);
+        var request = new LookupMainUnitRequest(orgNumber);
         var json = JsonSerializer.Serialize(request, _options);
         var stringContent = new StringContent(json, Encoding.UTF8, "application/json");
 

--- a/src/Altinn.Profile.Integrations/Register/RegisterClient.cs
+++ b/src/Altinn.Profile.Integrations/Register/RegisterClient.cs
@@ -43,7 +43,7 @@ public class RegisterClient : IRegisterClient
     /// <inheritdoc/>
     public async Task<string?> GetMainUnit(string orgNumber, CancellationToken cancellationToken)
     {
-        var request = new LookupMainUnitRequest(orgNumber);
+        var request = LookupMainUnitRequest.Create(orgNumber);
         var json = JsonSerializer.Serialize(request, _options);
         var stringContent = new StringContent(json, Encoding.UTF8, "application/json");
 

--- a/src/Altinn.Profile.Integrations/Register/RegisterClient.cs
+++ b/src/Altinn.Profile.Integrations/Register/RegisterClient.cs
@@ -43,6 +43,13 @@ public class RegisterClient : IRegisterClient
     /// <inheritdoc/>
     public async Task<string?> GetMainUnit(string orgNumber, CancellationToken cancellationToken)
     {
+        var accessToken = _accessTokenGenerator.GenerateAccessToken("platform", "profile");
+        if (string.IsNullOrEmpty(accessToken))
+        {
+            _logger.LogError("Invalid access token generated for org main unit lookup.");
+            return null;
+        }
+
         var request = LookupMainUnitRequest.Create(orgNumber);
         var json = JsonSerializer.Serialize(request, _options);
         var stringContent = new StringContent(json, Encoding.UTF8, "application/json");
@@ -52,11 +59,7 @@ public class RegisterClient : IRegisterClient
             Content = stringContent
         };
 
-        var accessToken = _accessTokenGenerator.GenerateAccessToken("platform", "profile");
-        if (!string.IsNullOrEmpty(accessToken))
-        {
-            requestMessage.Headers.Add("PlatformAccessToken", accessToken);
-        }
+        requestMessage.Headers.Add("PlatformAccessToken", accessToken);
 
         var response = await _httpClient.SendAsync(requestMessage, cancellationToken);
 

--- a/src/Altinn.Profile.Integrations/Register/RegisterClient.cs
+++ b/src/Altinn.Profile.Integrations/Register/RegisterClient.cs
@@ -34,22 +34,16 @@ public class RegisterClient : IRegisterClient
     /// <param name="logger">The logger</param>
     public RegisterClient(HttpClient httpClient, IOptions<RegisterSettings> settings, IAccessTokenGenerator accessTokenGenerator, ILogger<RegisterClient> logger)
     {
-        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
-        _accessTokenGenerator = accessTokenGenerator ?? throw new ArgumentNullException(nameof(accessTokenGenerator));
-        ArgumentNullException.ThrowIfNull(settings);
+        _httpClient = httpClient;
+        _accessTokenGenerator = accessTokenGenerator;
         _httpClient.BaseAddress = new Uri(settings.Value.ApiRegisterEndpoint);
-        _logger = logger ?? throw new ArgumentNullException(nameof(logger), "Logger cannot be null.");
+        _logger = logger;
     }
 
     /// <inheritdoc/>
     public async Task<string?> GetMainUnit(string orgNumber, CancellationToken cancellationToken)
     {
-        if (string.IsNullOrWhiteSpace(orgNumber))
-        {
-            throw new ArgumentException("Organization number cannot be null or empty.", nameof(orgNumber));
-        }
-
-        var request = LookupMainUnitRequest.Create(orgNumber);
+        var request = new LookupMainUnitRequest(orgNumber);
         var json = JsonSerializer.Serialize(request, _options);
         var stringContent = new StringContent(json, Encoding.UTF8, "application/json");
 
@@ -74,8 +68,8 @@ public class RegisterClient : IRegisterClient
 
         var responseData = await response.Content.ReadAsStringAsync(cancellationToken);
 
-        var responseObject = JsonSerializer.Deserialize<LookupMainUnitResponse>(responseData) ?? throw new InvalidOperationException("Failed to deserialize response from Register API.");
-        if (!(responseObject.Data?.Count > 0))
+        var responseObject = JsonSerializer.Deserialize<LookupMainUnitResponse>(responseData);
+        if (!(responseObject?.Data?.Count > 0))
         {
             return null;
         }

--- a/src/Altinn.Profile.Integrations/Register/RegisterClient.cs
+++ b/src/Altinn.Profile.Integrations/Register/RegisterClient.cs
@@ -31,6 +31,7 @@ public class RegisterClient : IRegisterClient
     /// <param name="httpClient">The HTTP client used to make requests to the register service.</param>
     /// <param name="settings">The register settings containing the API endpoint.</param>
     /// <param name="accessTokenGenerator">The access token generator.</param>
+    /// <param name="logger">The logger</param>
     public RegisterClient(HttpClient httpClient, IOptions<RegisterSettings> settings, IAccessTokenGenerator accessTokenGenerator, ILogger<RegisterClient> logger)
     {
         _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
@@ -47,7 +48,7 @@ public class RegisterClient : IRegisterClient
             throw new ArgumentException("Organization number cannot be null or empty.", nameof(orgNumber));
         }
 
-        var request = new LookupMainUnitRequest(orgNumber);
+        var request = LookupMainUnitRequest.Create(orgNumber);
         var json = JsonSerializer.Serialize(request, _options);
         var stringContent = new StringContent(json, Encoding.UTF8, "application/json");
 

--- a/src/Altinn.Profile.Integrations/Register/RegisterSettings.cs
+++ b/src/Altinn.Profile.Integrations/Register/RegisterSettings.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Altinn.Profile.Integrations.Register
+{
+    /// <summary>
+    /// Configuration object used to hold settings for all Altinn Register integrations.
+    /// </summary>
+    public class RegisterSettings
+    {
+        /// <summary>
+        /// Gets or sets the url for the register API
+        /// </summary>
+        public string ApiRegisterEndpoint { get; set; } = string.Empty;
+    }
+}

--- a/src/Altinn.Profile.Integrations/Register/RegisterSettings.cs
+++ b/src/Altinn.Profile.Integrations/Register/RegisterSettings.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Altinn.Profile.Integrations.Register
+﻿namespace Altinn.Profile.Integrations.Register
 {
     /// <summary>
     /// Configuration object used to hold settings for all Altinn Register integrations.

--- a/src/Altinn.Profile.Integrations/Repositories/OrganizationNotificationAddressRepository.cs
+++ b/src/Altinn.Profile.Integrations/Repositories/OrganizationNotificationAddressRepository.cs
@@ -138,6 +138,19 @@ public class OrganizationNotificationAddressRepository(IDbContextFactory<Profile
     }
 
     /// <inheritdoc/>
+    public async Task<Organization?> GetOrganizationAsync(string organizationNumber, CancellationToken cancellationToken)
+    {
+        var organizations = await GetOrganizationsAsync([organizationNumber], cancellationToken);
+
+        if (organizations.Count() > 1)
+        {
+            throw new InvalidOperationException($"Multiple organizations found for organization number {organizationNumber}. Expected only one organization.");
+        }
+
+        return organizations.FirstOrDefault();
+    }
+
+    /// <inheritdoc/>
     public async Task<IEnumerable<Organization>> GetOrganizationsAsync(List<string> organizationNumbers, CancellationToken cancellationToken)
     {
         using ProfileDbContext databaseContext = await _contextFactory.CreateDbContextAsync(cancellationToken);

--- a/src/Altinn.Profile.Integrations/Repositories/OrganizationNotificationAddressRepository.cs
+++ b/src/Altinn.Profile.Integrations/Repositories/OrganizationNotificationAddressRepository.cs
@@ -140,9 +140,9 @@ public class OrganizationNotificationAddressRepository(IDbContextFactory<Profile
     /// <inheritdoc/>
     public async Task<Organization?> GetOrganizationAsync(string organizationNumber, CancellationToken cancellationToken)
     {
-        var organizations = await GetOrganizationDEAsync(organizationNumber, cancellationToken);
+        var organization = await GetOrganizationDEAsync(organizationNumber, cancellationToken);
 
-        return _mapper.Map<Organization>(organizations);
+        return _mapper.Map<Organization>(organization);
     }
 
     /// <inheritdoc/>

--- a/src/Altinn.Profile.Integrations/Repositories/OrganizationNotificationAddressRepository.cs
+++ b/src/Altinn.Profile.Integrations/Repositories/OrganizationNotificationAddressRepository.cs
@@ -113,11 +113,11 @@ public class OrganizationNotificationAddressRepository(IDbContextFactory<Profile
     /// </returns>
     public async Task<OrganizationDE?> GetOrganizationDEAsync(string orgNumber, CancellationToken cancellationToken)
     {
-        using ProfileDbContext databaseContext = await _contextFactory.CreateDbContextAsync();
+        using ProfileDbContext databaseContext = await _contextFactory.CreateDbContextAsync(cancellationToken);
 
         return await databaseContext.Organizations
                 .Include(o => o.NotificationAddresses)
-                .FirstOrDefaultAsync(o => o.RegistryOrganizationNumber == orgNumber);
+                .FirstOrDefaultAsync(o => o.RegistryOrganizationNumber == orgNumber, cancellationToken);
     }
     
     private async Task<int> CreateOrganizationWithNotificationAddress(string orgNumber, Entry address)

--- a/src/Altinn.Profile.Integrations/Repositories/OrganizationNotificationAddressRepository.cs
+++ b/src/Altinn.Profile.Integrations/Repositories/OrganizationNotificationAddressRepository.cs
@@ -70,7 +70,7 @@ public class OrganizationNotificationAddressRepository(IDbContextFactory<Profile
             return 0;
         }
 
-        var organization = await GetOrganizationAsync(orgNumber);
+        var organization = await GetOrganizationDEAsync(orgNumber, CancellationToken.None);
         if (organization is null)
         {
             return await CreateOrganizationWithNotificationAddress(orgNumber, address);
@@ -111,7 +111,7 @@ public class OrganizationNotificationAddressRepository(IDbContextFactory<Profile
     /// <returns>
     /// A task that represents the asynchronous operation.
     /// </returns>
-    public async Task<OrganizationDE?> GetOrganizationAsync(string orgNumber)
+    public async Task<OrganizationDE?> GetOrganizationDEAsync(string orgNumber, CancellationToken cancellationToken)
     {
         using ProfileDbContext databaseContext = await _contextFactory.CreateDbContextAsync();
 
@@ -140,9 +140,9 @@ public class OrganizationNotificationAddressRepository(IDbContextFactory<Profile
     /// <inheritdoc/>
     public async Task<Organization?> GetOrganizationAsync(string organizationNumber, CancellationToken cancellationToken)
     {
-        var organizations = await GetOrganizationsAsync([organizationNumber], cancellationToken);
+        var organizations = await GetOrganizationDEAsync(organizationNumber, cancellationToken);
 
-        return organizations.SingleOrDefault();
+        return _mapper.Map<Organization>(organizations);
     }
 
     /// <inheritdoc/>

--- a/src/Altinn.Profile.Integrations/Repositories/OrganizationNotificationAddressRepository.cs
+++ b/src/Altinn.Profile.Integrations/Repositories/OrganizationNotificationAddressRepository.cs
@@ -142,12 +142,7 @@ public class OrganizationNotificationAddressRepository(IDbContextFactory<Profile
     {
         var organizations = await GetOrganizationsAsync([organizationNumber], cancellationToken);
 
-        if (organizations.Count() > 1)
-        {
-            throw new InvalidOperationException($"Multiple organizations found for organization number {organizationNumber}. Expected only one organization.");
-        }
-
-        return organizations.FirstOrDefault();
+        return organizations.SingleOrDefault();
     }
 
     /// <inheritdoc/>

--- a/src/Altinn.Profile.Integrations/ServiceCollectionExtensions.cs
+++ b/src/Altinn.Profile.Integrations/ServiceCollectionExtensions.cs
@@ -65,6 +65,7 @@ public static class ServiceCollectionExtensions
         }
 
         services.AddTransient<IAccessTokenGenerator, AccessTokenGenerator>();
+        services.AddTransient<ISigningCredentialsResolver, SigningCredentialsResolver>();
 
         services.Configure<RegisterSettings>(config.GetSection(nameof(RegisterSettings)));
         services.AddHttpClient<IRegisterClient, RegisterClient>();

--- a/src/Altinn.Profile.Integrations/ServiceCollectionExtensions.cs
+++ b/src/Altinn.Profile.Integrations/ServiceCollectionExtensions.cs
@@ -2,13 +2,14 @@
 
 using Altinn.ApiClients.Maskinporten.Extensions;
 using Altinn.ApiClients.Maskinporten.Services;
-
+using Altinn.Common.AccessTokenClient.Services;
 using Altinn.Profile.Core.Integrations;
 using Altinn.Profile.Integrations.ContactRegister;
 using Altinn.Profile.Integrations.Extensions;
 using Altinn.Profile.Integrations.Mappings;
 using Altinn.Profile.Integrations.OrganizationNotificationAddressRegistry;
 using Altinn.Profile.Integrations.Persistence;
+using Altinn.Profile.Integrations.Register;
 using Altinn.Profile.Integrations.Repositories;
 using Altinn.Profile.Integrations.SblBridge;
 using Altinn.Profile.Integrations.SblBridge.Unit.Profile;
@@ -62,6 +63,11 @@ public static class ServiceCollectionExtensions
         {
             throw new InvalidOperationException("Database connection string is not properly configured.");
         }
+
+        services.AddTransient<IAccessTokenGenerator, AccessTokenGenerator>();
+
+        services.Configure<RegisterSettings>(config.GetSection(nameof(RegisterSettings)));
+        services.AddHttpClient<IRegisterClient, RegisterClient>();
 
         services.AddScoped<IPersonService, PersonRepository>();
         services.AddScoped<IPersonUpdater, PersonRepository>();

--- a/src/Altinn.Profile/Controllers/OrgNotificationAddressController.cs
+++ b/src/Altinn.Profile/Controllers/OrgNotificationAddressController.cs
@@ -58,6 +58,7 @@ namespace Altinn.Profile.Controllers
                 var contactPoints = new NotificationAddresses
                 {
                     OrganizationNumber = organization.OrganizationNumber,
+                    AddressOrigin = organization.GetAddressOrigin(),
                 };
 
                 if (organization.NotificationAddresses?.Count > 0)

--- a/src/Altinn.Profile/Controllers/OrgNotificationAddressController.cs
+++ b/src/Altinn.Profile/Controllers/OrgNotificationAddressController.cs
@@ -44,7 +44,7 @@ namespace Altinn.Profile.Controllers
                 return BadRequest(ModelState);
             }
 
-            var organizations = await _notificationAddressService.GetOrganizationNotificationAddresses(orgContactPointLookup.OrganizationNumbers, cancellationToken);
+            var organizations = await _notificationAddressService.GetOrganizationNotificationAddresses(orgContactPointLookup.OrganizationNumbers, cancellationToken, true);
 
             OrgNotificationAddressesResponse result = MapResult(organizations);
             return Ok(result);

--- a/src/Altinn.Profile/Controllers/OrgNotificationAddressController.cs
+++ b/src/Altinn.Profile/Controllers/OrgNotificationAddressController.cs
@@ -26,7 +26,8 @@ namespace Altinn.Profile.Controllers
         private readonly IOrganizationNotificationAddressesService _notificationAddressService = notificationAddressService;
 
         /// <summary>
-        /// Endpoint looking up the notification addresses for the organization provided in the lookup object in the request body
+        /// Endpoint looking up the notification addresses for the organization provided in the lookup object in the request body.
+        /// If the organization has no notification addresses registered, the main unit address will be returned if it exists.
         /// </summary>
         /// <returns>Returns an overview of the user registered notification addresses for the provided organization</returns>
         [HttpPost("lookup")]
@@ -53,7 +54,7 @@ namespace Altinn.Profile.Controllers
                 var contactPoints = new NotificationAddresses
                 {
                     OrganizationNumber = organization.OrganizationNumber,
-                    AddressOrigin = organization.GetAddressOrigin(),
+                    AddressOrigin = organization.AddressOrigin,
                 };
 
                 if (organization.NotificationAddresses?.Count > 0)

--- a/src/Altinn.Profile/Controllers/OrgNotificationAddressController.cs
+++ b/src/Altinn.Profile/Controllers/OrgNotificationAddressController.cs
@@ -37,7 +37,7 @@ namespace Altinn.Profile.Controllers
         {
             if (!ModelState.IsValid)
             {
-                return BadRequest(ModelState);
+                return ValidationProblem(ModelState);
             }
 
             var organizations = await _notificationAddressService.GetOrganizationNotificationAddresses(orgContactPointLookup.OrganizationNumbers, cancellationToken, true);

--- a/src/Altinn.Profile/Controllers/OrgNotificationAddressController.cs
+++ b/src/Altinn.Profile/Controllers/OrgNotificationAddressController.cs
@@ -14,21 +14,16 @@ namespace Altinn.Profile.Controllers
     /// <summary>
     /// Controller for organization notifications address API endpoints for internal consumption (e.g. Notifications) requiring neither authenticated user token nor access token authorization.
     /// </summary>
+    /// <remarks>
+    /// Initializes a new instance of the <see cref="OrgNotificationAddressController"/> class.
+    /// </remarks>
     [Route("profile/api/v1/organizations/notificationaddresses")]
     [ApiExplorerSettings(IgnoreApi = true)]
     [Consumes("application/json")]
     [Produces("application/json")]
-    public class OrgNotificationAddressController : ControllerBase
+    public class OrgNotificationAddressController(IOrganizationNotificationAddressesService notificationAddressService) : ControllerBase
     {
-        private readonly IOrganizationNotificationAddressesService _notificationAddressService;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="OrgNotificationAddressController"/> class.
-        /// </summary>
-        public OrgNotificationAddressController(IOrganizationNotificationAddressesService notificationAddressService)
-        {
-            _notificationAddressService = notificationAddressService;
-        }
+        private readonly IOrganizationNotificationAddressesService _notificationAddressService = notificationAddressService;
 
         /// <summary>
         /// Endpoint looking up the notification addresses for the organization provided in the lookup object in the request body

--- a/src/Altinn.Profile/Models/OrgNotificationAddressRequest.cs
+++ b/src/Altinn.Profile/Models/OrgNotificationAddressRequest.cs
@@ -15,14 +15,16 @@ namespace Altinn.Profile.Models
         /// </summary>
         [JsonPropertyName("organizationNumbers")]
         [Required]
-        public List<string> OrganizationNumbers { get; set; } = [];
+        public List<string> OrganizationNumbers { get; set; }
 
         /// <inheritdoc/>
         public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {
-            if (OrganizationNumbers == null || OrganizationNumbers.Any(string.IsNullOrWhiteSpace))
+            if (OrganizationNumbers == null ||
+                OrganizationNumbers.Count == 0 ||
+                OrganizationNumbers.Any(string.IsNullOrWhiteSpace))
             {
-                yield return new ValidationResult("organizationNumbers must provide a list of valid organization number values", [nameof(OrganizationNumbers)]);
+                yield return new ValidationResult("OrganizationNumbers must contain a list of valid organization number values", [nameof(OrganizationNumbers)]);
             }
         }
     }

--- a/src/Altinn.Profile/Models/OrgNotificationAddressRequest.cs
+++ b/src/Altinn.Profile/Models/OrgNotificationAddressRequest.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
 using System.Text.Json.Serialization;
 
 namespace Altinn.Profile.Models
@@ -6,12 +8,22 @@ namespace Altinn.Profile.Models
     /// <summary>
     /// A class describing the query model for contact points for organizations
     /// </summary>
-    public class OrgNotificationAddressRequest
+    public class OrgNotificationAddressRequest: IValidatableObject
     {
         /// <summary>
         /// Gets or sets the list of organization numbers to lookup contact points for
         /// </summary>
         [JsonPropertyName("organizationNumbers")]
+        [Required]
         public List<string> OrganizationNumbers { get; set; } = [];
+
+        /// <inheritdoc/>
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            if (OrganizationNumbers == null || OrganizationNumbers.Any(string.IsNullOrWhiteSpace))
+            {
+                yield return new ValidationResult("organizationNumbers must provide a list of valid organization number values", [nameof(OrganizationNumbers)]);
+            }
+        }
     }
 }

--- a/src/Altinn.Profile/Models/OrgNotificationAddressesResponse.cs
+++ b/src/Altinn.Profile/Models/OrgNotificationAddressesResponse.cs
@@ -23,6 +23,12 @@ public class OrgNotificationAddressesResponse
         public string OrganizationNumber { get; set; } = string.Empty;
 
         /// <summary>
+        /// Gets or sets the organization number for the organization where the address originated
+        /// </summary>
+        /// <remarks>This will be the same as <see cref="OrganizationNumber"/> if the address is from this unit, otherwise it will be from a parent unit</remarks>
+        public string AddressOrigin { get; set; } = string.Empty;
+
+        /// <summary>
         /// Gets or sets the party id of the organization
         /// </summary>
         public int PartyId { get; set; }

--- a/src/Altinn.Profile/appsettings.json
+++ b/src/Altinn.Profile/appsettings.json
@@ -41,5 +41,8 @@
   "PlatformSettings": {
     "ApiAuthorizationEndpoint": "http://localhost:5101/authorization/api/v1/",
     "SubscriptionKey": "inserted-during-deployment"
+  },
+  "RegisterSettings": {
+    "ApiRegisterEndpoint": "http://localhost:5020/register/api/"
   }
 }

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/OrgNotificationAddressesControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/OrgNotificationAddressesControllerTests.cs
@@ -131,18 +131,24 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
             // Arrange
             OrgNotificationAddressRequest input = new()
             {
-                OrganizationNumbers = ["333333333", "111111111"],
+                OrganizationNumbers = ["333333333"],
             };
 
             _webApplicationFactorySetup.RegisterClientMock
                 .Setup(r => r.GetMainUnit(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync("123456789");
 
+            var childUnit = _testdata.Where(o => input.OrganizationNumbers.Contains(o.OrganizationNumber));
+            var parentUnit = _testdata.Where(o => o.OrganizationNumber == "123456789").First();
+
             _webApplicationFactorySetup.OrganizationNotificationAddressRepositoryMock
                 .SetupSequence(r => r.GetOrganizationsAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(_testdata.Where(o => input.OrganizationNumbers.Contains(o.OrganizationNumber)))
-                .ReturnsAsync(_testdata.Where(o => o.OrganizationNumber == "123456789"))
+                .ReturnsAsync(childUnit)
                 .ReturnsAsync([]);
+
+            _webApplicationFactorySetup.OrganizationNotificationAddressRepositoryMock
+                .SetupSequence(r => r.GetOrganizationAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(parentUnit);
 
             HttpClient client = _webApplicationFactorySetup.GetTestServerClient();
             HttpRequestMessage httpRequestMessage = new(HttpMethod.Post, "/profile/api/v1/organizations/notificationaddresses/lookup")

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/OrgNotificationAddressesControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/OrgNotificationAddressesControllerTests.cs
@@ -139,7 +139,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
                 .ReturnsAsync("123456789");
 
             var childUnit = _testdata.Where(o => input.OrganizationNumbers.Contains(o.OrganizationNumber));
-            var parentUnit = _testdata.Where(o => o.OrganizationNumber == "123456789").First();
+            var parentUnit = _testdata.First(o => o.OrganizationNumber == "123456789");
 
             _webApplicationFactorySetup.OrganizationNotificationAddressRepositoryMock
                 .SetupSequence(r => r.GetOrganizationsAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/OrgNotificationAddressesControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/OrgNotificationAddressesControllerTests.cs
@@ -262,5 +262,52 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
             var actual = JsonSerializer.Deserialize<OrgNotificationAddressesResponse>(responseContent, _serializerOptions);
             Assert.Empty(actual.ContactPointsList);
         }
+
+        [Fact]
+        public async Task PostLookup_WhenListIsNull_Returns400()
+        {
+            // Arrange
+            OrgNotificationAddressRequest input = new()
+            {
+                OrganizationNumbers = null
+            };
+
+            HttpClient client = _webApplicationFactorySetup.GetTestServerClient();
+            HttpRequestMessage httpRequestMessage = new(HttpMethod.Post, "/profile/api/v1/organizations/notificationaddresses/lookup")
+            {
+                Content = new StringContent(JsonSerializer.Serialize(input, _serializerOptions), System.Text.Encoding.UTF8, "application/json")
+            };
+
+            // Act
+            HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public async Task PostLookup_WhenOrgListContainsInvalidNos_Returns400(string invalidOrgNo)
+        {
+            // Arrange
+            OrgNotificationAddressRequest input = new()
+            {
+                OrganizationNumbers = ["987654321", "aValidOrg", invalidOrgNo],
+            };
+
+            HttpClient client = _webApplicationFactorySetup.GetTestServerClient();
+            HttpRequestMessage httpRequestMessage = new(HttpMethod.Post, "/profile/api/v1/organizations/notificationaddresses/lookup")
+            {
+                Content = new StringContent(JsonSerializer.Serialize(input, _serializerOptions), System.Text.Encoding.UTF8, "application/json")
+            };
+
+            // Act
+            HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        }
     }
 }

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/OrgNotificationAddressesControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/OrgNotificationAddressesControllerTests.cs
@@ -285,6 +285,28 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
         }
 
+        [Fact]
+        public async Task PostLookup_WhenListIsEmpty_Returns400()
+        {
+            // Arrange
+            OrgNotificationAddressRequest input = new()
+            {
+                OrganizationNumbers = []
+            };
+
+            HttpClient client = _webApplicationFactorySetup.GetTestServerClient();
+            HttpRequestMessage httpRequestMessage = new(HttpMethod.Post, "/profile/api/v1/organizations/notificationaddresses/lookup")
+            {
+                Content = new StringContent(JsonSerializer.Serialize(input, _serializerOptions), System.Text.Encoding.UTF8, "application/json")
+            };
+
+            // Act
+            HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        }
+
         [Theory]
         [InlineData(null)]
         [InlineData("")]

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/OrganizationsControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/OrganizationsControllerTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -15,7 +14,6 @@ using Altinn.Profile.Core.OrganizationNotificationAddresses;
 using Altinn.Profile.Models;
 using Altinn.Profile.Tests.IntegrationTests.Utils;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -333,8 +331,8 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
                 .Setup(r => r.GetOrganizationAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(_testdata.First(o => o.OrganizationNumber == orgNo));
             _webApplicationFactorySetup.OrganizationNotificationAddressRepositoryMock
-            .Setup(r => r.CreateNotificationAddressAsync(It.IsAny<string>(), It.IsAny<NotificationAddress>(), It.IsAny<string>()))
-            .ReturnsAsync(_testdata.First(o => o.OrganizationNumber == orgNo).NotificationAddresses.First());
+                .Setup(r => r.CreateNotificationAddressAsync(It.IsAny<string>(), It.IsAny<NotificationAddress>(), It.IsAny<string>()))
+                .ReturnsAsync(_testdata.First(o => o.OrganizationNumber == orgNo).NotificationAddresses.First());
 
             _webApplicationFactorySetup.OrganizationNotificationAddressUpdateClientMock.Setup(
                 c => c.CreateNewNotificationAddress(It.IsAny<NotificationAddress>(), It.IsAny<string>()))

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/OrganizationsControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/OrganizationsControllerTests.cs
@@ -330,8 +330,8 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
             Mock<IPDP> pdpMock = GetPDPMockWithResponse("Permit");
 
             _webApplicationFactorySetup.OrganizationNotificationAddressRepositoryMock
-                .Setup(r => r.GetOrganizationsAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(_testdata.Where(o => o.OrganizationNumber == orgNo));
+                .Setup(r => r.GetOrganizationAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(_testdata.First(o => o.OrganizationNumber == orgNo));
             _webApplicationFactorySetup.OrganizationNotificationAddressRepositoryMock
             .Setup(r => r.CreateNotificationAddressAsync(It.IsAny<string>(), It.IsAny<NotificationAddress>(), It.IsAny<string>()))
             .ReturnsAsync(_testdata.First(o => o.OrganizationNumber == orgNo).NotificationAddresses.First());
@@ -450,8 +450,8 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
             Mock<IPDP> pdpMock = GetPDPMockWithResponse("Permit");
 
             _webApplicationFactorySetup.OrganizationNotificationAddressRepositoryMock
-                .Setup(r => r.GetOrganizationsAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(_testdata.Where(o => o.OrganizationNumber == orgNo));
+                .Setup(r => r.GetOrganizationAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(_testdata.First(o => o.OrganizationNumber == orgNo));
             _webApplicationFactorySetup.OrganizationNotificationAddressRepositoryMock
                 .Setup(r => r.UpdateNotificationAddressAsync(It.IsAny<NotificationAddress>(), It.IsAny<string>()))
                 .ReturnsAsync(_testdata.First(o => o.OrganizationNumber == orgNo).NotificationAddresses.First());
@@ -487,8 +487,8 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
             Mock<IPDP> pdpMock = GetPDPMockWithResponse("Permit");
 
             _webApplicationFactorySetup.OrganizationNotificationAddressRepositoryMock
-                .Setup(r => r.GetOrganizationsAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(_testdata.Where(o => o.OrganizationNumber == orgNo));
+                .Setup(r => r.GetOrganizationAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(_testdata.First(o => o.OrganizationNumber == orgNo));
             _webApplicationFactorySetup.OrganizationNotificationAddressRepositoryMock
                 .Setup(r => r.UpdateNotificationAddressAsync(It.IsAny<NotificationAddress>(), It.IsAny<string>()))
                 .ReturnsAsync(_testdata.First(o => o.OrganizationNumber == orgNo).NotificationAddresses.First());
@@ -664,8 +664,8 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
             Mock<IPDP> pdpMock = GetPDPMockWithResponse("Permit");
 
             _webApplicationFactorySetup.OrganizationNotificationAddressRepositoryMock
-                .Setup(r => r.GetOrganizationsAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(_testdata.Where(o => o.OrganizationNumber == orgNo));
+                .Setup(r => r.GetOrganizationAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(_testdata.First(o => o.OrganizationNumber == orgNo));
             _webApplicationFactorySetup.OrganizationNotificationAddressRepositoryMock
             .Setup(r => r.DeleteNotificationAddressAsync(It.IsAny<int>()))
             .ReturnsAsync(_testdata.First(o => o.OrganizationNumber == orgNo).NotificationAddresses.First());
@@ -697,8 +697,8 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
             Mock<IPDP> pdpMock = GetPDPMockWithResponse("Permit");
 
             _webApplicationFactorySetup.OrganizationNotificationAddressRepositoryMock
-                .Setup(r => r.GetOrganizationsAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(_testdata.Where(o => o.OrganizationNumber == orgNo));
+                .Setup(r => r.GetOrganizationAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(_testdata.First(o => o.OrganizationNumber == orgNo));
             _webApplicationFactorySetup.OrganizationNotificationAddressRepositoryMock
             .Setup(r => r.DeleteNotificationAddressAsync(It.IsAny<int>()))
             .ReturnsAsync(_testdata.First(o => o.OrganizationNumber == orgNo).NotificationAddresses.First());

--- a/test/Altinn.Profile.Tests/IntegrationTests/Utils/WebApplicationFactorySetup.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/Utils/WebApplicationFactorySetup.cs
@@ -6,7 +6,6 @@ using Altinn.Common.PEP.Interfaces;
 using Altinn.Profile.Core.Integrations;
 using Altinn.Profile.Integrations.ContactRegister;
 using Altinn.Profile.Integrations.OrganizationNotificationAddressRegistry;
-using Altinn.Profile.Integrations.Register;
 using Altinn.Profile.Integrations.SblBridge;
 using Altinn.Profile.Integrations.SblBridge.Unit.Profile;
 using Altinn.Profile.Integrations.SblBridge.User.Profile;
@@ -27,15 +26,10 @@ using Moq;
 
 namespace Altinn.Profile.Tests.IntegrationTests.Utils;
 
-public class WebApplicationFactorySetup<T>
+public class WebApplicationFactorySetup<T>(WebApplicationFactory<T> webApplicationFactory)
     where T : class
 {
-    private readonly WebApplicationFactory<T> _webApplicationFactory;
-
-    public WebApplicationFactorySetup(WebApplicationFactory<T> webApplicationFactory)
-    {
-        _webApplicationFactory = webApplicationFactory;
-    }
+    private readonly WebApplicationFactory<T> _webApplicationFactory = webApplicationFactory;
 
     public Mock<IContactRegisterHttpClient> ContactRegisterServiceMock { get; set; } = new();
 
@@ -59,7 +53,7 @@ public class WebApplicationFactorySetup<T>
 
     public HttpClient GetTestServerClient(IPDP pdp = null)
     {
-        MemoryCache memoryCache = new MemoryCache(new MemoryCacheOptions());
+        MemoryCache memoryCache = new(new MemoryCacheOptions());
 
         SblBridgeSettingsOptions.Setup(gso => gso.Value).Returns(
             new SblBridgeSettings

--- a/test/Altinn.Profile.Tests/IntegrationTests/Utils/WebApplicationFactorySetup.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/Utils/WebApplicationFactorySetup.cs
@@ -6,6 +6,7 @@ using Altinn.Common.PEP.Interfaces;
 using Altinn.Profile.Core.Integrations;
 using Altinn.Profile.Integrations.ContactRegister;
 using Altinn.Profile.Integrations.OrganizationNotificationAddressRegistry;
+using Altinn.Profile.Integrations.Register;
 using Altinn.Profile.Integrations.SblBridge;
 using Altinn.Profile.Integrations.SblBridge.Unit.Profile;
 using Altinn.Profile.Integrations.SblBridge.User.Profile;
@@ -43,6 +44,8 @@ public class WebApplicationFactorySetup<T>
     public Mock<IOrganizationNotificationAddressSyncClient> OrganizationNotificationAddressSyncClientMock { get; set; } = new();
 
     public Mock<IOrganizationNotificationAddressUpdateClient> OrganizationNotificationAddressUpdateClientMock { get; set; } = new();
+
+    public Mock<IRegisterClient> RegisterClientMock { get; set; } = new();
 
     public Mock<ILogger<UnitProfileClient>> UnitProfileClientLogger { get; set; } = new();
 
@@ -83,6 +86,7 @@ public class WebApplicationFactorySetup<T>
                 services.AddSingleton(OrganizationNotificationAddressSyncClientMock.Object);
                 services.AddSingleton(OrganizationNotificationAddressUpdateClientMock.Object);
                 services.AddSingleton(OrganizationNotificationAddressRepositoryMock.Object);
+                services.AddSingleton(RegisterClientMock.Object);
                 services.AddSingleton(PartyGroupRepositoryMock.Object);
 
                 if (pdp != null)

--- a/test/Altinn.Profile.Tests/Profile.Core/OrganizationNotificationAddresses/OrganizationNotificationAddressesServiceTests.cs
+++ b/test/Altinn.Profile.Tests/Profile.Core/OrganizationNotificationAddresses/OrganizationNotificationAddressesServiceTests.cs
@@ -51,8 +51,6 @@ namespace Altinn.Profile.Tests.Profile.Core.OrganizationNotificationAddresses
                 }
             ];
             _repository = new Mock<IOrganizationNotificationAddressRepository>();
-            _repository.Setup(r => r.GetOrganizationsAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(_testdata);
 
             _updateClient = new Mock<IOrganizationNotificationAddressUpdateClient>();
             _registerClient = new Mock<IRegisterClient>();
@@ -64,6 +62,10 @@ namespace Altinn.Profile.Tests.Profile.Core.OrganizationNotificationAddresses
         public async Task GetOrganizationNotificationAddresses_WhenFound_Returns()
         {
             var lookup = new List<string>() { "123456789" };
+
+            // Arrange
+            _repository.Setup(r => r.GetOrganizationsAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(_testdata);
 
             // Act
             var result = await _service.GetOrganizationNotificationAddresses(lookup, CancellationToken.None);
@@ -112,18 +114,25 @@ namespace Altinn.Profile.Tests.Profile.Core.OrganizationNotificationAddresses
         public async Task GetOrganizationNotificationAddresses_WhenLookingUpMainUnitAndFound_ReturnsAddressFromMainUnit()
         {
             var lookup = new List<string>() { "111111111" };
+            var parentUnit = "123456789";
 
-            _repository.SetupSequence(r => r.GetOrganizationsAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync([])
-                .ReturnsAsync(_testdata.Where(o => o.OrganizationNumber == "123456789"));
+            _repository.Setup(r => r.GetOrganizationsAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync([]);
+            _repository.SetupSequence(r => r.GetOrganizationAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(_testdata.Where(o => o.OrganizationNumber == parentUnit).First());
+
             _registerClient.Setup(r => r.GetMainUnit(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync((string)null);
+                .ReturnsAsync(parentUnit);
 
             // Act
             var result = await _service.GetOrganizationNotificationAddresses(lookup, CancellationToken.None, true);
 
             // Assert
-            Assert.Empty(result);
+            Assert.NotEmpty(result);
+            Assert.Single(result);
+            var matchedOrg1 = result.FirstOrDefault();
+            Assert.Equal(lookup.First(), matchedOrg1.OrganizationNumber);
+            Assert.Equal(parentUnit, matchedOrg1.AddressOrigin);
         }
 
         [Fact]
@@ -147,8 +156,8 @@ namespace Altinn.Profile.Tests.Profile.Core.OrganizationNotificationAddresses
         public async Task CreateNotificationAddress_WhenDuplicateIsFound_ReturnsOrganizationWithoutUpdate()
         {
             // Arrange
-            _repository.Setup(r => r.GetOrganizationsAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(_testdata.Where(o => o.OrganizationNumber == "123456789"));
+            _repository.Setup(r => r.GetOrganizationAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(_testdata.First(o => o.OrganizationNumber == "123456789"));
 
             // Act
             var result = await _service.CreateNotificationAddress("123456789", new NotificationAddress { FullAddress = "test@test.com", AddressType = AddressType.Email }, CancellationToken.None);
@@ -184,6 +193,9 @@ namespace Altinn.Profile.Tests.Profile.Core.OrganizationNotificationAddresses
         public async Task UpdateNotificationAddress_SuccessfulUpdate_ReturnsUpdatedAddress()
         {
             // Arrange
+            _repository.Setup(r => r.GetOrganizationAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(_testdata.First(o => o.OrganizationNumber == "123456789"));
+
             _updateClient.Setup(c => c.UpdateNotificationAddress(It.IsAny<string>(), It.IsAny<NotificationAddress>(), It.IsAny<string>()))
                 .ReturnsAsync("registry-id");
 
@@ -201,6 +213,9 @@ namespace Altinn.Profile.Tests.Profile.Core.OrganizationNotificationAddresses
         public async Task DeleteNotificationAddress_SuccessfulDeletion_ReturnsDeletedAddress()
         {
             // Arrange
+            _repository.Setup(r => r.GetOrganizationAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(_testdata.First(o => o.OrganizationNumber == "123456789"));
+
             _updateClient.Setup(c => c.DeleteNotificationAddress(It.IsAny<string>()))
                 .ReturnsAsync("registry-id");
 
@@ -218,8 +233,8 @@ namespace Altinn.Profile.Tests.Profile.Core.OrganizationNotificationAddresses
         public async Task DeleteNotificationAddress_WhenTryingToDeleteLastAddress_ThrowsInvalidOperationException()
         {
             // Arrange
-            _repository.Setup(r => r.GetOrganizationsAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync([new Organization { OrganizationNumber = "123456789", NotificationAddresses = [new NotificationAddress { NotificationAddressID = 1 }] }]);
+            _repository.Setup(r => r.GetOrganizationAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Organization { OrganizationNumber = "123456789", NotificationAddresses = [new NotificationAddress { NotificationAddressID = 1 }] });
 
             // Act
             var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => _service.DeleteNotificationAddress("123456789", 1, CancellationToken.None));

--- a/test/Altinn.Profile.Tests/Profile.Core/OrganizationNotificationAddresses/OrganizationNotificationAddressesServiceTests.cs
+++ b/test/Altinn.Profile.Tests/Profile.Core/OrganizationNotificationAddresses/OrganizationNotificationAddressesServiceTests.cs
@@ -119,7 +119,7 @@ namespace Altinn.Profile.Tests.Profile.Core.OrganizationNotificationAddresses
             _repository.Setup(r => r.GetOrganizationsAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync([]);
             _repository.SetupSequence(r => r.GetOrganizationAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(_testdata.Where(o => o.OrganizationNumber == parentUnit).First());
+                .ReturnsAsync(_testdata.First(o => o.OrganizationNumber == parentUnit));
 
             _registerClient.Setup(r => r.GetMainUnit(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(parentUnit);

--- a/test/Altinn.Profile.Tests/Profile.Core/OrganizationNotificationAddresses/OrganizationNotificationAddressesServiceTests.cs
+++ b/test/Altinn.Profile.Tests/Profile.Core/OrganizationNotificationAddresses/OrganizationNotificationAddressesServiceTests.cs
@@ -55,7 +55,7 @@ namespace Altinn.Profile.Tests.Profile.Core.OrganizationNotificationAddresses
 
             _updateClient = new Mock<IOrganizationNotificationAddressUpdateClient>();
 
-            _service = new OrganizationNotificationAddressesService(_repository.Object, _updateClient.Object);
+            _service = new OrganizationNotificationAddressesService(_repository.Object, _updateClient.Object, null);
         }
 
         [Fact]

--- a/test/Altinn.Profile.Tests/Profile.Integrations/OrganizationNotificationAddressTests/OrganizationNotificationAddressRepositoryTests.cs
+++ b/test/Altinn.Profile.Tests/Profile.Integrations/OrganizationNotificationAddressTests/OrganizationNotificationAddressRepositoryTests.cs
@@ -86,7 +86,7 @@ public class OrganizationNotificationAddressRepositoryTests : IDisposable
         SeedDatabase(organizations, notificationAddresses);
 
         // Act
-        var matchedOrg = await _repository.GetOrganizationAsync("123456789");
+        var matchedOrg = await _repository.GetOrganizationDEAsync("123456789", CancellationToken.None);
 
         var expectedOrg = organizations
             .Find(p => p.RegistryOrganizationNumber == "123456789");
@@ -103,7 +103,7 @@ public class OrganizationNotificationAddressRepositoryTests : IDisposable
     {
         // Arrange - skip seeding the DB with data
         // Act
-        var matchedOrg = await _repository.GetOrganizationAsync("111111111");
+        var matchedOrg = await _repository.GetOrganizationDEAsync("111111111", CancellationToken.None);
 
         // Assert
         Assert.Null(matchedOrg);
@@ -120,8 +120,8 @@ public class OrganizationNotificationAddressRepositoryTests : IDisposable
 
         // Act
         var numberOfUpdatedRows = await _repository.SyncNotificationAddressesAsync(changes);
-        var updatedOrg1 = await _repository.GetOrganizationAsync("123456789");
-        var updatedOrg2 = await _repository.GetOrganizationAsync("920212345");
+        var updatedOrg1 = await _repository.GetOrganizationDEAsync("123456789", CancellationToken.None);
+        var updatedOrg2 = await _repository.GetOrganizationDEAsync("920212345", CancellationToken.None);
 
         // Assert
         Assert.NotNull(updatedOrg1);
@@ -151,8 +151,8 @@ public class OrganizationNotificationAddressRepositoryTests : IDisposable
 
         // Act
         var numberOfUpdatedRows = await _repository.SyncNotificationAddressesAsync(changesIncludingMissingPhonePrefix);
-        var updatedOrg1 = await _repository.GetOrganizationAsync("920254321");
-        var updatedOrg2 = await _repository.GetOrganizationAsync("920212345");
+        var updatedOrg1 = await _repository.GetOrganizationDEAsync("920254321", CancellationToken.None);
+        var updatedOrg2 = await _repository.GetOrganizationDEAsync("920212345", CancellationToken.None);
 
         // Assert
         Assert.NotNull(updatedOrg1);
@@ -175,7 +175,7 @@ public class OrganizationNotificationAddressRepositoryTests : IDisposable
 
         // Act
         var numberOfUpdatedAddresses = await _repository.SyncNotificationAddressesAsync(changeWithDelete);
-        var updatedOrg = await _repository.GetOrganizationAsync(orgToUpdate);
+        var updatedOrg = await _repository.GetOrganizationDEAsync(orgToUpdate, CancellationToken.None);
 
         // Assert
         Assert.Single(updatedOrg.NotificationAddresses);
@@ -194,7 +194,7 @@ public class OrganizationNotificationAddressRepositoryTests : IDisposable
         // Act - call delete twice
         await _repository.SyncNotificationAddressesAsync(changes);
         var numberOfUpdatedAddresses = await _repository.SyncNotificationAddressesAsync(changes);
-        var updatedOrg = await _repository.GetOrganizationAsync("987654321");
+        var updatedOrg = await _repository.GetOrganizationDEAsync("987654321", CancellationToken.None);
 
         // Assert
         Assert.Single(updatedOrg.NotificationAddresses);
@@ -216,7 +216,7 @@ public class OrganizationNotificationAddressRepositoryTests : IDisposable
         var numberOfUpdatedAddresses = await _repository.SyncNotificationAddressesAsync(changes);
 
         // Assert
-        var actualOrg = await _repository.GetOrganizationAsync("987654321");
+        var actualOrg = await _repository.GetOrganizationDEAsync("987654321", CancellationToken.None);
         Assert.Equal(2, actualOrg.NotificationAddresses.Count);
 
         var actualUpdatedAddress = actualOrg.NotificationAddresses.Find(address => address.RegistryID == identifierForAddressToUpdate);

--- a/test/Altinn.Profile.Tests/Profile.Integrations/OrganizationNotificationAddressTests/OrganizationNotificationAddressRepositoryTests.cs
+++ b/test/Altinn.Profile.Tests/Profile.Integrations/OrganizationNotificationAddressTests/OrganizationNotificationAddressRepositoryTests.cs
@@ -228,6 +228,29 @@ public class OrganizationNotificationAddressRepositoryTests : IDisposable
     }
 
     [Fact]
+    public async Task GetSingleOrganization_WhenFound_ReturnsWithNotificationAddresses()
+    {
+        // Arrange
+        var (organizations, notificationAddresses) = OrganizationNotificationAddressTestData.GetNotificationAddresses();
+        SeedDatabase(organizations, notificationAddresses);
+
+        var orgNumberLookup = "123456789";
+
+        var expectedOrg1 = organizations
+            .Find(p => p.RegistryOrganizationNumber == "123456789");
+
+        // Act
+        var result = await _repository.GetOrganizationAsync(orgNumberLookup, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.IsType<Organization>(result);
+        Assert.NotEmpty(result.NotificationAddresses);
+        Assert.Equal(result.NotificationAddresses.Count, expectedOrg1.NotificationAddresses.Count);
+        Assert.Equal(result.OrganizationNumber, expectedOrg1.RegistryOrganizationNumber);
+    }
+
+    [Fact]
     public async Task GetOrganizations_WhenFound_ReturnsWithNotificationAddresses()
     {
         // Arrange

--- a/test/Altinn.Profile.Tests/Profile.Integrations/OrganizationNotificationAddressTests/RegisterClientTests.cs
+++ b/test/Altinn.Profile.Tests/Profile.Integrations/OrganizationNotificationAddressTests/RegisterClientTests.cs
@@ -33,7 +33,7 @@ namespace Altinn.Profile.Tests.Profile.Integrations.OrganizationNotificationAddr
 
             _tokenGenMock = new Mock<IAccessTokenGenerator>();
             _tokenGenMock.Setup(t => t.GenerateAccessToken(It.IsAny<string>(), It.IsAny<string>()))
-                         .Returns((string)null);
+                         .Returns("token");
 
             _loggerMock = new Mock<ILogger<RegisterClient>>();
         }
@@ -132,6 +132,24 @@ namespace Altinn.Profile.Tests.Profile.Integrations.OrganizationNotificationAddr
             var handler = CreateHandler(response);
             _httpClient = new HttpClient(handler);
 
+            var client = new RegisterClient(_httpClient, _settingsMock.Object, _tokenGenMock.Object, _loggerMock.Object);
+
+            // Act
+            var result = await client.GetMainUnit("111111111", CancellationToken.None);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task GetMainUnit_WhenNotAbleToGenerateToken_ReturnsNull()
+        {
+            // Arrange
+            var response = new HttpResponseMessage(HttpStatusCode.OK);
+            var handler = CreateHandler(response);
+            _httpClient = new HttpClient(handler);
+            _tokenGenMock.Setup(t => t.GenerateAccessToken(It.IsAny<string>(), It.IsAny<string>()))
+                         .Returns((string)null); 
             var client = new RegisterClient(_httpClient, _settingsMock.Object, _tokenGenMock.Object, _loggerMock.Object);
 
             // Act

--- a/test/Altinn.Profile.Tests/Profile.Integrations/OrganizationNotificationAddressTests/RegisterClientTests.cs
+++ b/test/Altinn.Profile.Tests/Profile.Integrations/OrganizationNotificationAddressTests/RegisterClientTests.cs
@@ -2,6 +2,7 @@
 using System.Net;
 using System.Net.Http;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
 using Altinn.Common.AccessTokenClient.Services;
@@ -21,10 +22,6 @@ namespace Altinn.Profile.Tests.Profile.Integrations.OrganizationNotificationAddr
         private readonly Mock<ILogger<RegisterClient>> _loggerMock;
         private HttpClient _httpClient;
         private const string _testBaseUrl = "https://api.test.local/";
-        private readonly JsonSerializerOptions _serializerOptions = new()
-        {
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        };
 
         public RegisterClientTests()
         {
@@ -94,8 +91,9 @@ namespace Altinn.Profile.Tests.Profile.Integrations.OrganizationNotificationAddr
             Assert.Equal(HttpMethod.Post, sentRequest.Method);
             Assert.IsType<StringContent>(sentRequest.Content);
             var requestContent = await sentRequest.Content.ReadAsStringAsync();
-            var sentPayload = JsonSerializer.Deserialize<LookupMainUnitRequest>(requestContent, _serializerOptions);
-            Assert.Equal("urn:altinn:organization:identifier-no:111111111", sentPayload.Data);
+            JsonNode sentPayload = JsonNode.Parse(requestContent);
+            string sentData = (string)sentPayload["data"];
+            Assert.Equal("urn:altinn:organization:identifier-no:111111111", sentData);
             Assert.Equal(new Uri(_testBaseUrl + "v2/internal/parties/main-units"), sentRequest.RequestUri);
         }
 

--- a/test/Altinn.Profile.Tests/Profile.Integrations/OrganizationNotificationAddressTests/RegisterClientTests.cs
+++ b/test/Altinn.Profile.Tests/Profile.Integrations/OrganizationNotificationAddressTests/RegisterClientTests.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Altinn.Common.AccessTokenClient.Services;
+using Altinn.Profile.Integrations.Register;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace Altinn.Profile.Tests.Profile.Integrations.OrganizationNotificationAddressTests
+{
+    public class RegisterClientTests
+    {
+        private readonly Mock<IOptions<RegisterSettings>> _settingsMock;
+        private readonly Mock<IAccessTokenGenerator> _tokenGenMock;
+        private readonly Mock<ILogger<RegisterClient>> _loggerMock;
+        private HttpClient _httpClient;
+        private const string _testBaseUrl = "https://api.test.local/";
+
+        public RegisterClientTests()
+        {
+            _settingsMock = new Mock<IOptions<RegisterSettings>>();
+            _settingsMock.Setup(s => s.Value).Returns(new RegisterSettings { ApiRegisterEndpoint = _testBaseUrl });
+
+            _tokenGenMock = new Mock<IAccessTokenGenerator>();
+            _tokenGenMock.Setup(t => t.GenerateAccessToken(It.IsAny<string>(), It.IsAny<string>()))
+                         .Returns((string?)null);
+
+            _loggerMock = new Mock<ILogger<RegisterClient>>();
+        }
+
+        private static HttpMessageHandler CreateHandler(
+            HttpResponseMessage response,
+            Action<HttpRequestMessage>? requestCallback = null,
+            Action<CancellationToken>? cancelCallback = null)
+        {
+            var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            handlerMock.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync((HttpRequestMessage req, CancellationToken ct) =>
+                {
+                    requestCallback?.Invoke(req);
+                    cancelCallback?.Invoke(ct);
+                    return response;
+                });
+            return handlerMock.Object;
+        }
+
+        [Fact]
+        public void Constructor_NullLogger_ThrowsArgumentNullException()
+        {
+            var handler = CreateHandler(new HttpResponseMessage(HttpStatusCode.OK));
+            var httpClient = new HttpClient(handler);
+            Assert.Throws<ArgumentNullException>(() =>
+                new RegisterClient(httpClient, _settingsMock.Object, _tokenGenMock.Object, null!));
+        }
+
+        [Fact]
+        public void Constructor_BaseAddressIsSetFromSettings()
+        {
+            var handler = CreateHandler(new HttpResponseMessage(HttpStatusCode.OK));
+            _httpClient = new HttpClient(handler);
+            var client = new RegisterClient(_httpClient, _settingsMock.Object, _tokenGenMock.Object, _loggerMock.Object);
+            Assert.Equal(new Uri(_testBaseUrl), _httpClient.BaseAddress);
+        }
+
+        [Fact]
+        public async Task GetMainUnit_SingleEntry_ReturnsOrganizationRecord()
+        {
+            // Arrange
+            var responseContent = JsonSerializer.Serialize(new LookupMainUnitResponse
+            {
+                Data = [new() { OrganizationIdentifier = "123456789" }]
+            });
+
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(responseContent, System.Text.Encoding.UTF8, "application/json")
+            };
+            HttpRequestMessage? sentRequest = null;
+            var handler = CreateHandler(response, req => sentRequest = req);
+            _httpClient = new HttpClient(handler);
+            var client = new RegisterClient(_httpClient, _settingsMock.Object, _tokenGenMock.Object, _loggerMock.Object);
+
+            // Act
+            var result = await client.GetMainUnit("111111111", CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("123456789", result);
+            Assert.Equal(HttpMethod.Post, sentRequest.Method);
+            Assert.Equal(new Uri(_testBaseUrl + "v2/internal/parties/main-units"), sentRequest.RequestUri);
+        }
+
+        [Fact]
+        public async Task GetMainUnit_WhenNothingFound_ReturnsNull()
+        {
+            // Arrange
+            var responseContent = JsonSerializer.Serialize(new LookupMainUnitResponse
+            {
+                Data = []
+            });
+
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(responseContent, System.Text.Encoding.UTF8, "application/json")
+            };
+            HttpRequestMessage? sentRequest = null;
+            var handler = CreateHandler(response, req => sentRequest = req);
+            _httpClient = new HttpClient(handler);
+            var client = new RegisterClient(_httpClient, _settingsMock.Object, _tokenGenMock.Object, _loggerMock.Object);
+
+            // Act
+            var result = await client.GetMainUnit("111111111", CancellationToken.None);
+
+            // Assert
+            Assert.Null(result);
+        }
+    }
+}

--- a/test/Altinn.Profile.Tests/Profile.Integrations/OrganizationNotificationAddressTests/RegisterClientTests.cs
+++ b/test/Altinn.Profile.Tests/Profile.Integrations/OrganizationNotificationAddressTests/RegisterClientTests.cs
@@ -59,15 +59,6 @@ namespace Altinn.Profile.Tests.Profile.Integrations.OrganizationNotificationAddr
         }
 
         [Fact]
-        public void Constructor_NullLogger_ThrowsArgumentNullException()
-        {
-            var handler = CreateHandler(new HttpResponseMessage(HttpStatusCode.OK));
-            var httpClient = new HttpClient(handler);
-            Assert.Throws<ArgumentNullException>(() =>
-                new RegisterClient(httpClient, _settingsMock.Object, _tokenGenMock.Object, null!));
-        }
-
-        [Fact]
         public void Constructor_BaseAddressIsSetFromSettings()
         {
             var handler = CreateHandler(new HttpResponseMessage(HttpStatusCode.OK));
@@ -121,8 +112,8 @@ namespace Altinn.Profile.Tests.Profile.Integrations.OrganizationNotificationAddr
             {
                 Content = new StringContent(responseContent, System.Text.Encoding.UTF8, "application/json")
             };
-            HttpRequestMessage sentRequest = null;
-            var handler = CreateHandler(response, req => sentRequest = req);
+
+            var handler = CreateHandler(response);
             _httpClient = new HttpClient(handler);
             var client = new RegisterClient(_httpClient, _settingsMock.Object, _tokenGenMock.Object, _loggerMock.Object);
 
@@ -134,12 +125,11 @@ namespace Altinn.Profile.Tests.Profile.Integrations.OrganizationNotificationAddr
         }
 
         [Fact]
-        public async Task GetMainUnit_WhenRegisterReturns500_ReturnsNullAnLogsWarning()
+        public async Task GetMainUnit_WhenRegisterReturns500_ReturnsNull()
         {
             // Arrange
             var response = new HttpResponseMessage(HttpStatusCode.InternalServerError);
-            HttpRequestMessage sentRequest = null;
-            var handler = CreateHandler(response, req => sentRequest = req);
+            var handler = CreateHandler(response);
             _httpClient = new HttpClient(handler);
 
             var client = new RegisterClient(_httpClient, _settingsMock.Object, _tokenGenMock.Object, _loggerMock.Object);

--- a/test/Altinn.Profile.Tests/Profile.Integrations/Register/LookupMainUnitRequestTests.cs
+++ b/test/Altinn.Profile.Tests/Profile.Integrations/Register/LookupMainUnitRequestTests.cs
@@ -19,16 +19,5 @@ namespace Altinn.Profile.Tests.Profile.Integrations.Register
             Assert.NotNull(result);
             Assert.Equal($"urn:altinn:organization:identifier-no:{orgNumber}", result.Data);
         }
-
-        [Theory]
-        [InlineData(null)]
-        [InlineData("")]
-        [InlineData("   ")]
-        public void Create_NullOrWhitespaceOrgNumber_ThrowsArgumentException(string orgNumber)
-        {
-            // Act & Assert
-            var ex = Assert.Throws<ArgumentException>(() => LookupMainUnitRequest.Create(orgNumber!));
-            Assert.Equal("Organization number cannot be null or empty. (Parameter 'orgNumber')", ex.Message);
-        }
     }
 }

--- a/test/Altinn.Profile.Tests/Profile.Integrations/Register/LookupMainUnitRequestTests.cs
+++ b/test/Altinn.Profile.Tests/Profile.Integrations/Register/LookupMainUnitRequestTests.cs
@@ -13,7 +13,7 @@ namespace Altinn.Profile.Tests.Profile.Integrations.Register
             var orgNumber = "123456789";
 
             // Act
-            var result = LookupMainUnitRequest.Create(orgNumber);
+            var result = new LookupMainUnitRequest(orgNumber);
 
             // Assert
             Assert.NotNull(result);

--- a/test/Altinn.Profile.Tests/Profile.Integrations/Register/LookupMainUnitRequestTests.cs
+++ b/test/Altinn.Profile.Tests/Profile.Integrations/Register/LookupMainUnitRequestTests.cs
@@ -24,7 +24,7 @@ namespace Altinn.Profile.Tests.Profile.Integrations.Register
         [InlineData(null)]
         [InlineData("")]
         [InlineData("   ")]
-        public void Create_NullOrWhitespaceOrgNumber_ThrowsArgumentException(string? orgNumber)
+        public void Create_NullOrWhitespaceOrgNumber_ThrowsArgumentException(string orgNumber)
         {
             // Act & Assert
             var ex = Assert.Throws<ArgumentException>(() => LookupMainUnitRequest.Create(orgNumber!));

--- a/test/Altinn.Profile.Tests/Profile.Integrations/Register/LookupMainUnitRequestTests.cs
+++ b/test/Altinn.Profile.Tests/Profile.Integrations/Register/LookupMainUnitRequestTests.cs
@@ -1,0 +1,34 @@
+using System;
+using Altinn.Profile.Integrations.Register;
+using Xunit;
+
+namespace Altinn.Profile.Tests.Profile.Integrations.Register
+{
+    public class LookupMainUnitRequestTests
+    {
+        [Fact]
+        public void Create_ValidOrgNumber_SetsDataCorrectly()
+        {
+            // Arrange
+            var orgNumber = "123456789";
+
+            // Act
+            var result = LookupMainUnitRequest.Create(orgNumber);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal($"urn:altinn:organization:identifier-no:{orgNumber}", result.Data);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void Create_NullOrWhitespaceOrgNumber_ThrowsArgumentException(string? orgNumber)
+        {
+            // Act & Assert
+            var ex = Assert.Throws<ArgumentException>(() => LookupMainUnitRequest.Create(orgNumber!));
+            Assert.Equal("Organization number cannot be null or empty. (Parameter 'orgNumber')", ex.Message);
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* https://dev.azure.com/brreg/altinn-studio-ops/_git/altinn-studio-ops/pullrequest/1361?_a=files
* If an organization is missing notification addresses -> check if that unit has a main unit. 

## Related Issue(s)
- #297 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for retrieving notification addresses from a parent (main) organization unit if none are found for the requested organization.
  - Responses now include an "AddressOrigin" field to indicate the source organization number of the address.
  - Introduced integration with Altinn Register service to fetch main unit information for organizations.

- **Documentation**
  - Updated method documentation to reflect new parameters and behavior.

- **Tests**
  - Enhanced test coverage to validate the new "AddressOrigin" property and parent organization lookup behavior.
  - Added tests for the RegisterClient integration and main unit lookup scenarios.
  - Added input validation tests for organization number lists.

- **Chores**
  - Added new configuration options and services for register service integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->