### PR TITLE
Feature/587 Dashboard controller search for notificationaddress (kofuvi) by email address

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ dotnet user-secrets set "ContactAndReservationSettings:MaskinportenSettings:Enco
 
 ### Adding migrations with EF core
 1. Code the desired classes and add them to the DB context
+2. Ensure you have the EF core tools installed. If not, run the following command:
+   ```cmd
+   dotnet tool install --global dotnet-ef
+   ```
 2. Run the following command in a terminal from src/Altinn.Profile.Integrations to add a migration. The name should be more descriptive than AddNewMigration:
    ```cmd
    dotnet ef migrations Add AddNewMigration --startup-project ../Altinn.Profile

--- a/src/Altinn.Profile.Core/Integrations/IOrganizationNotificationAddressRepository.cs
+++ b/src/Altinn.Profile.Core/Integrations/IOrganizationNotificationAddressRepository.cs
@@ -20,6 +20,14 @@ public interface IOrganizationNotificationAddressRepository
     Task<IEnumerable<Organization>> GetOrganizationsAsync(List<string> organizationNumbers, CancellationToken cancellationToken);
 
     /// <summary>
+    /// Fetches notification addresses filtered by email address
+    /// </summary>
+    /// <param name="emailAddress">The email address to search for in notification addresses</param>
+    /// <param name="cancellationToken">Cancellation token to cancel the operation</param>
+    /// <returns>A <see cref="Task{TResult}"/> with a collection of organization notification addresses as value.</returns>
+    Task<IEnumerable<Organization>> GetOrganizationNotificationAddressesByEmailAddressAsync(string emailAddress, CancellationToken cancellationToken);
+
+    /// <summary>
     /// Creates a new notification address for an organization
     /// </summary>
     /// <returns>A <see cref="Task{TResult}"/> with the notification address as value.</returns>

--- a/src/Altinn.Profile.Core/OrganizationNotificationAddresses/IOrganizationNotificationAddressesService.cs
+++ b/src/Altinn.Profile.Core/OrganizationNotificationAddresses/IOrganizationNotificationAddressesService.cs
@@ -31,6 +31,14 @@ public interface IOrganizationNotificationAddressesService
     Task<IEnumerable<Organization>> GetOrganizationNotificationAddresses(List<string> organizationNumbers, CancellationToken cancellationToken, bool useAddressFromMainUnitIfEmpty = false);
 
     /// <summary>
+    /// Method for retrieving notification addresses filtered by email address.
+    /// </summary>
+    /// <param name="emailAddress">The email address to search for in notification addresses</param>
+    /// <param name="cancellationToken">To cancel the request before it is finished</param>
+    /// <returns>A collection of organizations that have notification addresses matching the specified email address.</returns>
+    Task<IEnumerable<Organization?>> GetOrganizationNotificationAddressesByEmailAddress(string emailAddress, CancellationToken cancellationToken);
+
+    /// <summary>
     /// Method for deleting a notification addresses for an organization
     /// </summary>
     /// <param name="organizationNumber">An organization number to indicate which organization to update addresses for</param>

--- a/src/Altinn.Profile.Core/OrganizationNotificationAddresses/OrganizationNotificationAddressesService.cs
+++ b/src/Altinn.Profile.Core/OrganizationNotificationAddresses/OrganizationNotificationAddressesService.cs
@@ -127,6 +127,12 @@ namespace Altinn.Profile.Core.OrganizationNotificationAddresses
             return result;
         }
 
+        /// <inheritdoc/>
+        public async Task<IEnumerable<Organization?>> GetOrganizationNotificationAddressesByEmailAddress(string emailAddress, CancellationToken cancellationToken)
+        {
+            return await _orgRepository.GetOrganizationNotificationAddressesByEmailAddressAsync(emailAddress, cancellationToken);
+        }
+
         private async Task<IEnumerable<Organization>> GetOrganizationsWithNotificationAddressesFromMainUnit(List<string> organizationNumbers, List<Organization> organizationList, CancellationToken cancellationToken)
         {
             var orgsMissingAddress = organizationNumbers.Except(organizationList.Select(o => o.OrganizationNumber));
@@ -154,6 +160,6 @@ namespace Altinn.Profile.Core.OrganizationNotificationAddresses
             }
 
             return organizationList;
-        }
+        }        
     }
 }

--- a/src/Altinn.Profile.Integrations/Migration/v0.20/01-add-index-for-notification-address.sql
+++ b/src/Altinn.Profile.Integrations/Migration/v0.20/01-add-index-for-notification-address.sql
@@ -1,0 +1,1 @@
+CREATE INDEX ix_full_address ON organization_notification_address.notifications_address (full_address);

--- a/src/Altinn.Profile.Integrations/Persistence/ProfiledbContext.cs
+++ b/src/Altinn.Profile.Integrations/Persistence/ProfiledbContext.cs
@@ -128,6 +128,7 @@ public partial class ProfileDbContext : DbContext
         modelBuilder.Entity<NotificationAddressDE>(entity =>
         {
             entity.HasKey(e => e.NotificationAddressID).HasName("contact_info_pkey");
+            entity.HasIndex(e => e.FullAddress, "ix_full_address");
             entity.Property(e => e.CreatedDateTime).HasDefaultValueSql("now()").ValueGeneratedOnAdd();
         });
 

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/DashboardNotificationAddressesControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/DashboardNotificationAddressesControllerTests.cs
@@ -45,7 +45,6 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
                             FullAddress = "test@example.com",
                             AddressType = AddressType.Email,
                             NotificationAddressID = 1,
-                           
                             RegistryUpdatedDateTime = _testTime,
                         },
                     ]
@@ -269,6 +268,82 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
 
             HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, $"/profile/api/v1/dashboard/organizations/{orgNumber}/notificationaddresses");
             httpRequestMessage = GenerateTokenWithoutScope(orgNumber, httpRequestMessage);
+
+            // Act
+            HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task GetNotificationAddressesByEmailAddress_WhenFound_ReturnsOkWithAddresses()
+        {
+            // Arrange
+            string emailAddress = "test@test.com";
+
+            _factory.OrganizationNotificationAddressRepositoryMock
+                .Setup(r => r.GetOrganizationNotificationAddressesByEmailAddressAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(_testdata.Where(o => o.NotificationAddresses != null && 
+                    o.NotificationAddresses.Any(n => n.FullAddress == emailAddress && 
+                    n.IsSoftDeleted != true && 
+                    n.HasRegistryAccepted != false)));
+
+            HttpClient client = _factory.CreateClient();
+
+            HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, $"/profile/api/v1/dashboard/organizations/notificationaddresses/email/{emailAddress}");
+
+            httpRequestMessage = CreateAuthorizedRequestWithScope(httpRequestMessage);
+
+            // Act
+            HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            string responseContent = await response.Content.ReadAsStringAsync();
+            var result = JsonSerializer.Deserialize<List<DashboardNotificationAddressResponse>>(responseContent, _serializerOptions);
+
+            Assert.NotNull(result);
+
+            var emailItem = result.FirstOrDefault(a => a.Email != null);
+            Assert.NotNull(emailItem);
+            Assert.Equal(emailAddress, emailItem.Email);
+        }
+
+        [Fact]
+        public async Task GetNotificationAddressesByEmailAddress_WhenNotFound_ReturnsNotFound()
+        {
+            // Arrange
+            string emailAddress = "missingtest@test.com";
+
+            _factory.OrganizationNotificationAddressRepositoryMock
+                .Setup(r => r.GetOrganizationNotificationAddressesByEmailAddressAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Enumerable.Empty<Organization>());
+
+            HttpClient client = _factory.CreateClient();
+            HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, $"/profile/api/v1/dashboard/organizations/notificationaddresses/email/{emailAddress}");
+            httpRequestMessage = CreateAuthorizedRequestWithScope(httpRequestMessage);
+            
+            // Act
+            HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);            
+        }
+
+        [Fact]
+        public async Task GetNotificationAddressesByEmailAddress_WhenNoAccess_ReturnsForbidden()
+        {
+            // Arrange
+            string emailAddress = "noaccess@test.com";
+
+            _factory.OrganizationNotificationAddressRepositoryMock
+          .Setup(r => r.GetOrganizationNotificationAddressesByEmailAddressAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+          .ReturnsAsync(Enumerable.Empty<Organization>());
+
+            HttpClient client = _factory.CreateClient();
+            HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, $"/profile/api/v1/dashboard/organizations/notificationaddresses/email/{emailAddress}");
+            httpRequestMessage = GenerateTokenWithoutScope("any-org", httpRequestMessage);
 
             // Act
             HttpResponseMessage response = await client.SendAsync(httpRequestMessage);

--- a/test/Altinn.Profile.Tests/Profile.Integrations/OrganizationNotificationAddressTests/OrganizationNotificationAddressRepositoryTests.cs
+++ b/test/Altinn.Profile.Tests/Profile.Integrations/OrganizationNotificationAddressTests/OrganizationNotificationAddressRepositoryTests.cs
@@ -104,6 +104,43 @@ public class OrganizationNotificationAddressRepositoryTests : IDisposable
     }
 
     [Fact]
+    public async Task GetOrganizationNotificationAddressByEmailAddress_WhenFound_ReturnsWithNotificationAddresses() 
+    { 
+        // Arrange
+        var (organizations, notificationAddresses) = OrganizationNotificationAddressTestData.GetNotificationAddresses();
+        SeedDatabase(organizations, notificationAddresses);
+
+        // Act
+        var result = await _repository.GetOrganizationNotificationAddressesByEmailAddressDEAsync("test.email@test.no", CancellationToken.None);
+        var list = result.ToList();
+
+        // Assert
+        Assert.Single(list);
+        var returned = list.Single();
+        Assert.Equal("123456789", returned.RegistryOrganizationNumber);
+
+        Assert.NotNull(returned.NotificationAddresses);
+        Assert.Equal(2, returned.NotificationAddresses.Count);
+        Assert.All(returned.NotificationAddresses, na => Assert.True(na.IsSoftDeleted != true));
+        Assert.Contains(returned.NotificationAddresses, na => na.AddressType == AddressType.Email && na.FullAddress == "test.email@test.no");
+    }
+
+    [Fact]
+    public async Task GetOrganizationNotificationAddressByEmailAddress_WhenNotFound_ReturnsEmptyList()
+    {
+        // Arrange
+        var (organizations, notificationAddresses) = OrganizationNotificationAddressTestData.GetNotificationAddresses();
+        SeedDatabase(organizations, notificationAddresses);
+        
+        // Act
+        var result = await _repository.GetOrganizationNotificationAddressesByEmailAddressDEAsync("doesnotexist@test.com", CancellationToken.None);
+        var list = result.ToList();
+        
+        // Assert
+        Assert.Empty(list);
+    }
+
+    [Fact]
     public async Task SyncNotificationAddressesAsync_WithProperData_ReturnsUpdatedRows()
     {
         // Arrange

--- a/test/Bruno/Profile/Dashboard/GetNotificationAddressesByEmailAddress.bru
+++ b/test/Bruno/Profile/Dashboard/GetNotificationAddressesByEmailAddress.bru
@@ -1,0 +1,15 @@
+meta {
+  name: GetNotificationAddressesByEmailAddress
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{ProfileBaseAddress}}/api/v1/dashboard/organizations/notificationaddresses/email/{{emailAddress}}
+  body: none
+  auth: inherit
+}
+
+script:pre-request {
+  await bru.runRequest("TokenGenerator/Application Owner Profile scope")
+}

--- a/test/Bruno/environments/Local.bru
+++ b/test/Bruno/environments/Local.bru
@@ -2,14 +2,17 @@ vars {
   Environment: dev
   BaseUrl: http://localhost:5030
   ProfileBaseAddress: {{BaseUrl}}/profile
-  AuthN_UserId: 20885478
+  AuthN_UserId:
   AuthN_PartyId: 
-  AuthN_Pid: 17902349936
-  AuthN_PartyUuid: 
+  AuthN_Pid:
+  AuthN_PartyUuid:   
   Party_OrgNo: 
-  Party_PartyId: 
-  Party_PartyUuid: 
+  Party_PartyId:   
+  Party_PartyUuid:   
+  organizationNumber: 
+  emailAddress: 
 }
 vars:secret [
+  AccessToken,
   BearerToken
 ]


### PR DESCRIPTION
## Description
* Create a search endpoint that returns all relevant notification addresses for the given email address
* Created a new index in Notification Address table to support search by email
* Align the response schema with existing DashboardController payload conventions so the Support Dashboard can present contact data consistently

Contract examples are documented in Swagger/OpenAP
## Related Issue(s)
- #587 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Query organization notification addresses by email — returns matching organizations with mapped notification addresses and proper validation/error responses.

* **Documentation**
  * Added EF Core tools installation step to migration setup.

* **Chores / Performance**
  * Added DB index on notification address full address to improve query performance.
  * Updated test environment placeholders and added org/email config fields.

* **Tests**
  * Added HTTP and integration tests for the email-based notification address endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->