### PR TITLE
Fix flaky cleanup of TelemetryTests

### DIFF
--- a/test/Altinn.Profile.Tests/IntegrationTests/TelemetryTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/TelemetryTests.cs
@@ -69,7 +69,7 @@ public class TelemetryTests(ProfileWebApplicationFactory<Program> factory)
         }
 
         // We need to let End callback execute as it is executed AFTER response was returned.
-        // In unit tests environment there may be a lot of parallel unit tests generated, so
+        // In unit tests environment there may be a lot of parallel unit tests executed, so
         // giving some breezing room for the End callback to complete
         await Task.Delay(TimeSpan.FromSeconds(1));
 


### PR DESCRIPTION
## Description
An alternative way to flush meter registrations before test assertion, to try and avoid periodic test runs where the test run exits with code 1 b/c of:
 `[Test Class Cleanup Failure (Altinn.Profile.Tests.IntegrationTests.TelemetryTests)] System.OperationCanceledException`
([example)](https://github.com/Altinn/altinn-profile/actions/runs/19138327849/job/54696151349?pr=624)


Because the test class uses IClassFixture, context is shared between tests (ref [xUnit docs on IClassFixture](https://xunit.net/docs/shared-context#class-fixture)). It seems that the current setup can result in race conditions during test cleanup and consequent flaky cleanup issues from the shared state.

This PR replaces the use of a shared field for the separately disposed MeterProvider with a local (non-shared) MeterProvider that is flushed in each test function.

## Related Issue(s)
N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated telemetry test resource management lifecycle and disposal patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->