### PR TITLE
Make timestamp solution more elegant for Changelog sync metadata table

### DIFF
--- a/src/Altinn.Profile.Integrations/Entities/ChangelogSyncMetadata.cs
+++ b/src/Altinn.Profile.Integrations/Entities/ChangelogSyncMetadata.cs
@@ -19,24 +19,17 @@ namespace Altinn.Profile.Integrations.Entities
         public required string LastChangedId { get; set; }
 
         /// <summary>
-        /// The time and date if last sync with changes
-        /// </summary>
-        [Required]
-        public DateTime LastChangedDateTime { get; set; }
-
-        /// <summary>
         /// What dataType this metadata is for.
         /// </summary>
         [Required]
         public DataType DataType { get; set; }
 
         /// <summary>
-        /// Nanosecond part of the LastChangedDateTime
-        /// <!-- This is needed because DateTime in C# supports up to 100-nanosecond precision 10^-7 -->
-        /// <!-- PostgreSQL does not support nanosecond precision, so precision 10^-6-->
+        /// The number of ticks (100 nanoseconds each) representing the last change time.
+        /// This is needed because DateTime in C# supports up to 100-nanosecond precision 10^-7
+        /// PostgreSQL does not support nanosecond precision, so precision 10^-6
         /// </summary>
         [Required]
-        [Range(0, 900)]
-        public int Nanosecond { get; set; }
+        public long LastChangeTicks { get; set; }
     }
 }

--- a/src/Altinn.Profile.Integrations/Migration/v0.16/01-alter-table-changelog-sync-metadata.sql
+++ b/src/Altinn.Profile.Integrations/Migration/v0.16/01-alter-table-changelog-sync-metadata.sql
@@ -1,0 +1,5 @@
+ALTER TABLE lease.changelog_sync_metadata DROP COLUMN IF EXISTS last_changed_date_time;
+
+ALTER TABLE lease.changelog_sync_metadata DROP COLUMN IF EXISTS nanosecond;
+
+ALTER TABLE lease.changelog_sync_metadata ADD IF NOT EXISTS last_change_ticks bigint NOT NULL DEFAULT 0;

--- a/test/Altinn.Profile.Tests/Profile.Integrations/Repositories/ChangelogSyncMetadataRepositoryTests.cs
+++ b/test/Altinn.Profile.Tests/Profile.Integrations/Repositories/ChangelogSyncMetadataRepositoryTests.cs
@@ -72,6 +72,22 @@ public class ChangelogSyncMetadataRepositoryTests : IDisposable
     }
 
     [Fact]
+    public async Task GetLatestSyncTimestampAsync_WhenEntry_ReturnsTimestamp()
+    {
+        // Arrange
+        var timestamp = DateTime.UtcNow;
+        var dataType = DataType.ReporteeNotificationSettings;
+        await _repository.UpdateLatestChangeTimestampAsync(timestamp, dataType);
+
+        // Act
+        var updatedTime = await _repository.GetLatestSyncTimestampAsync(dataType, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(updatedTime);
+        Assert.Equal(timestamp, updatedTime);
+    }
+
+    [Fact]
     public async Task UpdateLatestChangeTimestampAsync_AddsAndReturnsUpdatedTime()
     {
         // Arrange


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Change from storing datetime in two columns to one column of ticks. Handled in AT22 manually as this env has values aleady. Other envs are empty 

## Related Issue(s)
- #500 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None
- Bug Fixes
  - More consistent handling of synchronization timestamps, reducing edge-case inaccuracies.
- Refactor
  - Streamlined timestamp representation to improve reliability and performance.
- Tests
  - Added coverage to verify accurate retrieval of the latest synchronization timestamp.
- Chores
  - Database migration to align storage with the new timestamp format.
- Documentation
  - Updated internal descriptions to reflect the timestamp changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->