### PR TITLE
Add package rules for nuget major updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,7 +22,7 @@
       "matchManagers": ["nuget"],
       "matchUpdateTypes": ["major"],
       "matchPackagePatterns": ["/^([^\\.]+)/"],
-      "groupName": "Grouped major upgrades: {{depName}}",
+      "groupName": "Grouped major upgrades: {{depName}}"
     }
   ]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Group major upgrades with the same Package prefix so that major package upgrades are handled coherently. 

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a Renovate rule to group NuGet major updates by package, so major releases are handled per dependency.
  * Streamlines update management and reduces noisy or mixed-version major update PRs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->