### PR TITLE
Get CodeQL coverage on GH workflows

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -33,25 +33,25 @@ jobs:
           - language: csharp
             build-mode: autobuild
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-    - name: Setup .NET 9.0.* SDK
-      if: matrix.language == 'csharp'
-      uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d # v5.0.0
-      with:
-        dotnet-version: |
-          9.0.x
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@0499de31b99561a6d14a36a5f662c2a54f91beee # v4.31.2
-      with:
-        languages: ${{ matrix.language }}
-        build-mode: ${{ matrix.build-mode }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Setup .NET 9.0.* SDK
+        if: matrix.language == 'csharp'
+        uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d # v5.0.0
+        with:
+          dotnet-version: |
+            9.0.x
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@0499de31b99561a6d14a36a5f662c2a54f91beee # v4.31.2
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
+          # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@0499de31b99561a6d14a36a5f662c2a54f91beee # v4.31.2
-      with:
-        category: '/language:${{matrix.language}}'
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@0499de31b99561a6d14a36a5f662c2a54f91beee # v4.31.2
+        with:
+          category: '/language:${{matrix.language}}'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Adds `actions` as a language in the matrix to introduce a separate job for analysis of workflow files
- Adds '.github/workflows/**' as path trigger for `push` and `pull_request`, to have the CodeQL job run for PRs that modify workflow files
- Removes the CodeQL `Autobuild` step, as this is apparently redundant - can be replaced by setting `build-mode: autobuild` in the `init` step, [ref. docs](https://github.com/github/codeql-action?tab=readme-ov-file#actions)
- Formats the yaml

## Related Issue(s)
- https://github.com/Altinn/team-core-private/issues/353

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to support multi-language analysis via a matrix with language-specific entries.
  * Added conditional tooling setup so .NET tooling runs only for C# entries.
  * Propagated build-mode and language settings through the analysis pipeline for more accurate scans.
  * Expanded trigger scope to include workflow file changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->