### PR TITLE
Add more validation of resources

### DIFF
--- a/src/Altinn.Profile/Models/ProfessionalNotificationAddress.cs
+++ b/src/Altinn.Profile/Models/ProfessionalNotificationAddress.cs
@@ -38,7 +38,7 @@ namespace Altinn.Profile.Models
         {
             if (ResourceIncludeList.Any(r => string.IsNullOrWhiteSpace(r) || !ResourceIdRegex().IsMatch(r)))
             {
-                yield return new ValidationResult("ResourceIncludeList must contain valid URN values starting with 'urn:altinn:resource'", [nameof(ResourceIncludeList)]);
+                yield return new ValidationResult("ResourceIncludeList must contain valid URN values of the format 'urn:altinn:resource:{resourceId}' where resourceId has 4 or more characters of lowercase letter, number, underscore or hyphen)", [nameof(ResourceIncludeList)]);
             }
 
             if (ResourceIncludeList.Count > ResourceIncludeList.Distinct().Count())

--- a/src/Altinn.Profile/Models/ProfessionalNotificationAddress.cs
+++ b/src/Altinn.Profile/Models/ProfessionalNotificationAddress.cs
@@ -33,9 +33,14 @@ namespace Altinn.Profile.Models
         /// <inheritdoc/>
         public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {
-            if (ResourceIncludeList.Any(r => !r.StartsWith("urn:altinn:resource")))
+            if (ResourceIncludeList.Any(r => string.IsNullOrWhiteSpace(r) || !r.StartsWith("urn:altinn:resource:")))
             {
                 yield return new ValidationResult("ResourceIncludeList must contain valid URN values starting with 'urn:altinn:resource'", [nameof(ResourceIncludeList)]);
+            }
+
+            if (ResourceIncludeList.Count > ResourceIncludeList.Distinct().Count())
+            {
+                yield return new ValidationResult("ResourceIncludeList cannot contain duplicates", [nameof(ResourceIncludeList)]);
             }
         }
     }

--- a/src/Altinn.Profile/Models/ProfessionalNotificationAddress.cs
+++ b/src/Altinn.Profile/Models/ProfessionalNotificationAddress.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Altinn.Profile.Validators;
 
 namespace Altinn.Profile.Models
@@ -11,8 +12,10 @@ namespace Altinn.Profile.Models
     /// <summary>
     /// Data model for the professional notification address for an organization, also called personal notification address.
     /// </summary>
-    public abstract class ProfessionalNotificationAddress :IValidatableObject
+    public abstract partial class ProfessionalNotificationAddress :IValidatableObject
     {
+        private const string _resourceIdRegex = "^urn:altinn:resource:[a-z0-9_-]{4,}$";
+
         /// <summary>
         /// The email address. May be null if no email address is set.
         /// </summary>
@@ -33,7 +36,7 @@ namespace Altinn.Profile.Models
         /// <inheritdoc/>
         public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {
-            if (ResourceIncludeList.Any(r => string.IsNullOrWhiteSpace(r) || !r.StartsWith("urn:altinn:resource:")))
+            if (ResourceIncludeList.Any(r => string.IsNullOrWhiteSpace(r) || !ResourceIdRegex().IsMatch(r)))
             {
                 yield return new ValidationResult("ResourceIncludeList must contain valid URN values starting with 'urn:altinn:resource'", [nameof(ResourceIncludeList)]);
             }
@@ -43,5 +46,8 @@ namespace Altinn.Profile.Models
                 yield return new ValidationResult("ResourceIncludeList cannot contain duplicates", [nameof(ResourceIncludeList)]);
             }
         }
+
+        [GeneratedRegex(_resourceIdRegex)]
+        private static partial Regex ResourceIdRegex();
     }
 }

