### PR TITLE
Clarify field requirements when PUT notification setting has missing/null email & phone

### DIFF
--- a/src/Altinn.Profile/Models/ProfessionalNotificationAddress.cs
+++ b/src/Altinn.Profile/Models/ProfessionalNotificationAddress.cs
@@ -40,7 +40,7 @@ namespace Altinn.Profile.Models
 
             if (string.IsNullOrWhiteSpace(EmailAddress) && string.IsNullOrWhiteSpace(PhoneNumber))
             {
-                yield return new ValidationResult("Use DELETE endpoint when deleting both EmailAddress and PhoneNumber.", [nameof(EmailAddress)]);
+                yield return new ValidationResult("The notification setting for a party must include either EmailAddress, PhoneNumber, or both.", [nameof(EmailAddress), nameof(PhoneNumber)]);
             }
         }
     }

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/NotificationsSettingsControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/NotificationsSettingsControllerTests.cs
@@ -170,7 +170,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
             var userPartyContactInfo = new ProfessionalNotificationAddressRequest
             {
                 PhoneNumber = string.Empty,
-                ResourceIncludeList = ["example"]
+                ResourceIncludeList = ["urn:altinn:resource:example"]
             };
 
             HttpClient client = _webApplicationFactorySetup.GetTestServerClient();
@@ -195,8 +195,9 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
 
             Assert.Equal(2, actual.Errors.Count);
             Assert.NotNull(actual.Errors["EmailAddress"]);
+            Assert.NotNull(actual.Errors["PhoneNumber"]);
             Assert.True(actual.Errors.TryGetValue("EmailAddress", out var message));
-            Assert.Contains("Use DELETE endpoint when deleting both EmailAddress and PhoneNumber", message[0]);
+            Assert.Contains("The notification setting for a party must include either EmailAddress, PhoneNumber, or both.", message[0]);
         }
 
         [Theory]


### PR DESCRIPTION
## Description
There may be different reasons why an API user would `PUT` notification settings on a party with **both** email & phone **absent** or as **null**
- Creating the resource without knowing that email & phone are required
- Updating the resource to intentionally attempt a reset of these values
- Updating the resource to modify / set ResourceIncludeList and unintentionally forget to set email & phone

This suggested change could work better across these different scenarios, by focusing the validation feedback on the requirements of the target resource that is attempted for update

## Related Issue(s)
- #379 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation messages for notification settings to clearly state that at least one of EmailAddress or PhoneNumber is required.
  - Validation errors now reference both EmailAddress and PhoneNumber when neither is provided.

- **Tests**
  - Updated tests to check for validation errors on both EmailAddress and PhoneNumber, and to reflect the revised validation message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->