### PR TITLE
Add PUT method for professional notification addresses

### DIFF
--- a/src/Altinn.Profile.Core/Integrations/IProfessionalNotificationsRepository.cs
+++ b/src/Altinn.Profile.Core/Integrations/IProfessionalNotificationsRepository.cs
@@ -14,11 +14,11 @@ namespace Altinn.Profile.Core.Integrations
         /// <param name="partyUuid">The UUID of the party.</param>
         /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
         /// <returns>A task with the return value containing the identified notification addresses or null if there are none.</returns>
-        Task<UserPartyContactInfo?> GetNotificationAddress(int userId, Guid partyUuid, CancellationToken cancellationToken);
+        Task<UserPartyContactInfo?> GetNotificationAddressAsync(int userId, Guid partyUuid, CancellationToken cancellationToken);
 
         /// <summary>
         /// Adds a new or updates an existing notification address for a user and party.
-        /// Returns <c>true</c> if an existing record was updated, <c>false</c> if a new record was created.
+        /// Returns <c>true</c> if a new record was created, <c>false</c> if an existing record was updated.
         /// </summary>
         /// <param name="contactInfo">The contact info to be added</param>
         /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>

--- a/src/Altinn.Profile.Core/Integrations/IProfessionalNotificationsRepository.cs
+++ b/src/Altinn.Profile.Core/Integrations/IProfessionalNotificationsRepository.cs
@@ -14,6 +14,17 @@ namespace Altinn.Profile.Core.Integrations
         /// <param name="partyUuid">The UUID of the party.</param>
         /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
         /// <returns>A task with the return value containing the identified notification addresses or null if there are none.</returns>
-        Task<UserPartyContactInfo?> GetNotificationAddresses(int userId, Guid partyUuid, CancellationToken cancellationToken);
+        Task<UserPartyContactInfo?> GetNotificationAddress(int userId, Guid partyUuid, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Adds a new or updates an existing notification address for a user and party.
+        /// Returns <c>true</c> if an existing record was updated, <c>false</c> if a new record was created.
+        /// </summary>
+        /// <param name="contactInfo">The contact info to be added</param>
+        /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+        /// <returns>A <see cref="Task"/> containing a boolean value indicating if the value was added or not.         
+        /// Returns <c>true</c> if a new record was added, <c>false</c> if an existing record was updated.
+        /// </returns>
+        Task<bool> AddOrUpdateNotificationAddressAsync(UserPartyContactInfo contactInfo, CancellationToken cancellationToken);
     }
 }

--- a/src/Altinn.Profile.Core/ProfessionalNotificationAddresses/IProfessionalNotificationsService.cs
+++ b/src/Altinn.Profile.Core/ProfessionalNotificationAddresses/IProfessionalNotificationsService.cs
@@ -12,17 +12,17 @@
         /// <param name="partyUuid">The UUID of the party.</param>
         /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
         /// <returns>A task with the return value containing the identified notification addresses or null if there are none.</returns>
-        Task<UserPartyContactInfo?> GetNotificationAddresses(int userId, Guid partyUuid, CancellationToken cancellationToken);
+        Task<UserPartyContactInfo?> GetNotificationAddressAsync(int userId, Guid partyUuid, CancellationToken cancellationToken);
 
         /// <summary>
         /// Adds a new or updates an existing notification address for a user and party.
-        /// Returns <c>true</c> if an existing record was updated, <c>false</c> if a new record was created.
+        /// Returns <c>true</c> if a new record was created, <c>false</c> if an existing record was updated.
         /// </summary>
         /// <param name="contactInfo">The contact info to be added</param>
         /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
         /// <returns>A <see cref="Task"/> containing a boolean value indicating if the value was added or not.         
         /// Returns <c>true</c> if a new record was added, <c>false</c> if an existing record was updated.
         /// </returns>
-        Task<bool> AddOrUpdateNotificationAddressesAsync(UserPartyContactInfo contactInfo, CancellationToken cancellationToken);
+        Task<bool> AddOrUpdateNotificationAddressAsync(UserPartyContactInfo contactInfo, CancellationToken cancellationToken);
     }
 }

--- a/src/Altinn.Profile.Core/ProfessionalNotificationAddresses/IProfessionalNotificationsService.cs
+++ b/src/Altinn.Profile.Core/ProfessionalNotificationAddresses/IProfessionalNotificationsService.cs
@@ -13,5 +13,16 @@
         /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
         /// <returns>A task with the return value containing the identified notification addresses or null if there are none.</returns>
         Task<UserPartyContactInfo?> GetNotificationAddresses(int userId, Guid partyUuid, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Adds a new or updates an existing notification address for a user and party.
+        /// Returns <c>true</c> if an existing record was updated, <c>false</c> if a new record was created.
+        /// </summary>
+        /// <param name="contactInfo">The contact info to be added</param>
+        /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+        /// <returns>A <see cref="Task"/> containing a boolean value indicating if the value was added or not.         
+        /// Returns <c>true</c> if a new record was added, <c>false</c> if an existing record was updated.
+        /// </returns>
+        Task<bool> AddOrUpdateNotificationAddressesAsync(UserPartyContactInfo contactInfo, CancellationToken cancellationToken);
     }
 }

--- a/src/Altinn.Profile.Core/ProfessionalNotificationAddresses/ProfessionalNotificationsService.cs
+++ b/src/Altinn.Profile.Core/ProfessionalNotificationAddresses/ProfessionalNotificationsService.cs
@@ -12,7 +12,13 @@ namespace Altinn.Profile.Core.ProfessionalNotificationAddresses
         /// <inheritdoc/>
         public Task<UserPartyContactInfo?> GetNotificationAddresses(int userId, Guid partyUuid, CancellationToken cancellationToken)
         {
-            return _professionalNotificationsRepository.GetNotificationAddresses(userId, partyUuid, cancellationToken);
+            return _professionalNotificationsRepository.GetNotificationAddress(userId, partyUuid, cancellationToken);
+        }
+
+        /// <inheritdoc/>
+        public Task<bool> AddOrUpdateNotificationAddressesAsync(UserPartyContactInfo contactInfo, CancellationToken cancellationToken)
+        {
+            return _professionalNotificationsRepository.AddOrUpdateNotificationAddressAsync(contactInfo, cancellationToken);
         }
     }
 }

--- a/src/Altinn.Profile.Core/ProfessionalNotificationAddresses/ProfessionalNotificationsService.cs
+++ b/src/Altinn.Profile.Core/ProfessionalNotificationAddresses/ProfessionalNotificationsService.cs
@@ -10,13 +10,13 @@ namespace Altinn.Profile.Core.ProfessionalNotificationAddresses
         private readonly IProfessionalNotificationsRepository _professionalNotificationsRepository = professionalNotificationsRepository;
 
         /// <inheritdoc/>
-        public Task<UserPartyContactInfo?> GetNotificationAddresses(int userId, Guid partyUuid, CancellationToken cancellationToken)
+        public Task<UserPartyContactInfo?> GetNotificationAddressAsync(int userId, Guid partyUuid, CancellationToken cancellationToken)
         {
-            return _professionalNotificationsRepository.GetNotificationAddress(userId, partyUuid, cancellationToken);
+            return _professionalNotificationsRepository.GetNotificationAddressAsync(userId, partyUuid, cancellationToken);
         }
 
         /// <inheritdoc/>
