### PR TITLE
Feature/572 create resource to retrieve all groups for a user

### DIFF
--- a/src/Altinn.Profile.Core/User.PartyGroups/IPartyGroupService.cs
+++ b/src/Altinn.Profile.Core/User.PartyGroups/IPartyGroupService.cs
@@ -6,6 +6,11 @@
     public interface IPartyGroupService
     {
         /// <summary>
+        /// Retrieves all groups for a given user. If none are found, an empty list is returned.
+        /// </summary>
+        Task<List<Group>> GetGroupsForAUser(int userId, CancellationToken cancellationToken);
+
+        /// <summary>
         /// Gets the favorite parties for a given user. If no favorites are added, an empty group will be returned.
         /// </summary>
         Task<Group> GetFavorites(int userId, CancellationToken cancellationToken);
@@ -20,5 +25,5 @@
         /// Delete the given party from a users list of favorites.
         /// </summary>
         Task<bool> DeleteFromFavorites(int userId, Guid partyUuid, CancellationToken cancellationToken);
-    }
+   }
 }

--- a/src/Altinn.Profile.Core/User.PartyGroups/PartyGroupService.cs
+++ b/src/Altinn.Profile.Core/User.PartyGroups/PartyGroupService.cs
@@ -8,6 +8,14 @@ namespace Altinn.Profile.Core.PartyGroups
         private readonly IPartyGroupRepository _groupRepository = groupRepository;
 
         /// <inheritdoc/>
