### PR TITLE
Feature/562 remove EnableLocalKrrFetch flag

### DIFF
--- a/src/Altinn.Profile.Core/CoreSettings.cs
+++ b/src/Altinn.Profile.Core/CoreSettings.cs
@@ -6,11 +6,6 @@ namespace Altinn.Profile.Core;
 public class CoreSettings
 {
     /// <summary>
-    /// Feature flag that dictates whether KRR data should be fetched locally (from our own copy) or remotely (from Altinn 2)
-    /// </summary>
-    public bool EnableLocalKrrFetch { get; set; } = false;
-
-    /// <summary>
     /// The number of seconds the user profile will be kept in the cache
     /// </summary>
     public int ProfileCacheLifetimeSeconds { get; set; } = 600;

--- a/src/Altinn.Profile.Core/Integrations/IPersonService.cs
+++ b/src/Altinn.Profile.Core/Integrations/IPersonService.cs
@@ -13,8 +13,9 @@ public interface IPersonService
     /// Asynchronously retrieves the contact details for multiple persons by their national identity numbers.
     /// </summary>
     /// <param name="nationalIdentityNumbers">A collection of national identity numbers to look up.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
     /// <returns>
     /// A task that represents the asynchronous operation. The task result contains a an <see cref="ImmutableList{T}"/> of <see cref="PersonContactPreferences"/> objects representing the contact details of the persons.
     /// </returns>
-    Task<ImmutableList<PersonContactPreferences>> GetContactPreferencesAsync(IEnumerable<string> nationalIdentityNumbers);
+    Task<ImmutableList<PersonContactPreferences>> GetContactPreferencesAsync(IEnumerable<string> nationalIdentityNumbers, CancellationToken cancellationToken);
 }

--- a/src/Altinn.Profile.Core/User.ContactPoints/IUserContactPointsService.cs
+++ b/src/Altinn.Profile.Core/User.ContactPoints/IUserContactPointsService.cs
@@ -9,8 +9,9 @@ public interface IUserContactPointsService
     /// Method for retriveing contact points for a user 
     /// </summary>
     /// <param name="nationalIdentityNumbers">A list of national identity numbers to lookup contact points for</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
     /// <returns>The users' contact points and reservation status or a boolean if failure.</returns>
-    Task<UserContactPointsList> GetContactPoints(List<string> nationalIdentityNumbers);
+    Task<UserContactPointsList> GetContactPoints(List<string> nationalIdentityNumbers, CancellationToken cancellationToken);
 
     /// <summary>
     /// Method for retriveing information about the availability of contact points for a user 

--- a/src/Altinn.Profile.Core/User.ContactPoints/UserContactPointService.cs
+++ b/src/Altinn.Profile.Core/User.ContactPoints/UserContactPointService.cs
@@ -48,11 +48,11 @@ public class UserContactPointService : IUserContactPointsService
     }
 
     /// <inheritdoc/>