-        public Task<bool> AddOrUpdateNotificationAddressesAsync(UserPartyContactInfo contactInfo, CancellationToken cancellationToken)
+        public Task<bool> AddOrUpdateNotificationAddressAsync(UserPartyContactInfo contactInfo, CancellationToken cancellationToken)
         {
             return _professionalNotificationsRepository.AddOrUpdateNotificationAddressAsync(contactInfo, cancellationToken);
         }

--- a/src/Altinn.Profile.Integrations/Repositories/ProfessionalNotificationsRepository.cs
+++ b/src/Altinn.Profile.Integrations/Repositories/ProfessionalNotificationsRepository.cs
@@ -24,10 +24,6 @@ namespace Altinn.Profile.Integrations.Repositories
         }
 
         /// <inheritdoc/>
-        /// <summary>
-        /// Adds a new or updates an existing notification address for a user and party.
-        /// Returns <c>true</c> if a new record was added, <c>false</c> if an existing record was updated.
-        /// </summary>
         public async Task<bool> AddOrUpdateNotificationAddressAsync(UserPartyContactInfo contactInfo, CancellationToken cancellationToken)
         {
             using ProfileDbContext databaseContext = await _contextFactory.CreateDbContextAsync(cancellationToken);
@@ -55,8 +51,7 @@ namespace Altinn.Profile.Integrations.Repositories
                 if (existing.UserPartyContactInfoResources?.Count > 0)
                 {
                     var resourcesToRemove = existing.UserPartyContactInfoResources
-                        .Where(r => !incomingResourceIds.Contains(r.ResourceId))
-                        .ToList();
+                        .Where(r => !incomingResourceIds.Contains(r.ResourceId));
 
                     foreach (var resourceToRemove in resourcesToRemove)
                     {
@@ -70,8 +65,7 @@ namespace Altinn.Profile.Integrations.Repositories
                     existing.UserPartyContactInfoResources ??= [];
 
                     var newResources = contactInfo.UserPartyContactInfoResources
-                        .Where(r => !existingResourceIds.Contains(r.ResourceId))
-                        .ToList();
+                        .Where(r => !existingResourceIds.Contains(r.ResourceId));
 
                     foreach (var newResource in newResources)
                     {

--- a/src/Altinn.Profile.Integrations/Repositories/ProfessionalNotificationsRepository.cs
+++ b/src/Altinn.Profile.Integrations/Repositories/ProfessionalNotificationsRepository.cs
@@ -24,7 +24,6 @@ namespace Altinn.Profile.Integrations.Repositories
         }
 
         /// <inheritdoc/>
-
         public async Task<bool> AddOrUpdateNotificationAddressAsync(UserPartyContactInfo contactInfo, CancellationToken cancellationToken)
         {
             using ProfileDbContext databaseContext = await _contextFactory.CreateDbContextAsync(cancellationToken);

--- a/src/Altinn.Profile.Integrations/Repositories/ProfessionalNotificationsRepository.cs
+++ b/src/Altinn.Profile.Integrations/Repositories/ProfessionalNotificationsRepository.cs
@@ -11,7 +11,7 @@ namespace Altinn.Profile.Integrations.Repositories
         private readonly IDbContextFactory<ProfileDbContext> _contextFactory = contextFactory;
 
         /// <inheritdoc/>
-        public async Task<UserPartyContactInfo?> GetNotificationAddress(int userId, Guid partyUuid, CancellationToken cancellationToken)
+        public async Task<UserPartyContactInfo?> GetNotificationAddressAsync(int userId, Guid partyUuid, CancellationToken cancellationToken)
         {
             using ProfileDbContext databaseContext = await _contextFactory.CreateDbContextAsync(cancellationToken);
 

--- a/src/Altinn.Profile.Integrations/Repositories/ProfessionalNotificationsRepository.cs
+++ b/src/Altinn.Profile.Integrations/Repositories/ProfessionalNotificationsRepository.cs
@@ -47,6 +47,8 @@ namespace Altinn.Profile.Integrations.Repositories
                 existing.EmailAddress = contactInfo.EmailAddress;
                 existing.PhoneNumber = contactInfo.PhoneNumber;
                 existing.UserPartyContactInfoResources = contactInfo.UserPartyContactInfoResources;
+
+                // This is also adding, removing or updating the records in the UserPartyContactInfoResources collection, if any
                 databaseContext.UserPartyContactInfo.Update(existing);
                 wasAdded = false;
             }

--- a/src/Altinn.Profile.Integrations/Repositories/ProfessionalNotificationsRepository.cs
+++ b/src/Altinn.Profile.Integrations/Repositories/ProfessionalNotificationsRepository.cs
@@ -11,7 +11,7 @@ namespace Altinn.Profile.Integrations.Repositories
         private readonly IDbContextFactory<ProfileDbContext> _contextFactory = contextFactory;
 
         /// <inheritdoc/>
-        public async Task<UserPartyContactInfo?> GetNotificationAddresses(int userId, Guid partyUuid, CancellationToken cancellationToken)
+        public async Task<UserPartyContactInfo?> GetNotificationAddress(int userId, Guid partyUuid, CancellationToken cancellationToken)
         {
             using ProfileDbContext databaseContext = await _contextFactory.CreateDbContextAsync(cancellationToken);
 
@@ -21,6 +21,39 @@ namespace Altinn.Profile.Integrations.Repositories
                 .FirstOrDefaultAsync(g => g.UserId == userId && g.PartyUuid == partyUuid, cancellationToken);
 
             return userPartyContactInfo;
+        }
+
+        /// <inheritdoc/>
+        /// <summary>
+        /// Adds a new or updates an existing notification address for a user and party.
+        /// Returns <c>true</c> if a new record was added, <c>false</c> if an existing record was updated.
+        /// </summary>
+        public async Task<bool> AddOrUpdateNotificationAddressAsync(UserPartyContactInfo contactInfo, CancellationToken cancellationToken)
+        {
+            using ProfileDbContext databaseContext = await _contextFactory.CreateDbContextAsync(cancellationToken);
+
+            var existing = await databaseContext.UserPartyContactInfo
+                .Include(g => g.UserPartyContactInfoResources)
+                .FirstOrDefaultAsync(g => g.UserId == contactInfo.UserId && g.PartyUuid == contactInfo.PartyUuid, cancellationToken);
+
+            bool wasAdded;
+            if (existing == null)
+            {
+                databaseContext.UserPartyContactInfo.Add(contactInfo);
+                wasAdded = true;
+            }
+            else
+            {
+                existing.EmailAddress = contactInfo.EmailAddress;
+                existing.PhoneNumber = contactInfo.PhoneNumber;
+                existing.UserPartyContactInfoResources = contactInfo.UserPartyContactInfoResources;
+                databaseContext.UserPartyContactInfo.Update(existing);
+                wasAdded = false;
+            }
+
+            await databaseContext.SaveChangesAsync(cancellationToken);
+
+            return wasAdded;
         }
     }
 }

--- a/src/Altinn.Profile.Integrations/Repositories/ProfessionalNotificationsRepository.cs
+++ b/src/Altinn.Profile.Integrations/Repositories/ProfessionalNotificationsRepository.cs
@@ -24,6 +24,7 @@ namespace Altinn.Profile.Integrations.Repositories
         }
 
         /// <inheritdoc/>
+
         public async Task<bool> AddOrUpdateNotificationAddressAsync(UserPartyContactInfo contactInfo, CancellationToken cancellationToken)
         {
             using ProfileDbContext databaseContext = await _contextFactory.CreateDbContextAsync(cancellationToken);
@@ -51,7 +52,7 @@ namespace Altinn.Profile.Integrations.Repositories
                 if (existing.UserPartyContactInfoResources?.Count > 0)
                 {
                     var resourcesToRemove = existing.UserPartyContactInfoResources
-                        .Where(r => !incomingResourceIds.Contains(r.ResourceId));
+                        .Where(r => !incomingResourceIds.Contains(r.ResourceId)).ToList();
 
                     foreach (var resourceToRemove in resourcesToRemove)
                     {

--- a/src/Altinn.Profile/Controllers/NotificationsSettingsController.cs
+++ b/src/Altinn.Profile/Controllers/NotificationsSettingsController.cs
@@ -56,7 +56,7 @@ namespace Altinn.Profile.Controllers
                 return BadRequest("Party UUID cannot be empty.");
             }
 
-            var notificationAddress = await _professionalNotificationsService.GetNotificationAddresses(userId, partyUuid, cancellationToken);
+            var notificationAddress = await _professionalNotificationsService.GetNotificationAddressAsync(userId, partyUuid, cancellationToken);
 
             if (notificationAddress == null)
             {
@@ -111,11 +111,11 @@ namespace Altinn.Profile.Controllers
                     ResourceId = resource
                 }).ToList()
             };
-            var added = await _professionalNotificationsService.AddOrUpdateNotificationAddressesAsync(userPartyContactInfo, cancellationToken);
+            var added = await _professionalNotificationsService.AddOrUpdateNotificationAddressAsync(userPartyContactInfo, cancellationToken);
 
             if (added)
             {
-                return Created($"profile/api/v1/users/current/notificationsettings/parties/{partyUuid}", null);
+                return CreatedAtAction(nameof(Get), new { partyUuid }, null);
             }
 
             return NoContent();

--- a/src/Altinn.Profile/Controllers/NotificationsSettingsController.cs
+++ b/src/Altinn.Profile/Controllers/NotificationsSettingsController.cs
@@ -76,7 +76,7 @@ namespace Altinn.Profile.Controllers
         }
 
         /// <summary>
