### PR TITLE
Feature/297 main unit lookup suggestion

### DIFF
--- a/src/Altinn.Profile.Integrations/Register/LookupMainUnitRequest.cs
+++ b/src/Altinn.Profile.Integrations/Register/LookupMainUnitRequest.cs
@@ -5,31 +5,16 @@ namespace Altinn.Profile.Integrations.Register
     /// <summary>
     /// Request model for the lookup resource for main units
     /// </summary>
-    public class LookupMainUnitRequest
+    /// <remarks>
+    /// Initializes a new instance of the <see cref="LookupMainUnitRequest"/> class.
+    /// </remarks>
+    /// <param name="orgNumber">Organization Number of the organization to lookup parent units for</param>
+    public class LookupMainUnitRequest(string orgNumber)
     {
         /// <summary>
         /// Data containing the urn of the organization with either orgNumber, partyId or PartyUuid.
         /// </summary>
         [JsonPropertyName("data")]
-        public string? Data { get; init; }
-
-        /// <summary>
-        /// Set the OrgNumber in the Data property of the request.
-        /// </summary>
-        /// <param name="orgNumber">Organization Number of the organization to lookup parent units for</param>
-        public static LookupMainUnitRequest Create(string orgNumber)
-        {
-            if (string.IsNullOrWhiteSpace(orgNumber))
-            {
-                throw new ArgumentException("Organization number cannot be null or empty.", nameof(orgNumber));
-            }
-
-            var request = new LookupMainUnitRequest
-            {
-                Data = $"urn:altinn:organization:identifier-no:{orgNumber}"
-            };
-
-            return request;
-        }
+        public string Data { get; init; } = $"urn:altinn:organization:identifier-no:{orgNumber}";
     }
 }

--- a/src/Altinn.Profile.Integrations/Register/RegisterClient.cs
+++ b/src/Altinn.Profile.Integrations/Register/RegisterClient.cs
@@ -43,7 +43,7 @@ public class RegisterClient : IRegisterClient
     /// <inheritdoc/>
     public async Task<string?> GetMainUnit(string orgNumber, CancellationToken cancellationToken)
     {
-        var request = LookupMainUnitRequest.Create(orgNumber);
+        var request = new LookupMainUnitRequest(orgNumber);
         var json = JsonSerializer.Serialize(request, _options);
         var stringContent = new StringContent(json, Encoding.UTF8, "application/json");
 

--- a/src/Altinn.Profile/Controllers/OrgNotificationAddressController.cs
+++ b/src/Altinn.Profile/Controllers/OrgNotificationAddressController.cs
@@ -37,7 +37,7 @@ namespace Altinn.Profile.Controllers
         {
             if (!ModelState.IsValid)
             {
-                return BadRequest(ModelState);
+                return ValidationProblem(ModelState);
             }
 
             var organizations = await _notificationAddressService.GetOrganizationNotificationAddresses(orgContactPointLookup.OrganizationNumbers, cancellationToken, true);

--- a/src/Altinn.Profile/Models/OrgNotificationAddressRequest.cs
+++ b/src/Altinn.Profile/Models/OrgNotificationAddressRequest.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
 using System.Text.Json.Serialization;
 
 namespace Altinn.Profile.Models
@@ -6,12 +8,21 @@ namespace Altinn.Profile.Models
     /// <summary>
     /// A class describing the query model for contact points for organizations
     /// </summary>
-    public class OrgNotificationAddressRequest
+    public class OrgNotificationAddressRequest: IValidatableObject
     {
         /// <summary>
         /// Gets or sets the list of organization numbers to lookup contact points for
         /// </summary>
         [JsonPropertyName("organizationNumbers")]
         public List<string> OrganizationNumbers { get; set; } = [];
+
+        /// <inheritdoc/>
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            if (OrganizationNumbers.Any(string.IsNullOrWhiteSpace))
+            {
+                yield return new ValidationResult("organizationNumbers contains one or more invalid (null or whitespace) values", [nameof(OrganizationNumbers)]);
+            }
+        }
     }
 }

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/OrgNotificationAddressesControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/OrgNotificationAddressesControllerTests.cs
@@ -262,5 +262,30 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
             var actual = JsonSerializer.Deserialize<OrgNotificationAddressesResponse>(responseContent, _serializerOptions);
             Assert.Empty(actual.ContactPointsList);
         }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public async Task PostLookup_WhenOrgListContainsInvalidNos_Returns400(string invalidOrgNo)