+        public async Task<List<Group>> GetGroupsForAUser(int userId, CancellationToken cancellationToken)
+        {
+            var groups = await _groupRepository.GetGroups(userId, false, cancellationToken) ?? [];            
+            
+            return groups;
+        }
+
+        /// <inheritdoc/>
         public async Task<Group> GetFavorites(int userId, CancellationToken cancellationToken)
         {
             var favorites = await _groupRepository.GetFavorites(userId, cancellationToken);

--- a/src/Altinn.Profile/Controllers/PartyGroupsController.cs
+++ b/src/Altinn.Profile/Controllers/PartyGroupsController.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Altinn.Profile.Authorization;
+using Altinn.Profile.Core.PartyGroups;
+using Altinn.Profile.Models;
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Altinn.Profile.Controllers
+{
+    /// <summary>
+    /// Controller for retrieving all groups for the current user
+    /// </summary>
+    /// <remarks>
+    /// Initializes a new instance of the <see cref="PartyGroupsController"/> class.
+    /// </remarks>
+    [Authorize]
+    [Route("profile/api/v1/users/current/party-groups")]    
+    [Produces("application/json")]
+    public class PartyGroupsController(IPartyGroupService partyGroupService) : ControllerBase
+    {
+        private readonly IPartyGroupService _partyGroupService = partyGroupService;
+
+        /// <summary>
+        /// Retrieve all groups for a user
+        /// </summary>
+        /// <returns>All groups for the current user.</returns>
+        [HttpGet]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        public async Task<ActionResult<IReadOnlyList<GroupResponse>>> Get(CancellationToken cancellationToken)
+        {
+            var validationResult = ClaimsHelper.TryGetUserIdFromClaims(Request.HttpContext, out int userId);
+            if (validationResult != null)
+            {
+                return validationResult;
+            }
+
+            var groupResponse = await _partyGroupService.GetGroupsForAUser(userId, cancellationToken);
+
+            var response = groupResponse.Select(g => new GroupResponse 
+                            { 
+                                Parties = [.. g.Parties.Select(p => p.PartyUuid)],
+                                Name = g.Name, 
+                                IsFavorite = g.IsFavorite,
+                                GroupId = g.GroupId
+                            });
+
+            return Ok(response);
+        }
+    }
+}

--- a/src/Altinn.Profile/Models/GroupResponse.cs
+++ b/src/Altinn.Profile/Models/GroupResponse.cs
@@ -8,6 +8,11 @@ namespace Altinn.Profile.Models
     public class GroupResponse
     {
         /// <summary>
+        /// The unique identifier of the group
+        /// </summary>
+        public int GroupId { get; set; }
+
+        /// <summary>
         /// The name of the group
         /// </summary>
         public string Name { get; set; }

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/PartyGroupControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/PartyGroupControllerTests.cs
@@ -1,0 +1,248 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Altinn.Profile.Core.PartyGroups;
+using Altinn.Profile.Models;
+using Altinn.Profile.Tests.IntegrationTests.Utils;
+
+using Moq;
+
+using Xunit;
+
+namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
+{
+    public class PartyGroupControllerTests : IClassFixture<ProfileWebApplicationFactory<Program>>
+    {
+        private readonly JsonSerializerOptions _serializerOptionsCamelCase = new()
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+
+        private readonly ProfileWebApplicationFactory<Program> _factory;
+
+        public PartyGroupControllerTests(ProfileWebApplicationFactory<Program> factory)
+        {
+            _factory = factory;
+            _factory.PartyGroupRepositoryMock.Reset();
+            _factory.PartyGroupRepositoryMock
+                .Setup(x => x.GetGroups(It.IsAny<int>(), false, It.IsAny<CancellationToken>()))
+             .ReturnsAsync(new List<Group>
+                {
+                    new Group
+                    {
+                        Parties = [new PartyGroupAssociation { PartyUuid = Guid.NewGuid() }, new PartyGroupAssociation { PartyUuid = Guid.NewGuid() }],
+                        Name = "__group0__",
+                        GroupId = 1,
+                    }
+                });
+        }
+
+        [Fact]
+        public async Task Get_ReturnsGroupedPartyUuids_WhenUserIsValid()
+        {
+            // Arrange
+            const int UserId = 2516356;
+
+            HttpClient client = _factory.CreateClient();
+
+            HttpRequestMessage httpRequestMessage = CreateRequest(HttpMethod.Get, UserId, "profile/api/v1/users/current/party-groups");
+
+            // Act
+            HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+
+            // Assert
+            Assert.NotNull(response);
+            Assert.True(response.IsSuccessStatusCode);
+
+            string responseContent = await response.Content.ReadAsStringAsync();
+
+            List<GroupResponse> groupResponses = JsonSerializer.Deserialize<List<GroupResponse>>(
+                responseContent, _serializerOptionsCamelCase);
+                       
+            Assert.Equal(2, groupResponses[0].Parties.Length);
+            Assert.Equal("__group0__", groupResponses[0].Name);
+            Assert.Equal(1, groupResponses[0].GroupId);
+        }
+
+        [Fact]
+        public async Task Get_ReturnsMultipleGroupedPartyUuids_WhenUserIsValid()
+        {
+            // Arrange
+            const int UserId = 2516356;
+
+            _factory.PartyGroupRepositoryMock
+                .Setup(x => x.GetGroups(It.IsAny<int>(), false, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<Group>
+                {
+                    new Group
+                    {
+                        Parties = [
+                            new PartyGroupAssociation { PartyUuid = Guid.NewGuid() },
+                            new PartyGroupAssociation { PartyUuid = Guid.NewGuid() }],
+                        Name = "__group0__",
+                        GroupId = 1,
+                    },
+                    new Group
+                    {
+                        Parties = [new PartyGroupAssociation { PartyUuid = Guid.NewGuid() },
+                                   new PartyGroupAssociation { PartyUuid = Guid.NewGuid() },
+                                   new PartyGroupAssociation { PartyUuid = Guid.NewGuid() },
+                                   new PartyGroupAssociation { PartyUuid = Guid.NewGuid() }
+                        ],
+                        Name = "__group1__",
+                        GroupId = 2,
+                    },
+                });
+
+            HttpClient client = _factory.CreateClient();
+
+            HttpRequestMessage httpRequestMessage = CreateRequest(HttpMethod.Get, UserId, "profile/api/v1/users/current/party-groups");
+
+            // Act
+            HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+
+            // Assert
+            Assert.NotNull(response);
+            Assert.True(response.IsSuccessStatusCode);
+
+            string responseContent = await response.Content.ReadAsStringAsync();
+
+            List<GroupResponse> groupResponses = JsonSerializer.Deserialize<List<GroupResponse>>(
+                responseContent, _serializerOptionsCamelCase);
+
+            Assert.Equal(2, groupResponses[0].Parties.Length);
+            Assert.Equal("__group0__", groupResponses[0].Name);
+            Assert.Equal(1, groupResponses[0].GroupId);
+            Assert.Equal(4, groupResponses[1].Parties.Length);
+            Assert.Equal("__group1__", groupResponses[1].Name);
+            Assert.Equal(2, groupResponses[1].GroupId);
+        }
+
+        [Fact]
+        public async Task GetPartyGroups_WhenRepositoryReturnsEmptyGroup_IsOk()
+        {
+            // Arrange
+            const int UserId = 2516356;
+
+            _factory.PartyGroupRepositoryMock
+            .Setup(x => x.GetGroups(It.IsAny<int>(), false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<Group>
+            {
+                        new Group
+                        {
+                            Parties = [],
+                            Name = "__group0__",
+                            GroupId = 1,
+                        }
+            });
+
+            HttpClient client = _factory.CreateClient();
+
+            HttpRequestMessage httpRequestMessage = CreateRequest(HttpMethod.Get, UserId, "profile/api/v1/users/current/party-groups");
+
+            // Act
+            HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+
+            // Assert
+            Assert.NotNull(response);
+            Assert.True(response.IsSuccessStatusCode);
+
+            string responseContent = await response.Content.ReadAsStringAsync();
+
+            List<GroupResponse> groupResponse = JsonSerializer.Deserialize<List<GroupResponse>>(
+                responseContent, _serializerOptionsCamelCase);
+
+            Assert.Empty(groupResponse[0].Parties);
+        }
+
+        [Fact]
+        public async Task GetPartyGroups_WhenUserHasNoGroups_ReturnsEmptyList()
+        {
+            // Arrange
+            const int UserId = 2516356;
+
+            _factory.PartyGroupRepositoryMock
+               .Setup(x => x.GetGroups(It.IsAny<int>(), false, It.IsAny<CancellationToken>()))
+               .ReturnsAsync(new List<Group> { });
+
+            HttpClient client = _factory.CreateClient();
+
+            HttpRequestMessage httpRequestMessage = CreateRequest(HttpMethod.Get, UserId, "profile/api/v1/users/current/party-groups");
+
+            // Act
+            HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+
+            // Assert
+            Assert.NotNull(response);
+            Assert.True(response.IsSuccessStatusCode);
+
+            string responseContent = await response.Content.ReadAsStringAsync();
+
+            List<GroupResponse> groupResponse = JsonSerializer.Deserialize<List<GroupResponse>>(
+                responseContent, _serializerOptionsCamelCase);
+
+            Assert.Empty(groupResponse);
+        }
+
+        [Fact]
+        public async Task GetPartyGroups_WhenRepositoryReturnsNull_ReturnsEmptyList()
+        {
+            // Arrange
+            const int UserId = 2516356;
+
+            _factory.PartyGroupRepositoryMock
+               .Setup(x => x.GetGroups(It.IsAny<int>(), false, It.IsAny<CancellationToken>()))
+               .ReturnsAsync((List<Group>)null);
+
+            HttpClient client = _factory.CreateClient();
+
+            HttpRequestMessage httpRequestMessage = CreateRequest(HttpMethod.Get, UserId, "profile/api/v1/users/current/party-groups");
+
+            // Act
+            HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+
+            // Assert
+            Assert.NotNull(response);
+            Assert.True(response.IsSuccessStatusCode);
+
+            string responseContent = await response.Content.ReadAsStringAsync();
+
+            List<GroupResponse> groupResponse = JsonSerializer.Deserialize<List<GroupResponse>>(
+                responseContent, _serializerOptionsCamelCase);
+
+            Assert.NotNull(groupResponse);
+            Assert.Empty(groupResponse);
+        }
+
+        [Fact]
+        public async Task Get_WhenNoUserIdClaim_ReturnsBadRequest_AndRepositoryNotCalled()
+        {
+            // Arrange
+            HttpClient client = _factory.CreateClient();
+            var request = new HttpRequestMessage(HttpMethod.Get, "profile/api/v1/users/current/party-groups");
+
+            // Act
+            HttpResponseMessage response = await client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+            
+            _factory.PartyGroupRepositoryMock.Verify(x => x.GetGroups(It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        private static HttpRequestMessage CreateRequest(HttpMethod method, int userId, string requestUri)
+        {
+            HttpRequestMessage httpRequestMessage = new(method, requestUri);
+            string token = PrincipalUtil.GetToken(userId);
+            httpRequestMessage.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            return httpRequestMessage;
+        }
+    }
+}

--- a/test/Bruno/Profile/Favorites/Get Party Groups.bru
+++ b/test/Bruno/Profile/Favorites/Get Party Groups.bru
@@ -1,0 +1,15 @@
+meta {
+  name: Get Party Groups
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{ProfileBaseAddress}}/api/v1/users/current/party-groups
+  body: none
+  auth: inherit
+}
+
+script:pre-request {
+  await bru.runRequest("TokenGenerator/portal user")
+}


### PR DESCRIPTION
## Description
* Create a new controller for the new resource
* PartyGroupsController returns a list of all group names, along with a list of parties
* Added a new GroupId field to the GroupResponse model
* Return a list of all group names, along with a list of parties

## Related Issue(s)
- #572 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an authorized JSON GET endpoint to retrieve all party groups for the current user. Responses include GroupId, name, associated parties (party UUIDs), favorite flag, and return an empty list when none are found.

* **Tests**
  * Integration tests covering single/multiple groups, empty results, user with no groups, and missing user-id claim.
  * Added an automated HTTP test/spec for the new endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->