-        /// Get the notification addresses the current user has registered for a party
+        /// Add or update the notification addresses the current user has registered for a party
         /// </summary>
         [HttpPut("parties/{partyUuid:guid}")]
         [ProducesResponseType(StatusCodes.Status201Created)]

--- a/src/Altinn.Profile/Controllers/NotificationsSettingsController.cs
+++ b/src/Altinn.Profile/Controllers/NotificationsSettingsController.cs
@@ -34,6 +34,8 @@ namespace Altinn.Profile.Controllers
         /// <summary>
         /// Get the notification addresses the current user has registered for a party
         /// </summary>
+        /// <param name="partyUuid">The UUID of the party for which the notification address is being set</param>
+        /// <param name="cancellationToken"> Cancellation token for the operation</param>
         [HttpGet("parties/{partyUuid:guid}")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -78,6 +80,9 @@ namespace Altinn.Profile.Controllers
         /// <summary>
         /// Add or update the notification addresses the current user has registered for a party
         /// </summary>
+        /// <param name="partyUuid">The UUID of the party for which the notification address is being set</param>
+        /// <param name="request"> The request containing the notification address details</param>
+        /// <param name="cancellationToken"> Cancellation token for the operation</param>
         [HttpPut("parties/{partyUuid:guid}")]
         [ProducesResponseType(StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status204NoContent)]

--- a/src/Altinn.Profile/Models/ProfessionalNotificationAddress.cs
+++ b/src/Altinn.Profile/Models/ProfessionalNotificationAddress.cs
@@ -37,7 +37,6 @@ namespace Altinn.Profile.Models
             {
                 yield return new ValidationResult("ResourceIncludeList must contain valid URN values starting with 'urn:altinn:resource'", [nameof(ResourceIncludeList)]);
             }
-
         }
     }
 }

--- a/src/Altinn.Profile/Models/ProfessionalNotificationAddress.cs
+++ b/src/Altinn.Profile/Models/ProfessionalNotificationAddress.cs
@@ -7,7 +7,7 @@ using Altinn.Profile.Validators;
 namespace Altinn.Profile.Models
 {
     /// <summary>
-    /// Data model for the personal notification address for an organization
+    /// Data model for the professional notification address for an organization, also called personal notification address.
     /// </summary>
     public abstract class ProfessionalNotificationAddress
     {

--- a/src/Altinn.Profile/Models/ProfessionalNotificationAddress.cs
+++ b/src/Altinn.Profile/Models/ProfessionalNotificationAddress.cs
@@ -2,6 +2,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
 using Altinn.Profile.Validators;
 
 namespace Altinn.Profile.Models
@@ -9,7 +11,7 @@ namespace Altinn.Profile.Models
     /// <summary>
     /// Data model for the professional notification address for an organization, also called personal notification address.
     /// </summary>
-    public abstract class ProfessionalNotificationAddress
+    public abstract class ProfessionalNotificationAddress :IValidatableObject
     {
         /// <summary>
         /// The email address. May be null if no email address is set.
@@ -27,5 +29,15 @@ namespace Altinn.Profile.Models
         /// A list of resources that the user has registered to receive notifications for. The format is in URN. This is used to determine which resources the user can receive notifications for.
         /// </summary>
         public List<string> ResourceIncludeList { get; set; } = [];
+
+        /// <inheritdoc/>
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            if (ResourceIncludeList.Any(r => !r.StartsWith("urn:altinn:resource")))
+            {
+                yield return new ValidationResult("ResourceIncludeList must contain valid URN values starting with 'urn:altinn:resource'", [nameof(ResourceIncludeList)]);
+            }
+
+        }
     }
 }

--- a/src/Altinn.Profile/Models/ProfessionalNotificationAddress.cs
+++ b/src/Altinn.Profile/Models/ProfessionalNotificationAddress.cs
@@ -2,32 +2,25 @@
 
 using System;
 using System.Collections.Generic;