-    public async Task<UserContactPointsList> GetContactPoints(List<string> nationalIdentityNumbers)
+    public async Task<UserContactPointsList> GetContactPoints(List<string> nationalIdentityNumbers, CancellationToken cancellationToken)
     {
         UserContactPointsList resultList = new();
 
-        var preferencesForContacts = await _personService.GetContactPreferencesAsync(nationalIdentityNumbers);
+        var preferencesForContacts = await _personService.GetContactPreferencesAsync(nationalIdentityNumbers, cancellationToken);
 
         preferencesForContacts.ForEach(contactPreference =>
         {

--- a/src/Altinn.Profile.Integrations/Repositories/PersonRepository.cs
+++ b/src/Altinn.Profile.Integrations/Repositories/PersonRepository.cs
@@ -35,22 +35,23 @@ public class PersonRepository(IDbContextFactory<ProfileDbContext> contextFactory
     /// Asynchronously retrieves the contact details for multiple persons by their national identity numbers.
     /// </summary>
     /// <param name="nationalIdentityNumbers">A collection of national identity numbers to look up.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
     /// <returns>
     /// A task that represents the asynchronous operation. The task result contains a an <see cref="ImmutableList{T}"/> of <see cref="PersonContactPreferences"/> objects representing the contact details of the persons.
     /// </returns>
     /// <exception cref="ArgumentNullException">Thrown when the <paramref name="nationalIdentityNumbers"/> is null.</exception>
-    public async Task<ImmutableList<PersonContactPreferences>> GetContactPreferencesAsync(IEnumerable<string> nationalIdentityNumbers)
+    public async Task<ImmutableList<PersonContactPreferences>> GetContactPreferencesAsync(IEnumerable<string> nationalIdentityNumbers, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(nationalIdentityNumbers);
 
         if (!nationalIdentityNumbers.Any())
         {
-            return ImmutableList<PersonContactPreferences>.Empty;
+            return [];
         }
 
-        using ProfileDbContext databaseContext = await _contextFactory.CreateDbContextAsync();
+        using ProfileDbContext databaseContext = await _contextFactory.CreateDbContextAsync(cancellationToken);
 
-        List<Person> people = await databaseContext.People.Where(e => nationalIdentityNumbers.Contains(e.FnumberAk)).ToListAsync();
+        List<Person> people = await databaseContext.People.Where(e => nationalIdentityNumbers.Contains(e.FnumberAk)).ToListAsync(cancellationToken);
 
         var asContactPreferences = people.Select(PersonContactPreferencesMapper.Map);
         return asContactPreferences.ToImmutableList();

--- a/src/Altinn.Profile/Controllers/UserContactPointController.cs
+++ b/src/Altinn.Profile/Controllers/UserContactPointController.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 
 using Altinn.Profile.Core.User.ContactPoints;
@@ -51,14 +52,14 @@ public class UserContactPointController : ControllerBase
     /// <returns>Returns an overview of the contact points for the user</returns>
     [HttpPost("lookup")]
     [ProducesResponseType(StatusCodes.Status200OK)]
-    public async Task<ActionResult<UserContactPointsList>> PostLookup([FromBody] UserContactDetailsLookupCriteria userContactPointLookup)
+    public async Task<ActionResult<UserContactPointsList>> PostLookup([FromBody] UserContactDetailsLookupCriteria userContactPointLookup, CancellationToken cancellationToken)
     {
         if (userContactPointLookup.NationalIdentityNumbers.Count == 0)
         {
             return Ok(new UserContactPointsList());
         }
  
-        UserContactPointsList userContactPointsList = await _contactPointService.GetContactPoints(userContactPointLookup.NationalIdentityNumbers);
+        UserContactPointsList userContactPointsList = await _contactPointService.GetContactPoints(userContactPointLookup.NationalIdentityNumbers, cancellationToken);
         return Ok(userContactPointsList);
     }
 }

--- a/src/Altinn.Profile/appsettings.json
+++ b/src/Altinn.Profile/appsettings.json
@@ -9,7 +9,6 @@
     "UpdateA2NotificationSettings": false
   },
   "CoreSettings": {
-    "EnableLocalKrrFetch": false,
     "ProfileCacheLifetimeSeconds": 600
   },
   "PostgreSqlSettings": {

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/UserContactPointControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/UserContactPointControllerTests.cs
@@ -182,7 +182,7 @@ public class UserContactPointControllerTests : IClassFixture<ProfileWebApplicati
         Assert.NotEmpty(actual.ContactPointsList[0].Email);
     }
 
-    private async Task<HttpResponseMessage> GetSBlResponseForSsn(string ssn)
+    private async Task<HttpResponseMessage> GetStoredDataForSsn(string ssn)
     {
         UserProfile userProfile;
 

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/UserContactPointControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/UserContactPointControllerTests.cs
@@ -3,7 +3,6 @@ using System.Collections.Immutable;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Json;
-using System.Runtime.Intrinsics.X86;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -47,6 +46,11 @@ public class UserContactPointControllerTests : IClassFixture<ProfileWebApplicati
     {
         // Seed test data
         var user1 = await GetStoredDataForSsn(ssn);
+
+        if (user1 == null)
+        {
+            return;
+        }
 
         _factory.PersonServiceMock
         .Setup(s => s.GetContactPreferencesAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
@@ -116,8 +120,6 @@ public class UserContactPointControllerTests : IClassFixture<ProfileWebApplicati
         {
             NationalIdentityNumbers = new List<string>() { "01025101037", "99999999999" }
         };
-
-        var user = await GetStoredDataForSsn("01025101037");
 
         HttpClient client = _factory.CreateClient();
         HttpRequestMessage httpRequestMessage = new(HttpMethod.Post, "/profile/api/v1/users/contactpoint/availability");

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/UserContactPointControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/UserContactPointControllerTests.cs
@@ -43,7 +43,7 @@ public class UserContactPointControllerTests : IClassFixture<ProfileWebApplicati
         _factory.SblBridgeSettingsOptions.Setup(s => s.Value).Returns(sblBrideSettings);
     }
 
-    public async Task SeedTestData(string ssn)
+    private async Task SeedTestData(string ssn)
     {
         // Seed test data
         var user1 = await GetStoredDataForSsn(ssn);
@@ -211,7 +211,7 @@ public class UserContactPointControllerTests : IClassFixture<ProfileWebApplicati
         Assert.NotEmpty(actual.ContactPointsList[0].Email);
     }
 
-    private async Task<UserProfile> GetStoredDataForSsn(string ssn)
+    private static async Task<UserProfile> GetStoredDataForSsn(string ssn)
     {
         UserProfile userProfile;
 

--- a/test/Altinn.Profile.Tests/IntegrationTests/ProfileWebApplicationFactory.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/ProfileWebApplicationFactory.cs
@@ -46,6 +46,8 @@ public sealed class ProfileWebApplicationFactory<TProgram> : WebApplicationFacto
 
     public Mock<IContactRegisterHttpClient> ContactRegisterServiceMock { get; set; } = new();
 
+    public Mock<IPersonService> PersonServiceMock { get; set; } = new();
+
     public Mock<IOrganizationNotificationAddressRepository> OrganizationNotificationAddressRepositoryMock { get; set; } = new();
 
     public Mock<IOrganizationNotificationAddressSyncClient> OrganizationNotificationAddressSyncClientMock { get; set; } = new();
@@ -117,6 +119,7 @@ public sealed class ProfileWebApplicationFactory<TProgram> : WebApplicationFacto
 
             services.AddSingleton(AuthorizationClientMock.Object);
             services.AddSingleton(ContactRegisterServiceMock.Object);
+            services.AddSingleton(PersonServiceMock.Object);
             services.AddSingleton(OrganizationNotificationAddressRepositoryMock.Object);
             services.AddSingleton(OrganizationNotificationAddressSyncClientMock.Object);
             services.AddSingleton(OrganizationNotificationAddressUpdateClientMock.Object);

--- a/test/Altinn.Profile.Tests/Profile.Core/User/UserContactPointServiceTest.cs
+++ b/test/Altinn.Profile.Tests/Profile.Core/User/UserContactPointServiceTest.cs
@@ -19,18 +19,12 @@ namespace Altinn.Profile.Tests.Profile.Core.User;
 
 public class UserContactPointServiceTest
 {
-    private readonly Mock<IOptions<CoreSettings>> _coreSettingsOptions;
     private readonly Mock<IUserProfileService> _userProfileServiceMock = new();
     private readonly Mock<IPersonService> _personServiceMock = new();
 
     private static readonly string _userIdAStr = "2001606";
 
     private static readonly string _userIdBStr = "2001607";
-
-    public UserContactPointServiceTest()
-    {
-        _coreSettingsOptions = new Mock<IOptions<CoreSettings>>();
-    }
 
     private async Task<List<UserContactPoints>> MockTestUsers() // Take a look at IAsyncLifetime / InitializeAsync from XUnit, as something for next time
     {
@@ -72,17 +66,12 @@ public class UserContactPointServiceTest
         return [expectedUserContactPointA, expectedUserContactPointB];
     }
 
-    /// <summary>
-    /// Tests that the userprofile available in the cache is returned to the caller without forwarding request to decorated service.
-    /// </summary>
     [Fact]
-    public async Task GetContactPoints_FeatureFlagDisabled_PersonServiceNotCalled()
+    public async Task GetContactPoints_WhenPersonServiceIsCalled_IsSuccess()
     {
         // Arrange
-        _coreSettingsOptions.Setup(s => s.Value).Returns(new CoreSettings { EnableLocalKrrFetch = false });
         List<UserContactPoints> expectedUsers = await MockTestUsers();
-
-        var target = new UserContactPointService(_userProfileServiceMock.Object, _personServiceMock.Object, _coreSettingsOptions.Object);
+        var target = new UserContactPointService(_userProfileServiceMock.Object, _personServiceMock.Object);
 
         // Act
         Result<UserContactPointsList, bool> result = await target.GetContactPoints(
@@ -92,153 +81,26 @@ public class UserContactPointServiceTest
             ]);
 
         // Assert
-        _personServiceMock.Verify(service => service.GetContactPreferencesAsync(It.IsAny<IEnumerable<string>>()), Times.Never());
-    }
+        Assert.True(result.IsSuccess, "Expected a success result");
 
-    [Fact]
-    public async Task GetContactPoints_FeatureFlagDisabled_ProfileServiceIsCalled()
-    {
-        // Arrange
-        _coreSettingsOptions.Setup(s => s.Value).Returns(new CoreSettings { EnableLocalKrrFetch = false });
-        List<UserContactPoints> expectedUsers = await MockTestUsers();
-        var target = new UserContactPointService(_userProfileServiceMock.Object, _personServiceMock.Object, _coreSettingsOptions.Object);
+        result.Match(
+            actual =>
+            {
+                Assert.Equal(2, actual.ContactPointsList.Count);
+                Assert.Contains(actual.ContactPointsList, ob => AreEqualUserContactPoints(ob, expectedUsers[0]));
+                Assert.Contains(actual.ContactPointsList, ob => AreEqualUserContactPoints(ob, expectedUsers[1]));
+            },
+            _ => { });
 
-        // Act
-        Result<UserContactPointsList, bool> result = await target.GetContactPoints(
-            [
-                expectedUsers[0].NationalIdentityNumber,
-                expectedUsers[1].NationalIdentityNumber
-            ]);
-
-        // Assert
-        _userProfileServiceMock.Verify(service => service.GetUser(It.IsAny<string>()), Times.Exactly(2));
-    }
-
-    [Fact]
-    public async Task GetContactPoints_FeatureFlagEnabled_PersonServiceIsCalled()
-    {
-        // Arrange
-        _coreSettingsOptions.Setup(s => s.Value).Returns(new CoreSettings { EnableLocalKrrFetch = true });
-        List<UserContactPoints> expectedUsers = await MockTestUsers();
-        var target = new UserContactPointService(_userProfileServiceMock.Object, _personServiceMock.Object, _coreSettingsOptions.Object);
-
-        // Act
-        Result<UserContactPointsList, bool> result = await target.GetContactPoints(
-            [
-                expectedUsers[0].NationalIdentityNumber,
-                expectedUsers[1].NationalIdentityNumber
-            ]);
-
-        // Assert
         _personServiceMock.Verify(service => service.GetContactPreferencesAsync(It.IsAny<IEnumerable<string>>()), Times.Exactly(1));
     }
 
     [Fact]
-    public async Task GetContactPoints_FeatureFlagEnabled_ProfileServiceNotCalled()
+    public async Task GetContactPoints_WhenNoUsers_ReturnsZeroForUserIds()
     {
         // Arrange
-        _coreSettingsOptions.Setup(s => s.Value).Returns(new CoreSettings { EnableLocalKrrFetch = true });
         List<UserContactPoints> expectedUsers = await MockTestUsers();
-        var target = new UserContactPointService(_userProfileServiceMock.Object, _personServiceMock.Object, _coreSettingsOptions.Object);
-
-        // Act
-        Result<UserContactPointsList, bool> result = await target.GetContactPoints(
-            [
-                expectedUsers[0].NationalIdentityNumber,
-                expectedUsers[1].NationalIdentityNumber
-            ]);
-
-        // Assert
-        _userProfileServiceMock.Verify(service => service.GetUser(It.IsAny<string>()), Times.Never());
-    }
-
-    [Fact]
-    public async Task GetContactPoints_FeatureFlagEnabled_ReturnsExpectedMappingToUserContactPoints()
-    {
-        // Arrange
-        _coreSettingsOptions.Setup(s => s.Value).Returns(new CoreSettings { EnableLocalKrrFetch = true });
-        List<UserContactPoints> expectedUsers = await MockTestUsers();
-        var target = new UserContactPointService(_userProfileServiceMock.Object, _personServiceMock.Object, _coreSettingsOptions.Object);
-
-        // Act
-        Result<UserContactPointsList, bool> result = await target.GetContactPoints(
-            [
-                expectedUsers[0].NationalIdentityNumber,
-                expectedUsers[1].NationalIdentityNumber
-            ]);
-
-        // Assert
-        Assert.True(result.IsSuccess, "Expected a success result");
-
-        result.Match(
-            actual =>
-            {
-                Assert.Equal(2, actual.ContactPointsList.Count);
-                Assert.Contains(actual.ContactPointsList, ob => AreEqualUserContactPoints(ob, expectedUsers[0]));
-                Assert.Contains(actual.ContactPointsList, ob => AreEqualUserContactPoints(ob, expectedUsers[1]));
-            },
-            _ => { });
-    }
-
-    [Fact]
-    public async Task GetContactPoints_FeatureFlagDisabled_ReturnsExpectedMappingToUserContactPoints()
-    {
-        // Arrange
-        _coreSettingsOptions.Setup(s => s.Value).Returns(new CoreSettings { EnableLocalKrrFetch = false });
-        List<UserContactPoints> expectedUsers = await MockTestUsers();
-        var target = new UserContactPointService(_userProfileServiceMock.Object, _personServiceMock.Object, _coreSettingsOptions.Object);
-
-        // Act
-        Result<UserContactPointsList, bool> result = await target.GetContactPoints(
-            [
-                expectedUsers[0].NationalIdentityNumber,
-                expectedUsers[1].NationalIdentityNumber
-            ]);
-
-        // Assert
-        Assert.True(result.IsSuccess, "Expected a success result");
-
-        result.Match(
-            actual =>
-            {
-                Assert.Equal(2, actual.ContactPointsList.Count);
-                Assert.Contains(actual.ContactPointsList, ob => AreEqualUserContactPoints(ob, expectedUsers[0]));
-                Assert.Contains(actual.ContactPointsList, ob => AreEqualUserContactPoints(ob, expectedUsers[1]));
-            },
-            _ => { });
-    }
-
-    [Fact]
-    public async Task GetContactPoints_FeatureFlagEnabled_ReturnsZeroForUserIds()
-    {
-        // Arrange
-        _coreSettingsOptions.Setup(s => s.Value).Returns(new CoreSettings { EnableLocalKrrFetch = true });
-        List<UserContactPoints> expectedUsers = await MockTestUsers();
-        var target = new UserContactPointService(_userProfileServiceMock.Object, _personServiceMock.Object, _coreSettingsOptions.Object);
-
-        // Act
-        Result<UserContactPointsList, bool> result = await target.GetContactPoints(
-            [
-                expectedUsers[0].NationalIdentityNumber,
-                expectedUsers[1].NationalIdentityNumber
-            ]);
-
-        // Assert
-        result.Match(
-            actual =>
-            {
-                Assert.DoesNotContain(actual.ContactPointsList, contactPoint => contactPoint.UserId != 0);
-            },
-            _ => { });
-    }
-
-    [Fact]
-    public async Task GetContactPoints_FeatureFlagDisabled_ReturnsZeroForUserIds()
-    {
-        // Arrange
-        _coreSettingsOptions.Setup(s => s.Value).Returns(new CoreSettings { EnableLocalKrrFetch = false });
-        List<UserContactPoints> expectedUsers = await MockTestUsers();
-        var target = new UserContactPointService(_userProfileServiceMock.Object, _personServiceMock.Object, _coreSettingsOptions.Object);
+        var target = new UserContactPointService(_userProfileServiceMock.Object, _personServiceMock.Object);
 
         // Act
         Result<UserContactPointsList, bool> result = await target.GetContactPoints(

--- a/test/Altinn.Profile.Tests/Profile.Core/User/UserContactPointServiceTest.cs
+++ b/test/Altinn.Profile.Tests/Profile.Core/User/UserContactPointServiceTest.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Altinn.Profile.Core;
@@ -61,7 +62,7 @@ public class UserContactPointServiceTest
         };
         _userProfileServiceMock.Setup(m => m.GetUser(userProfileA.Party.SSN)).ReturnsAsync(userProfileA);
         _userProfileServiceMock.Setup(m => m.GetUser(userProfileB.Party.SSN)).ReturnsAsync(userProfileB);
-        _personServiceMock.Setup(m => m.GetContactPreferencesAsync(It.IsAny<IEnumerable<string>>())).ReturnsAsync([contactPreferencesA, contactPreferencesB]);
+        _personServiceMock.Setup(m => m.GetContactPreferencesAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>())).ReturnsAsync([contactPreferencesA, contactPreferencesB]);
 
         return [expectedUserContactPointA, expectedUserContactPointB];
     }
@@ -78,7 +79,8 @@ public class UserContactPointServiceTest
             [
                 expectedUsers[0].NationalIdentityNumber,
                 expectedUsers[1].NationalIdentityNumber
-            ]);
+            ],
+            CancellationToken.None);
 
         // Assert
         Assert.True(result.IsSuccess, "Expected a success result");
@@ -92,7 +94,7 @@ public class UserContactPointServiceTest
             },
             _ => { });
 