--- a/src/Altinn.Profile/Models/ProfessionalNotificationAddress.cs
+++ b/src/Altinn.Profile/Models/ProfessionalNotificationAddress.cs
@@ -38,7 +38,7 @@ namespace Altinn.Profile.Models
         {
             if (ResourceIncludeList.Any(r => string.IsNullOrWhiteSpace(r) || !ResourceIdRegex().IsMatch(r)))
             {
-                yield return new ValidationResult("ResourceIncludeList must contain valid URN values of the format 'urn:altinn:resource:{resourceId}' where resourceId has 4 or more characters of lowercase letter, number, underscore or hyphen)", [nameof(ResourceIncludeList)]);
+                yield return new ValidationResult("ResourceIncludeList must contain valid URN values of the format 'urn:altinn:resource:{resourceId}' where resourceId has 4 or more characters of lowercase letter, number, underscore or hyphen", [nameof(ResourceIncludeList)]);
             }
 
             if (ResourceIncludeList.Count > ResourceIncludeList.Distinct().Count())

--- a/src/Altinn.Profile/Models/ProfessionalNotificationAddress.cs
+++ b/src/Altinn.Profile/Models/ProfessionalNotificationAddress.cs
@@ -44,6 +44,7 @@ namespace Altinn.Profile.Models
             if (ResourceIncludeList.Count > ResourceIncludeList.Distinct().Count())
             {
                 yield return new ValidationResult("ResourceIncludeList cannot contain duplicates", [nameof(ResourceIncludeList)]);
+            }
 
             if (string.IsNullOrWhiteSpace(EmailAddress) && string.IsNullOrWhiteSpace(PhoneNumber))
             {

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/NotificationsSettingsControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/NotificationsSettingsControllerTests.cs
@@ -166,6 +166,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
         [InlineData("")]
         [InlineData(" ")] // whitespace
         [InlineData("urn:altinn:resource")]
+        [InlineData("urn:altinn:resource:abc")] // Too short resource ID
         public async Task PutNotificationAddress_WhenResourcesIsInvalid_ReturnsBadRequest(string resource)
         {
             // Arrange

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/NotificationsSettingsControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/NotificationsSettingsControllerTests.cs
@@ -206,6 +206,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
         [InlineData(" ")] // whitespace
         [InlineData("urn:altinn:resource")]
         [InlineData("urn:altinn:resource:abc")] // Too short resource ID
+        [InlineData("urn:altinn:resource:some*resource")] // Contains invalid char
         public async Task PutNotificationAddress_WhenResourcesIsInvalid_ReturnsBadRequest(string resource)
         {
             // Arrange

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/NotificationsSettingsControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/NotificationsSettingsControllerTests.cs
@@ -13,7 +13,6 @@ using Altinn.Profile.Tests.IntegrationTests.Utils;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Moq;
-using OpenTelemetry.Resources;
 using Xunit;
 
 namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
@@ -163,7 +162,10 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
 
         [Theory]
         [InlineData("example")]
-        [InlineData(null)] // Valid URN format
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")] // whitespace
+        [InlineData("urn:altinn:resource")]
         public async Task PutNotificationAddress_WhenResourcesIsInvalid_ReturnsBadRequest(string resource)
         {
             // Arrange

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/NotificationsSettingsControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/NotificationsSettingsControllerTests.cs
@@ -243,7 +243,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
             Assert.Single(actual.Errors);
             Assert.NotNull(actual.Errors["ResourceIncludeList"]);
             Assert.True(actual.Errors.TryGetValue("ResourceIncludeList", out var message));
-            Assert.Contains("ResourceIncludeList must contain valid URN values starting with 'urn:altinn:resource'", message[0]);
+            Assert.Contains("ResourceIncludeList must contain valid URN values of the format 'urn:altinn:resource:{resourceId}' where resourceId has 4 or more characters of lowercase letter, number, underscore or hyphen", message[0]);
         }
 
         [Fact]
@@ -286,8 +286,12 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
             Assert.Contains("ResourceIncludeList cannot contain duplicates", message[0]);
         }
 
-        [Fact]
-        public async Task PutNotificationAddress_WhenContactInfoIsNew_ReturnsCreated()
+        [Theory]
+        [InlineData("urn:altinn:resource:example")]
+        [InlineData("urn:altinn:resource:app_other_vale")]
+        [InlineData("urn:altinn:resource:ttd-resource-1")]
+
+        public async Task PutNotificationAddress_WhenContactInfoIsNew_ReturnsCreated(string resource)
         {
             // Arrange
             const int UserId = 2516356;
@@ -297,7 +301,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
             {
                 EmailAddress = "test@example.com",
                 PhoneNumber = "12345678",
-                ResourceIncludeList = ["urn:altinn:resource:example"]
+                ResourceIncludeList = [resource]
             };
 
             _webApplicationFactorySetup


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR is meant to handle these three use-cases


* Set resourceIncludeList to [null]:
`PUT profile/api/v1/users/current/notificationsettings/parties/{{partyUuid}} with body { "resourceIncludeList": [null] }`
==> 500 response

* It's allowed to put several duplicate element values in resourceIncludeList - this results in unexpected behavior when one of the duplicates is later modified
* "urn:altinn:resource" is a valid value for an element in resourceIncludeList


## Related Issue(s)
- #416 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced validation to reject empty, improperly formatted, or duplicate resource entries in notification settings.

- **Tests**
  - Added and expanded tests to verify handling of invalid and duplicate resource entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->