+using Altinn.Profile.Validators;
 
 namespace Altinn.Profile.Models
 {
     /// <summary>
     /// Data model for the personal notification address for an organization
     /// </summary>
-    public class ProfessionalNotificationAddresses
+    public abstract class ProfessionalNotificationAddress
     {
-        /// <summary>
-        /// The user id of logged-in user for whom the specific contact information belongs to.
-        /// </summary>
-        public int UserId { get; set; }
-
-        /// <summary>
-        /// Id of the party
-        /// </summary>
-        public Guid PartyUuid { get; set; }
-
         /// <summary>
         /// The email address. May be null if no email address is set.
         /// </summary>
+        [CustomRegexForNotificationAddresses("ProfessionalEmail")]
         public string? EmailAddress { get; set; }
 
         /// <summary>
         /// The phone number. May be null if no phone number is set. 
         /// </summary>
+        [CustomRegexForNotificationAddresses("ProfessionalPhone")]
         public string? PhoneNumber { get; set; }
 
         /// <summary>

--- a/src/Altinn.Profile/Models/ProfessionalNotificationAddressRequest.cs
+++ b/src/Altinn.Profile/Models/ProfessionalNotificationAddressRequest.cs
@@ -1,0 +1,15 @@
+﻿#nullable enable
+
+using System;
+using System.Collections.Generic;
+using Altinn.Profile.Validators;
+
+namespace Altinn.Profile.Models
+{
+    /// <summary>
+    /// Data model for the personal notification address for an organization
+    /// </summary>
+    public class ProfessionalNotificationAddressRequest : ProfessionalNotificationAddress
+    {
+    }
+}

--- a/src/Altinn.Profile/Models/ProfessionalNotificationAddressRequest.cs
+++ b/src/Altinn.Profile/Models/ProfessionalNotificationAddressRequest.cs
@@ -1,13 +1,9 @@
 ﻿#nullable enable
 
-using System;
-using System.Collections.Generic;
-using Altinn.Profile.Validators;
-
 namespace Altinn.Profile.Models
 {
     /// <summary>
-    /// Data model for the personal notification address for an organization
+    /// Request model for the professional notification address for an organization, also called personal notification address.
     /// </summary>
     public class ProfessionalNotificationAddressRequest : ProfessionalNotificationAddress
     {

--- a/src/Altinn.Profile/Models/ProfessionalNotificationAddressResponse.cs
+++ b/src/Altinn.Profile/Models/ProfessionalNotificationAddressResponse.cs
@@ -1,0 +1,22 @@
+﻿#nullable enable
+
+using System;
+
+namespace Altinn.Profile.Models
+{
+    /// <summary>
+    /// Data model for the personal notification address for an organization
+    /// </summary>
+    public class ProfessionalNotificationAddressResponse : ProfessionalNotificationAddress
+    {
+        /// <summary>
+        /// The user id of logged-in user for whom the specific contact information belongs to.
+        /// </summary>
+        public int UserId { get; set; }
+
+        /// <summary>
+        /// Id of the party
+        /// </summary>
+        public Guid PartyUuid { get; set; }
+    }
+}

--- a/src/Altinn.Profile/Models/ProfessionalNotificationAddressResponse.cs
+++ b/src/Altinn.Profile/Models/ProfessionalNotificationAddressResponse.cs
@@ -5,7 +5,7 @@ using System;
 namespace Altinn.Profile.Models
 {
     /// <summary>
-    /// Data model for the personal notification address for an organization
+    /// Response model for the professional notification address for an organization, also called personal notification address.
     /// </summary>
     public class ProfessionalNotificationAddressResponse : ProfessionalNotificationAddress
     {

--- a/src/Altinn.Profile/Validators/CustomRegexForNotificationAddressesAttribute.cs
+++ b/src/Altinn.Profile/Validators/CustomRegexForNotificationAddressesAttribute.cs
@@ -9,6 +9,11 @@ namespace Altinn.Profile.Validators
     [AttributeUsage(AttributeTargets.Property)]
     public class CustomRegexForNotificationAddressesAttribute : RegularExpressionAttribute
     {
+        // Professional (personal) notification addresses
+        private const string _professionalEmailRegexPattern = @"((&quot;[^&quot;]+&quot;)|(([a-zA-Z0-9!#$%&amp;'*+\-=?\^_`{|}~])+(\.([a-zA-Z0-9!#$%&amp;'*+\-=?\^_`{|}~])+)*))@((((([a-zA-Z0-9æøåÆØÅ]([a-zA-Z0-9\-æøåÆØÅ]{0,61})[a-zA-Z0-9æøåÆØÅ]\.)|[a-zA-Z0-9æøåÆØÅ]\.){1,9})([a-zA-Z]{2,14}))|((\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})))";
+        private const string _professionalPhoneRegexPattern = @"(([0-9]{5})|([0-9]{8})|((00[0-9]{2})[0-9]+)|((\+[0-9]{2})[0-9]+))$";
+
+        // Organization notification addresses
         private const string _emailRegexPattern = @"^((([a-zA-Z0-9!#$%&'*+\-=?\^_`{}~])+(\.([a-zA-Z0-9!#$%&'*+\-=?\^_`{}~])+)*)@(((([a-zA-Z0-9æøåÆØÅ]([a-zA-Z0-9\-æøåÆØÅ]{0,61})[a-zA-Z0-9æøåÆØÅ]\.)|[a-zA-Z0-9æøåÆØÅ]\.){1,9})([a-zA-Z]{2,14})))$";
         private const string _phoneRegexPattern = @"(^[0-9]+$)";
         private const string _countryCodeRegexPattern = @"(^\+([0-9]{1,3}))";
@@ -26,6 +31,8 @@ namespace Altinn.Profile.Validators
         {
             return inputType switch
             {
+                "ProfessionalEmail" => _professionalEmailRegexPattern,
+                "ProfessionalPhone" => _professionalPhoneRegexPattern,
                 "Email" => _emailRegexPattern,
                 "Phone" => _phoneRegexPattern,
                 "CountryCode" => _countryCodeRegexPattern,

--- a/src/Altinn.Profile/Validators/CustomRegexForNotificationAddressesAttribute.cs
+++ b/src/Altinn.Profile/Validators/CustomRegexForNotificationAddressesAttribute.cs
@@ -36,7 +36,7 @@ namespace Altinn.Profile.Validators
                 "Email" => _emailRegexPattern,
                 "Phone" => _phoneRegexPattern,
                 "CountryCode" => _countryCodeRegexPattern,
-                _ => string.Empty
+                _ => throw new ArgumentException($"Unknown input type: {inputType}", nameof(inputType)),
             };
         }
     }

--- a/src/Altinn.Profile/Validators/CustomRegexForNotificationAddressesAttribute.cs
+++ b/src/Altinn.Profile/Validators/CustomRegexForNotificationAddressesAttribute.cs
@@ -10,7 +10,7 @@ namespace Altinn.Profile.Validators
     public class CustomRegexForNotificationAddressesAttribute : RegularExpressionAttribute
     {
         // Professional (personal) notification addresses
-        private const string _professionalEmailRegexPattern = @"^((&quot;[^&quot;]+&quot;)|(([a-zA-Z0-9!#$%&'*+\-=?\^_`{|}~])+(\.([a-zA-Z0-9!#$%&'*+\-=?\^_`{|}~])+)*))@((((([a-zA-Z0-9æøåÆØÅ]([a-zA-Z0-9\-æøåÆØÅ]{0,61})[a-zA-Z0-9æøåÆØÅ]\.)|[a-zA-Z0-9æøåÆØÅ]\.){1,9})([a-zA-Z]{2,14}))|((\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})))";
+        private const string _professionalEmailRegexPattern = @"^((""[^""]+"")|(([a-zA-Z0-9!#$%&'*+\-=?\^_`{|}~])+(\.([a-zA-Z0-9!#$%&'*+\-=?\^_`{|}~])+)*))@((((([a-zA-Z0-9æøåÆØÅ]([a-zA-Z0-9\-æøåÆØÅ]{0,61})[a-zA-Z0-9æøåÆØÅ]\.)|[a-zA-Z0-9æøåÆØÅ]\.){1,9})([a-zA-Z]{2,14}))|((\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})))$";
         private const string _professionalPhoneRegexPattern = @"^(([0-9]{5})|([0-9]{8})|((00[0-9]{2})[0-9]+)|((\+[0-9]{2})[0-9]+))$";
 
         // Organization notification addresses

--- a/src/Altinn.Profile/Validators/CustomRegexForNotificationAddressesAttribute.cs
+++ b/src/Altinn.Profile/Validators/CustomRegexForNotificationAddressesAttribute.cs
@@ -10,8 +10,8 @@ namespace Altinn.Profile.Validators
     public class CustomRegexForNotificationAddressesAttribute : RegularExpressionAttribute
     {
         // Professional (personal) notification addresses
-        private const string _professionalEmailRegexPattern = @"((&quot;[^&quot;]+&quot;)|(([a-zA-Z0-9!#$%&amp;'*+\-=?\^_`{|}~])+(\.([a-zA-Z0-9!#$%&amp;'*+\-=?\^_`{|}~])+)*))@((((([a-zA-Z0-9æøåÆØÅ]([a-zA-Z0-9\-æøåÆØÅ]{0,61})[a-zA-Z0-9æøåÆØÅ]\.)|[a-zA-Z0-9æøåÆØÅ]\.){1,9})([a-zA-Z]{2,14}))|((\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})))";
-        private const string _professionalPhoneRegexPattern = @"(([0-9]{5})|([0-9]{8})|((00[0-9]{2})[0-9]+)|((\+[0-9]{2})[0-9]+))$";
+        private const string _professionalEmailRegexPattern = @"^((&quot;[^&quot;]+&quot;)|(([a-zA-Z0-9!#$%&'*+\-=?\^_`{|}~])+(\.([a-zA-Z0-9!#$%&'*+\-=?\^_`{|}~])+)*))@((((([a-zA-Z0-9æøåÆØÅ]([a-zA-Z0-9\-æøåÆØÅ]{0,61})[a-zA-Z0-9æøåÆØÅ]\.)|[a-zA-Z0-9æøåÆØÅ]\.){1,9})([a-zA-Z]{2,14}))|((\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})))";
+        private const string _professionalPhoneRegexPattern = @"^(([0-9]{5})|([0-9]{8})|((00[0-9]{2})[0-9]+)|((\+[0-9]{2})[0-9]+))$";
 
         // Organization notification addresses
         private const string _emailRegexPattern = @"^((([a-zA-Z0-9!#$%&'*+\-=?\^_`{}~])+(\.([a-zA-Z0-9!#$%&'*+\-=?\^_`{}~])+)*)@(((([a-zA-Z0-9æøåÆØÅ]([a-zA-Z0-9\-æøåÆØÅ]{0,61})[a-zA-Z0-9æøåÆØÅ]\.)|[a-zA-Z0-9æøåÆØÅ]\.){1,9})([a-zA-Z]{2,14})))$";

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/NotificationsSettingsControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/NotificationsSettingsControllerTests.cs
@@ -122,6 +122,36 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
         }
 
         [Fact]
+        public async Task PutNotificationAddress_WhenContactInfoIsInvalid_ReturnsBadRequest()
+        {
+            // Arrange
+            const int UserId = 2516356;
+            var partyGuid = Guid.NewGuid();
+
+            var userPartyContactInfo = new ProfessionalNotificationAddressRequest
+            {
+                EmailAddress = "test@@example.com",
+                PhoneNumber = "++",
+                ResourceIncludeList = ["urn:altinn:resource:example"]
+            };
+
+            HttpClient client = _webApplicationFactorySetup.GetTestServerClient();
+
+            HttpRequestMessage httpRequestMessage = new(HttpMethod.Put, $"profile/api/v1/users/current/notificationsettings/parties/{partyGuid}")
+            {
+                Content = new StringContent(JsonSerializer.Serialize(userPartyContactInfo, _serializerOptionsCamelCase), System.Text.Encoding.UTF8, "application/json")
+            };
+            httpRequestMessage = AddAuthHeadersToRequest(httpRequestMessage, UserId);
+
+            // Act
+            HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+
+            // Assert
+            Assert.NotNull(response);
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        }
+
+        [Fact]
         public async Task PutNotificationAddress_WhenContactInfoIsNew_ReturnsCreated()
         {
             // Arrange

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/NotificationsSettingsControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/NotificationsSettingsControllerTests.cs
@@ -48,7 +48,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
 
             _webApplicationFactorySetup
                 .ProfessionalNotificationsRepositoryMock
-                .Setup(x => x.GetNotificationAddress(UserId, partyGuid, It.IsAny<CancellationToken>()))
+                .Setup(x => x.GetNotificationAddressAsync(UserId, partyGuid, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(userPartyContactInfo);
 
             HttpClient client = _webApplicationFactorySetup.GetTestServerClient();
@@ -85,7 +85,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
 
             _webApplicationFactorySetup
                 .ProfessionalNotificationsRepositoryMock
-                .Setup(x => x.GetNotificationAddress(UserId, partyGuid, It.IsAny<CancellationToken>()))
+                .Setup(x => x.GetNotificationAddressAsync(UserId, partyGuid, It.IsAny<CancellationToken>()))
                 .ReturnsAsync((UserPartyContactInfo)null);
 
             HttpClient client = _webApplicationFactorySetup.GetTestServerClient();

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/NotificationsSettingsControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/NotificationsSettingsControllerTests.cs
@@ -53,7 +53,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
 
             HttpClient client = _webApplicationFactorySetup.GetTestServerClient();
 
-            HttpRequestMessage httpRequestMessage = CreateRequest(HttpMethod.Get, UserId, $"profile/api/v1/users/current/notificationsettings/parties/{partyGuid}");
+            HttpRequestMessage httpRequestMessage = CreateGetRequest(HttpMethod.Get, UserId, $"profile/api/v1/users/current/notificationsettings/parties/{partyGuid}");
 
             // Act
             HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
@@ -90,7 +90,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
 
             HttpClient client = _webApplicationFactorySetup.GetTestServerClient();
 
-            HttpRequestMessage httpRequestMessage = CreateRequest(HttpMethod.Get, UserId, $"profile/api/v1/users/current/notificationsettings/parties/{partyGuid}");
+            HttpRequestMessage httpRequestMessage = CreateGetRequest(HttpMethod.Get, UserId, $"profile/api/v1/users/current/notificationsettings/parties/{partyGuid}");
 
             // Act
             HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
@@ -225,7 +225,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
             Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
         }
 
-        private static HttpRequestMessage CreateRequest(HttpMethod method, int userId, string requestUri)
+        private static HttpRequestMessage CreateGetRequest(HttpMethod method, int userId, string requestUri)
         {
             HttpRequestMessage httpRequestMessage = new(method, requestUri);
             httpRequestMessage = AddAuthHeadersToRequest(httpRequestMessage, userId);

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/NotificationsSettingsControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/NotificationsSettingsControllerTests.cs
@@ -214,8 +214,6 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
                 ResourceIncludeList = ["urn:altinn:resource:example"]
             };
 
-            var resource =
-
             _webApplicationFactorySetup
                 .ProfessionalNotificationsRepositoryMock
                 .Setup(x => x.AddOrUpdateNotificationAddressAsync(It.IsAny<UserPartyContactInfo>(), It.IsAny<CancellationToken>()))

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/NotificationsSettingsControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/NotificationsSettingsControllerTests.cs
@@ -44,8 +44,6 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
                 }
             };
 
-            var resource = 
-
             _webApplicationFactorySetup
                 .ProfessionalNotificationsRepositoryMock
                 .Setup(x => x.GetNotificationAddressAsync(UserId, partyGuid, It.IsAny<CancellationToken>()))
@@ -53,7 +51,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
 
             HttpClient client = _webApplicationFactorySetup.GetTestServerClient();
 
-            HttpRequestMessage httpRequestMessage = CreateGetRequest(HttpMethod.Get, UserId, $"profile/api/v1/users/current/notificationsettings/parties/{partyGuid}");
+            HttpRequestMessage httpRequestMessage = CreateGetRequest(UserId, $"profile/api/v1/users/current/notificationsettings/parties/{partyGuid}");
 
             // Act
             HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
@@ -90,7 +88,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
 
             HttpClient client = _webApplicationFactorySetup.GetTestServerClient();
 
-            HttpRequestMessage httpRequestMessage = CreateGetRequest(HttpMethod.Get, UserId, $"profile/api/v1/users/current/notificationsettings/parties/{partyGuid}");
+            HttpRequestMessage httpRequestMessage = CreateGetRequest(UserId, $"profile/api/v1/users/current/notificationsettings/parties/{partyGuid}");
 
             // Act
             HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
@@ -225,9 +223,9 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
             Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
         }
 
-        private static HttpRequestMessage CreateGetRequest(HttpMethod method, int userId, string requestUri)
+        private static HttpRequestMessage CreateGetRequest(int userId, string requestUri)
         {
-            HttpRequestMessage httpRequestMessage = new(method, requestUri);
+            HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, requestUri);
             httpRequestMessage = AddAuthHeadersToRequest(httpRequestMessage, userId);
             return httpRequestMessage;
         }

--- a/test/Altinn.Profile.Tests/Profile.Integrations/ProfessionalNotifications/ProfessionalNotificationsRepositoryTests.cs
+++ b/test/Altinn.Profile.Tests/Profile.Integrations/ProfessionalNotifications/ProfessionalNotificationsRepositoryTests.cs
@@ -86,7 +86,7 @@ namespace Altinn.Profile.Tests.Profile.Integrations.ProfessionalNotifications
             await SeedUserPartyContactInfo(userId, partyUuid, "test@example.com", "12345678", resources);
 
             // Act
-            var result = await _repository.GetNotificationAddress(userId, partyUuid, CancellationToken.None);
+            var result = await _repository.GetNotificationAddressAsync(userId, partyUuid, CancellationToken.None);
 
             // Assert
             Assert.NotNull(result);
@@ -107,7 +107,7 @@ namespace Altinn.Profile.Tests.Profile.Integrations.ProfessionalNotifications
             Guid partyUuid = Guid.NewGuid();
 
             // Act
-            var result = await _repository.GetNotificationAddress(userId, partyUuid, CancellationToken.None);
+            var result = await _repository.GetNotificationAddressAsync(userId, partyUuid, CancellationToken.None);
 
             // Assert
             Assert.Null(result);
@@ -125,7 +125,7 @@ namespace Altinn.Profile.Tests.Profile.Integrations.ProfessionalNotifications
 
             // Act & Assert
             await Assert.ThrowsAsync<OperationCanceledException>(
-                () => _repository.GetNotificationAddress(userId, partyUuid, cts.Token));
+                () => _repository.GetNotificationAddressAsync(userId, partyUuid, cts.Token));
         }
 
         [Fact]
@@ -150,10 +150,18 @@ namespace Altinn.Profile.Tests.Profile.Integrations.ProfessionalNotifications
                 PartyUuid = partyUuid,
                 EmailAddress = string.Empty
             };
+
+            var secondCcontactInfo = new UserPartyContactInfo
+            {
+                UserId = userId,
+                PartyUuid = partyUuid,
+                EmailAddress = "updated@email.com"
+            };
+
             await _repository.AddOrUpdateNotificationAddressAsync(contactInfo, CancellationToken.None);
 
             // Act
-            var result = await _repository.AddOrUpdateNotificationAddressAsync(contactInfo, CancellationToken.None);
+            var result = await _repository.AddOrUpdateNotificationAddressAsync(secondCcontactInfo, CancellationToken.None);
 
             // Assert
             Assert.False(result);
@@ -190,7 +198,7 @@ namespace Altinn.Profile.Tests.Profile.Integrations.ProfessionalNotifications
 
             // Act
             var result = await _repository.AddOrUpdateNotificationAddressAsync(updatedContactInfo, CancellationToken.None);
-            var storedValue = await _repository.GetNotificationAddress(userId, partyUuid, CancellationToken.None);
+            var storedValue = await _repository.GetNotificationAddressAsync(userId, partyUuid, CancellationToken.None);
 
             // Assert
             Assert.False(result);
@@ -230,7 +238,7 @@ namespace Altinn.Profile.Tests.Profile.Integrations.ProfessionalNotifications
 
             // Act
             var result = await _repository.AddOrUpdateNotificationAddressAsync(updatedContactInfo, CancellationToken.None);
-            var storedValue = await _repository.GetNotificationAddress(userId, partyUuid, CancellationToken.None);
+            var storedValue = await _repository.GetNotificationAddressAsync(userId, partyUuid, CancellationToken.None);
 
             // Assert
             Assert.False(result);

--- a/test/Altinn.Profile.Tests/Profile.Integrations/ProfessionalNotifications/ProfessionalNotificationsRepositoryTests.cs
+++ b/test/Altinn.Profile.Tests/Profile.Integrations/ProfessionalNotifications/ProfessionalNotificationsRepositoryTests.cs
@@ -70,7 +70,7 @@ namespace Altinn.Profile.Tests.Profile.Integrations.ProfessionalNotifications
         }
 
         [Fact]
-        public async Task GetNotificationAddresses_WhenExists_ReturnsContactInfoWithResources()
+        public async Task GetNotificationAddress_WhenExists_ReturnsContactInfoWithResources()
         {
             // Arrange
             int userId = 1;
@@ -86,7 +86,7 @@ namespace Altinn.Profile.Tests.Profile.Integrations.ProfessionalNotifications
             await SeedUserPartyContactInfo(userId, partyUuid, "test@example.com", "12345678", resources);
 
             // Act
-            var result = await _repository.GetNotificationAddresses(userId, partyUuid, CancellationToken.None);
+            var result = await _repository.GetNotificationAddress(userId, partyUuid, CancellationToken.None);
 
             // Assert
             Assert.NotNull(result);
@@ -100,21 +100,21 @@ namespace Altinn.Profile.Tests.Profile.Integrations.ProfessionalNotifications
         }
 
         [Fact]
-        public async Task GetNotificationAddresses_WhenNotExists_ReturnsNull()
+        public async Task GetNotificationAddress_WhenNotExists_ReturnsNull()
         {
             // Arrange
             int userId = 2;
             Guid partyUuid = Guid.NewGuid();
 
             // Act
-            var result = await _repository.GetNotificationAddresses(userId, partyUuid, CancellationToken.None);
+            var result = await _repository.GetNotificationAddress(userId, partyUuid, CancellationToken.None);
 
             // Assert
             Assert.Null(result);
         }
 
         [Fact]
-        public async Task GetNotificationAddresses_WhenCancellationRequested_ThrowsOperationCanceledException()
+        public async Task GetNotificationAddress_WhenCancellationRequested_ThrowsOperationCanceledException()
         {
             // Arrange
             int userId = 1;
@@ -125,7 +125,38 @@ namespace Altinn.Profile.Tests.Profile.Integrations.ProfessionalNotifications
 
             // Act & Assert
             await Assert.ThrowsAsync<OperationCanceledException>(
-                () => _repository.GetNotificationAddresses(userId, partyUuid, cts.Token));
+                () => _repository.GetNotificationAddress(userId, partyUuid, cts.Token));
+        }
+
+        [Fact]
+        public async Task AddOrUpdateNotificationAddressAsync_WhenNew_ReturnsTrue()
+        {
+            // Act
+            var result = await _repository.AddOrUpdateNotificationAddressAsync(new UserPartyContactInfo(), CancellationToken.None);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task AddOrUpdateNotificationAddressAsync_WhenAlreadyExists_ReturnsFalse()
+        {
+            // arrange
+            int userId = 1;
+            Guid partyUuid = Guid.NewGuid();
+            var contactInfo = new UserPartyContactInfo
+            {
+                UserId = userId,
+                PartyUuid = partyUuid,
+                EmailAddress = string.Empty
+            };
+            await _repository.AddOrUpdateNotificationAddressAsync(contactInfo, CancellationToken.None);
+
+            // Act
+            var result = await _repository.AddOrUpdateNotificationAddressAsync(contactInfo, CancellationToken.None);
+
+            // Assert
+            Assert.False(result);
         }
     }
 }

