### PR TITLE
Improve handling of corrupted authorization_details claims.

### DIFF
--- a/src/Altinn.Profile/Middleware/RequestFilterProcessor.cs
+++ b/src/Altinn.Profile/Middleware/RequestFilterProcessor.cs
@@ -77,9 +77,16 @@ namespace Altinn.Profile.Middleware
                     "authorization_details",
                     static (claim, activity) =>
                     {
-                        SystemUserClaim claimValue = JsonSerializer.Deserialize<SystemUserClaim>(claim.Value);
-                        activity.SetTag("user.system.id", claimValue?.Systemuser_id[0] ?? null);
-                        activity.SetTag("user.system.owner.number", claimValue?.Systemuser_org.ID ?? null);
+                        try
+                        {
+                            SystemUserClaim claimValue = JsonSerializer.Deserialize<SystemUserClaim>(claim.Value);
+                            activity.SetTag("user.system.id", claimValue?.Systemuser_id[0] ?? null);
+                            activity.SetTag("user.system.owner.number", claimValue?.Systemuser_org.ID ?? null);
+                        }
+                        catch
+                        {
+                            // Ignore all exceptions.
+                        }
                     }
                 },
             };

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/UsersControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/UsersControllerTests.cs
@@ -257,9 +257,10 @@ public class UsersControllerTests : IClassFixture<ProfileWebApplicationFactory<P
     [Fact]
     public async Task GetUsersById_AsInvalidSystemUser_SblBridgeFindsProfile_ResponseOk_ReturnsUserProfile()
     {
-        //// The content of the bearer token is invalid, but the profile doesn't check the content of the token. It's only
-        //// checking that the token is valid by verifying the signature. The purpose of the test is to trigger an
-        //// exception during telemetry enrichment from the claims principal.
+        //// The content of the bearer token is invalid, but Profile doesn't check the content of the token. It's only
+        //// checking that the token is valid by verifying the signature. The purpose of the test is to ensure we can
+        //// handle an exception during deserialization of an invalid authorization_details claims value. The request
+        //// processing should continue as normal.
 
         // Arrange
         const int UserId = 2516356;


### PR DESCRIPTION
## Description
This is primarily a change to fix an unstable test. The test were trying to prove that request processing would continue and finish even if the content of an `authorization_details` claim were invalid JSON. 

This change makes doubly sure by adding a try catch around deserialization of the authorization_details value. Tests should be more stable after this. 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of request processing: malformed authorization data in incoming requests no longer triggers errors.
  * When parsing such data fails, the request proceeds without adding related diagnostic tags, ensuring stable behavior with no change for valid inputs.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->