### PR TITLE
Make it possible to disable PlatformAccessToken validation

### DIFF
--- a/src/Altinn.Profile/appsettings.Development.json
+++ b/src/Altinn.Profile/appsettings.Development.json
@@ -1,4 +1,5 @@
 {
+  "PlatformAccessTokenAuthorization:Disabled": true,
   "PostgreSqlSettings": {
     "MigrationScriptPath": "../Altinn.Profile.Integrations/Migration"
   },


### PR DESCRIPTION
## Description
The AccessToken library is poorly written, causing issues in Development environment. This change removes platform access token authorization if the feature is disabled. I hope this will fix the issue for Profile at least.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