--- a/test/Altinn.Profile.Tests/Profile.Integrations/ProfessionalNotifications/ProfessionalNotificationsRepositoryTests.cs
+++ b/test/Altinn.Profile.Tests/Profile.Integrations/ProfessionalNotifications/ProfessionalNotificationsRepositoryTests.cs
@@ -131,8 +131,18 @@ namespace Altinn.Profile.Tests.Profile.Integrations.ProfessionalNotifications
         [Fact]
         public async Task AddOrUpdateNotificationAddressAsync_WhenNew_ReturnsTrue()
         {
+            // Arrange 
+            int userId = 1;
+            Guid partyUuid = Guid.NewGuid();
+            var contactInfo = new UserPartyContactInfo
+            {
+                UserId = userId,
+                PartyUuid = partyUuid,
+                EmailAddress = string.Empty
+            };
+
             // Act
-            var result = await _repository.AddOrUpdateNotificationAddressAsync(new UserPartyContactInfo(), CancellationToken.None);
+            var result = await _repository.AddOrUpdateNotificationAddressAsync(contactInfo, CancellationToken.None);
 
             // Assert
             Assert.True(result);
@@ -141,7 +151,7 @@ namespace Altinn.Profile.Tests.Profile.Integrations.ProfessionalNotifications
         [Fact]
         public async Task AddOrUpdateNotificationAddressAsync_WhenAlreadyExists_ReturnsFalse()
         {
-            // arrange
+            // Arrange
             int userId = 1;
             Guid partyUuid = Guid.NewGuid();
             var contactInfo = new UserPartyContactInfo
@@ -170,7 +180,7 @@ namespace Altinn.Profile.Tests.Profile.Integrations.ProfessionalNotifications
         [Fact]
         public async Task AddOrUpdateNotificationAddressAsync_WhenRemovingResources_ReturnsFalse()
         {
-            // arrange
+            // Arrange
             int userId = 1;
             Guid partyUuid = Guid.NewGuid();
             var contactInfo = new UserPartyContactInfo
@@ -211,7 +221,7 @@ namespace Altinn.Profile.Tests.Profile.Integrations.ProfessionalNotifications
         [Fact]
         public async Task AddOrUpdateNotificationAddressAsync_WhenEditingResources_ReturnsFalse()
         {
-            // arrange
+            // Arrange
             int userId = 1;
             Guid partyUuid = Guid.NewGuid();
             var contactInfo = new UserPartyContactInfo

--- a/test/Altinn.Profile.Tests/Profile.Integrations/ProfessionalNotifications/ProfessionalNotificationsRepositoryTests.cs
+++ b/test/Altinn.Profile.Tests/Profile.Integrations/ProfessionalNotifications/ProfessionalNotificationsRepositoryTests.cs
@@ -158,5 +158,86 @@ namespace Altinn.Profile.Tests.Profile.Integrations.ProfessionalNotifications
             // Assert
             Assert.False(result);
         }
+
+        [Fact]
+        public async Task AddOrUpdateNotificationAddressAsync_WhenRemovingResources_ReturnsFalse()
+        {
+            // arrange
+            int userId = 1;
+            Guid partyUuid = Guid.NewGuid();
+            var contactInfo = new UserPartyContactInfo
+            {
+                UserId = userId,
+                PartyUuid = partyUuid,
+                EmailAddress = string.Empty,
+                UserPartyContactInfoResources =
+                [
+                    new() { ResourceId = "res1" },
+                    new() { ResourceId = "res2" }
+                ]
+            };
+            var updatedContactInfo = new UserPartyContactInfo
+            {
+                UserId = userId,
+                PartyUuid = partyUuid,
+                EmailAddress = "some@value.com",
+                UserPartyContactInfoResources =
+                [
+                    new() { ResourceId = "res1" } // Removing "res2"
+                ]
+            };
+            await _repository.AddOrUpdateNotificationAddressAsync(contactInfo, CancellationToken.None);
+
+            // Act
+            var result = await _repository.AddOrUpdateNotificationAddressAsync(updatedContactInfo, CancellationToken.None);
+            var storedValue = await _repository.GetNotificationAddress(userId, partyUuid, CancellationToken.None);
+
+            // Assert
+            Assert.False(result);
+            Assert.NotNull(storedValue);
+            Assert.Single(storedValue.UserPartyContactInfoResources);
+            Assert.Equal("res1", storedValue.UserPartyContactInfoResources[0].ResourceId);
+            Assert.Equal("some@value.com", storedValue.EmailAddress);
+        }
+
+        [Fact]
+        public async Task AddOrUpdateNotificationAddressAsync_WhenEditingResources_ReturnsFalse()
+        {
+            // arrange
+            int userId = 1;
+            Guid partyUuid = Guid.NewGuid();
+            var contactInfo = new UserPartyContactInfo
+            {
+                UserId = userId,
+                PartyUuid = partyUuid,
+                EmailAddress = string.Empty,
+                UserPartyContactInfoResources =
+                [
+                    new() { ResourceId = "res1" },
+                ]
+            };
+            var updatedContactInfo = new UserPartyContactInfo
+            {
+                UserId = userId,
+                PartyUuid = partyUuid,
+                EmailAddress = "some@value.com",
+                UserPartyContactInfoResources =
+                [
+                    new() { ResourceId = "res2" } 
+                ]
+            };
+            await _repository.AddOrUpdateNotificationAddressAsync(contactInfo, CancellationToken.None);
+
+            // Act
+            var result = await _repository.AddOrUpdateNotificationAddressAsync(updatedContactInfo, CancellationToken.None);
+            var storedValue = await _repository.GetNotificationAddress(userId, partyUuid, CancellationToken.None);
+
+            // Assert
+            Assert.False(result);
+            Assert.NotNull(storedValue);
+            Assert.Single(storedValue.UserPartyContactInfoResources);
+            Assert.Equal("res2", storedValue.UserPartyContactInfoResources[0].ResourceId);
+            Assert.Equal("some@value.com", storedValue.EmailAddress);
+        }
     }
 }

--- a/test/Altinn.Profile.Tests/Profile.Integrations/ProfessionalNotifications/ProfessionalNotificationsRepositoryTests.cs
+++ b/test/Altinn.Profile.Tests/Profile.Integrations/ProfessionalNotifications/ProfessionalNotificationsRepositoryTests.cs
@@ -231,7 +231,7 @@ namespace Altinn.Profile.Tests.Profile.Integrations.ProfessionalNotifications
                 EmailAddress = string.Empty,
                 UserPartyContactInfoResources =
                 [
-                    new() { ResourceId = "res1" },
+                    new() { ResourceId = "urn:altinn:resource:res1" },
                 ]
             };
             var updatedContactInfo = new UserPartyContactInfo
