### PR TITLE
Fix handling of lease when already exists

### DIFF
--- a/src/Altinn.Profile.Integrations/Repositories/LeaseRepository.cs
+++ b/src/Altinn.Profile.Integrations/Repositories/LeaseRepository.cs
@@ -44,6 +44,12 @@ namespace Altinn.Profile.Integrations.Repositories
 
                         databaseContext.Lease.Update(existingLease);
                     }
+                    else
+                    {
+                        // Lease is held by another token and has not expired
+                        result = LeaseAcquireResult.Failed(existingLease.Expires, existingLease.Acquired, existingLease.Released);
+                        return result;
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents acquiring or updating a lease when an active lease is already held by another token, returning a clear failure response with timing details.
  * Improves reliability under contention, reducing accidental overwrites and duplicate processing.
* **Tests**
  * Added test coverage to verify that attempts to acquire a lease fail gracefully when a conflicting active lease exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->