### PR TITLE
Exclude digest updates from minRelAge requirement

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,13 @@
   ],
   "packageRules": [
     {
+      "description": "Disable minimumReleaseAge for digest updates since they lack release timestamps (ref. https://docs.renovatebot.com/key-concepts/minimum-release-age/#which-update-types-take-minimumreleaseage-into-account)",
+      "matchUpdateTypes": [
+        "digest"
+      ],
+      "minimumReleaseAge": null
+    },
+    {
       "matchManagers": [
         "nuget"
       ],


### PR DESCRIPTION
Digest updates don't have release timestamps, which means the minimumReleaseAge (formerly stabilityDays) check cannot be evaluated and remains stuck in a "pending" state indefinitely. Examples include the PRs https://github.com/Altinn/altinn-profile/pull/675 and https://github.com/Altinn/altinn-profile/pull/666

From the [Renovate documentation](https://docs.renovatebot.com/key-concepts/minimum-release-age/#which-update-types-take-minimumreleaseage-into-account):

"Generally, Renovate does not provide release timestamps for digest updates." 

The solution of this PR is recommended from the Renovate team, ref [this discussion](https://github.com/renovatebot/renovate/discussions/39058) and [the official docs](https://docs.renovatebot.com/key-concepts/minimum-release-age/#how-do-i-opt-out-dependencies-from-minimum-release-age-checks)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined dependency management configuration to optimize handling of digest-based dependency updates. Timing restrictions previously applied to digest updates have been removed, enabling faster and more efficient processing. The system can now apply digest updates more promptly without unnecessary delays in the automated dependency management workflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->