@@ -241,7 +241,7 @@ namespace Altinn.Profile.Tests.Profile.Integrations.ProfessionalNotifications
                 EmailAddress = "some@value.com",
                 UserPartyContactInfoResources =
                 [
-                    new() { ResourceId = "res2" } 
+                    new() { ResourceId = "urn:altinn:resource:res2" } 
                 ]
             };
             await _repository.AddOrUpdateNotificationAddressAsync(contactInfo, CancellationToken.None);
@@ -254,7 +254,7 @@ namespace Altinn.Profile.Tests.Profile.Integrations.ProfessionalNotifications
             Assert.False(result);
             Assert.NotNull(storedValue);
             Assert.Single(storedValue.UserPartyContactInfoResources);
-            Assert.Equal("res2", storedValue.UserPartyContactInfoResources[0].ResourceId);
+            Assert.Equal("urn:altinn:resource:res2", storedValue.UserPartyContactInfoResources[0].ResourceId);
             Assert.Equal("some@value.com", storedValue.EmailAddress);
         }
     }

--- a/test/Altinn.Profile.Tests/Profile/Validators/CustomRegexForNotificationAddressesTests.cs
+++ b/test/Altinn.Profile.Tests/Profile/Validators/CustomRegexForNotificationAddressesTests.cs
@@ -5,6 +5,66 @@ namespace Altinn.Profile.Tests.Profile.Validators
 {
     public class CustomRegexForNotificationAddressesTests
     {
+        // Professional notification addresses
+        [Theory]
+        [InlineData("+4798765432")]
+        [InlineData("004798765432")]
+        [InlineData("98765432")]
+        [InlineData("98765")]
+        [InlineData("")]
+        [InlineData(null)]
+        public void CustomRegexForProfessional_WhenPhoneHasAllowedValues_ReturnsValidResult(string input)
+        {
+            var attribute = new CustomRegexForNotificationAddressesAttribute("ProfessionalPhone");
+
+            var validationResult = attribute.IsValid(input);
+
+            Assert.True(validationResult);
+        }
+
+        [Theory]
+        [InlineData(" ")]
+        [InlineData("error")]
+        [InlineData("+47")]
+        public void CustomRegexForProfessional_WhenPhoneHasInvalidValues_IsInvalid(string input)
+        {
+            var attribute = new CustomRegexForNotificationAddressesAttribute("ProfessionalPhone");
+
+            var validationResult = attribute.IsValid(input);
+
+            Assert.False(validationResult);
+        }
+
+        [Theory]
+        [InlineData("test@test.com")]
+        [InlineData("test-test@test.com")]
+        [InlineData("test.test@test.com")]
+        [InlineData("")]
+        [InlineData(null)]
+        public void CustomRegexForProfessional_WhenEmailHasAllowedValues_IsValid(string input)
+        {
+            var attribute = new CustomRegexForNotificationAddressesAttribute("ProfessionalEmail");
+
+            var validationResult = attribute.IsValid(input);
+
+            Assert.True(validationResult);
+        }
+
+        [Theory]
+        [InlineData(" ")]
+        [InlineData("98765432")]
+        [InlineData("test-test@@test.com")]
+        [InlineData("test@test..com")]
+        public void CustomRegexForProfessional_WhenEmailHasWrongFormat_IsInvalid(string input)
+        {
+            var attribute = new CustomRegexForNotificationAddressesAttribute("ProfessionalEmail");
+
+            var validationResult = attribute.IsValid(input);
+
+            Assert.False(validationResult);
+        }
+
+        // Organization notification addresses
         [Theory]
         [InlineData("98765432")]
         [InlineData("98765")]

--- a/test/Bruno/Profile/Personal notificationaddress for an org/PUT party.bru
+++ b/test/Bruno/Profile/Personal notificationaddress for an org/PUT party.bru
@@ -1,0 +1,25 @@
+meta {
+  name: PUT party
+  type: http
+  seq: 2
+}
+
+put {
+  url: {{ProfileBaseAddress}}/api/v1/users/current/notificationsettings/parties/{{partyUuid}}
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "emailAddress": "test@test.no",
+    "phoneNumber": "+1234567890",
+    "resourceIncludeList": [
+      "some-val"
+    ]
+  }
+}
+
+script:pre-request {
+  bru.runRequest("TokenGenerator/end user token")
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Note: Missing validation that the user has access to the party!

## Related Issue(s)
- #416 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for adding or updating professional notification addresses via a new API endpoint.
  - Introduced validation for professional email and phone number formats with custom regex rules.
  - Updated response structure for retrieving notification addresses to include user and party identifiers.

- **Bug Fixes**
  - Improved validation error handling for notification address updates.

- **Tests**
  - Added comprehensive tests for the new add/update notification address endpoint.
  - Enhanced test coverage for professional email and phone number validation.
  - Aligned test method names and mocks with updated notification address retrieval methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->