+        {
+            // Arrange
+            OrgNotificationAddressRequest input = new()
+            {
+                OrganizationNumbers = ["aValidOrg", invalidOrgNo],
+            };
+
+            HttpClient client = _webApplicationFactorySetup.GetTestServerClient();
+            HttpRequestMessage httpRequestMessage = new(HttpMethod.Post, "/profile/api/v1/organizations/notificationaddresses/lookup")
+            {
+                Content = new StringContent(JsonSerializer.Serialize(input, _serializerOptions), System.Text.Encoding.UTF8, "application/json")
+            };
+
+            // Act
+            HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        }
     }
 }

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/OrgNotificationAddressesControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/OrgNotificationAddressesControllerTests.cs
@@ -272,7 +272,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
             // Arrange
             OrgNotificationAddressRequest input = new()
             {
-                OrganizationNumbers = ["aValidOrg", invalidOrgNo],
+                OrganizationNumbers = ["987654321", "aValidOrg", invalidOrgNo],
             };
 
             HttpClient client = _webApplicationFactorySetup.GetTestServerClient();

--- a/test/Altinn.Profile.Tests/Profile.Integrations/OrganizationNotificationAddressTests/RegisterClientTests.cs
+++ b/test/Altinn.Profile.Tests/Profile.Integrations/OrganizationNotificationAddressTests/RegisterClientTests.cs
@@ -2,6 +2,7 @@
 using System.Net;
 using System.Net.Http;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
 using Altinn.Common.AccessTokenClient.Services;
@@ -21,10 +22,6 @@ namespace Altinn.Profile.Tests.Profile.Integrations.OrganizationNotificationAddr
         private readonly Mock<ILogger<RegisterClient>> _loggerMock;
         private HttpClient _httpClient;
         private const string _testBaseUrl = "https://api.test.local/";
-        private readonly JsonSerializerOptions _serializerOptions = new()
-        {
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        };
 
         public RegisterClientTests()
         {
@@ -94,8 +91,9 @@ namespace Altinn.Profile.Tests.Profile.Integrations.OrganizationNotificationAddr
             Assert.Equal(HttpMethod.Post, sentRequest.Method);
             Assert.IsType<StringContent>(sentRequest.Content);
             var requestContent = await sentRequest.Content.ReadAsStringAsync();
-            var sentPayload = JsonSerializer.Deserialize<LookupMainUnitRequest>(requestContent, _serializerOptions);
-            Assert.Equal("urn:altinn:organization:identifier-no:111111111", sentPayload.Data);
+            JsonNode sentPayload = JsonNode.Parse(requestContent);
+            string sentData = (string)sentPayload["data"];
+            Assert.Equal("urn:altinn:organization:identifier-no:111111111", sentData);
             Assert.Equal(new Uri(_testBaseUrl + "v2/internal/parties/main-units"), sentRequest.RequestUri);
         }
 

--- a/test/Altinn.Profile.Tests/Profile.Integrations/Register/LookupMainUnitRequestTests.cs
+++ b/test/Altinn.Profile.Tests/Profile.Integrations/Register/LookupMainUnitRequestTests.cs
@@ -13,22 +13,11 @@ namespace Altinn.Profile.Tests.Profile.Integrations.Register
             var orgNumber = "123456789";
 
             // Act
-            var result = LookupMainUnitRequest.Create(orgNumber);
+            var result = new LookupMainUnitRequest(orgNumber);
 
             // Assert
             Assert.NotNull(result);
             Assert.Equal($"urn:altinn:organization:identifier-no:{orgNumber}", result.Data);
-        }
-
-        [Theory]
-        [InlineData(null)]
-        [InlineData("")]
-        [InlineData("   ")]
-        public void Create_NullOrWhitespaceOrgNumber_ThrowsArgumentException(string orgNumber)
-        {
-            // Act & Assert
-            var ex = Assert.Throws<ArgumentException>(() => LookupMainUnitRequest.Create(orgNumber!));
-            Assert.Equal("Organization number cannot be null or empty. (Parameter 'orgNumber')", ex.Message);
         }
     }
 }


### PR DESCRIPTION
- Add controller level validation of null/whitespace in org numbers, including tests
- RegisterClientTests:
  - Do non-typed deserialization of request (just parse and check the `data` field) to avoid special object construction in `LookupMainUnitRequest`
- LookupMainUnitRequest:
  - Skip org no. argument check on null/whitespace
  - Use primary constructor rather than static Create 
  - Make `Data` property non-nullable