-        _personServiceMock.Verify(service => service.GetContactPreferencesAsync(It.IsAny<IEnumerable<string>>()), Times.Exactly(1));
+        _personServiceMock.Verify(service => service.GetContactPreferencesAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
     }
 
     [Fact]
@@ -107,7 +109,8 @@ public class UserContactPointServiceTest
             [
                 expectedUsers[0].NationalIdentityNumber,
                 expectedUsers[1].NationalIdentityNumber
-            ]);
+            ],
+            CancellationToken.None);
 
         // Assert
         result.Match(

--- a/test/Altinn.Profile.Tests/Profile.Integrations/Person/PersonRepositoryTests.cs
+++ b/test/Altinn.Profile.Tests/Profile.Integrations/Person/PersonRepositoryTests.cs
@@ -75,7 +75,7 @@ public class PersonRepositoryTests : IDisposable
     public async Task GetContactDetailsAsync_WhenFound_ReturnsContactInfo()
     {
         // Act
-        var matches = await _personRepository.GetContactPreferencesAsync(["17111933790"]);
+        var matches = await _personRepository.GetContactPreferencesAsync(["17111933790"], CancellationToken.None);
         var matchedPersonContactPreferences = matches[0];
 
         var expectedPerson = _personContactAndReservationTestData
@@ -90,7 +90,7 @@ public class PersonRepositoryTests : IDisposable
     public async Task GetContactDetailsAsync_WhenMultipleContactsFound_ReturnsMultipleContacts()
     {
         // Act
-        var matchedPersonContactPreferences = await _personRepository.GetContactPreferencesAsync(["24064316776", "11044314101"]);
+        var matchedPersonContactPreferences = await _personRepository.GetContactPreferencesAsync(["24064316776", "11044314101"], CancellationToken.None);
 
         var expectedPersons = _personContactAndReservationTestData
             .Where(e => e.FnumberAk == "24064316776" || e.FnumberAk == "11044314101")
@@ -112,7 +112,7 @@ public class PersonRepositoryTests : IDisposable
     public async Task GetContactDetailsAsync_WhenNoNationalIdentityNumbersProvided_ReturnsEmpty()
     {
         // Act
-        var matchedPersonContactPreferences = await _personRepository.GetContactPreferencesAsync([]);
+        var matchedPersonContactPreferences = await _personRepository.GetContactPreferencesAsync([], It.IsAny<CancellationToken>());
 
         // Assert
         Assert.Empty(matchedPersonContactPreferences);
@@ -122,7 +122,7 @@ public class PersonRepositoryTests : IDisposable
     public async Task GetContactDetailsAsync_WhenNoneFound_ReturnsEmpty()
     {
         // Act
-        var matchedPersonContactPreferences = await _personRepository.GetContactPreferencesAsync(["nonexistent1", "nonexistent2"]);
+        var matchedPersonContactPreferences = await _personRepository.GetContactPreferencesAsync(["nonexistent1", "nonexistent2"], CancellationToken.None);
 
         // Assert
         Assert.Empty(matchedPersonContactPreferences);
@@ -134,7 +134,7 @@ public class PersonRepositoryTests : IDisposable
         // Act
         var expectedPerson = _personContactAndReservationTestData.Find(e => e.FnumberAk == "28026698350");
 
-        var matchedPersonContactPreferences = await _personRepository.GetContactPreferencesAsync(["28026698350", "nonexistent2"]);
+        var matchedPersonContactPreferences = await _personRepository.GetContactPreferencesAsync(["28026698350", "nonexistent2"], CancellationToken.None);
 
         // Assert invalid result
         Assert.Single(matchedPersonContactPreferences);
@@ -229,7 +229,7 @@ public class PersonRepositoryTests : IDisposable
 
         // Assert
         Assert.Equal(1, result);
-        var personList = await _personRepository.GetContactPreferencesAsync(["88888888888"]);
+        var personList = await _personRepository.GetContactPreferencesAsync(["88888888888"], It.IsAny<CancellationToken>());
         var person = personList.FirstOrDefault();
         Assert.NotNull(person);
         Assert.Equal("NO", person.LanguageCode);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Remove the feature flag "EnableLocalKrrFetch" as we allways want to do this from now. 
* Add support for cancellation token to "GetUserContactPoints" vertical

## Related Issue(s)
- #562 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cancellation support across contact-point APIs and integrations to allow aborting long-running requests.
* **Refactor**
  * Simplified contact-point retrieval to a single consistent path and removed a legacy configuration flag controlling local fetch.
* **Tests**
  * Updated tests and test factories to seed data, mock the person service, and cover the new cancellation-aware and streamlined flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->