### PR TITLE
Use semver for Docker images

### DIFF
--- a/.github/workflows/build-and-analyze.yml
+++ b/.github/workflows/build-and-analyze.yml
@@ -1,12 +1,12 @@
 name: Code test and analysis
 on:
   push:
-    branches: [ main ]
+    branches: [main]
     paths-ignore:
-      - "test/k6/**"
-      - ".github/**"
+      - 'test/k6/**'
+      - '.github/**'
   pull_request:
-    branches: [ main ]
+    branches: [main]
     types: [opened, synchronize, reopened]
   workflow_dispatch:
 jobs:
@@ -18,19 +18,19 @@ jobs:
       contents: read
       checks: write
     services:
-     postgres:
-       image: postgres:17@sha256:7352e0c4d62bbac8aa69d95e40220a60967c4a19f9c4f65b4d118175f7ce9e3b
-       env:
-         POSTGRES_USER: platform_profile_admin
-         POSTGRES_PASSWORD: Password
-         POSTGRES_DB: profiledb
-       options: >-
-         --health-cmd pg_isready
-         --health-interval 10s
-         --health-timeout 5s
-         --health-retries 5
-       ports:
-         - 5432:5432
+      postgres:
+        image: postgres:17.7@sha256:7352e0c4d62bbac8aa69d95e40220a60967c4a19f9c4f65b4d118175f7ce9e3b
+        env:
+          POSTGRES_USER: platform_profile_admin
+          POSTGRES_PASSWORD: Password
+          POSTGRES_DB: profiledb
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
     steps:
       - name: Setup .NET
         uses: actions/setup-dotnet@baa11fbfe1d6520db94683bd5c7a3818018e4309 # v5.1.0
@@ -44,11 +44,11 @@ jobs:
           java-version: 17
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
       - name: Setup PostgreSQL
         run: |
-            chmod +x dbsetup.sh
-            ./dbsetup.sh
+          chmod +x dbsetup.sh
+          ./dbsetup.sh
       - name: Restart database to enable config changes
         run: |
           docker restart $(docker ps -q)
@@ -57,7 +57,7 @@ jobs:
           dotnet tool install --global dotnet-sonarscanner
       - name: Build & Test
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
           dotnet-sonarscanner begin /k:"Altinn_altinn-profile" /o:"altinn" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vstest.reportsPaths="**/*.trx" /d:sonar.cs.opencover.reportsPaths="**/coverage.opencover.xml" /d:sonar.exclusions="**/ServiceDefaults.**"
@@ -74,7 +74,7 @@ jobs:
       - name: Complete sonar analysis
         if: always()
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
           dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
@@ -83,7 +83,7 @@ jobs:
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: TestResults
-          path: '**/TestResults/*.trx'      
+          path: '**/TestResults/*.trx'
       - name: Process .NET test result
         if: always()
         uses: NasAmin/trx-parser@359b39f5319df4478443ef1f0eb952f159896995 # v0.7.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN dotnet restore ./src/Altinn.Profile/Altinn.Profile.csproj
 COPY src ./src
 RUN dotnet publish -c Release -o /app_output ./src/Altinn.Profile/Altinn.Profile.csproj
 
-FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine3.23@sha256:961ef553f5b47185707ef693f9103004ea98cf022ce826cc8aacd5da29c93a46 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:10.0.2-alpine3.23@sha256:961ef553f5b47185707ef693f9103004ea98cf022ce826cc8aacd5da29c93a46 AS final
 EXPOSE 5030
 WORKDIR /app
 


### PR DESCRIPTION
Should solve digest patch PRs where the renovate/stabilityDays check cannot be evaluated and remains stuck in a "pending" state indefinitely. Examples include the PRs https://github.com/Altinn/altinn-profile/pull/675 and https://github.com/Altinn/altinn-profile/pull/666

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PostgreSQL service image to a newer patch version for improved stability
  * Updated application base runtime image to a newer patch version
  * Applied formatting refinements and structural improvements to CI/CD pipeline configuration
  * Enhanced code alignment and consistency in automation workflows

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->