### PR TITLE
Feature/785 use register as source

### DIFF
--- a/src/Altinn.Profile.Core/CoreSettings.cs
+++ b/src/Altinn.Profile.Core/CoreSettings.cs
@@ -16,7 +16,12 @@ public class CoreSettings
     public bool LookupPreselectedPartyIdAtRegister { get; set; }
 
     /// <summary>
-    /// A flag indicating whether to perform a lookup for users from the register and compare this
+    /// A flag indicating whether to perform a lookup for users from the register and compare this.
     /// </summary>
     public bool RegisterLookupInShadowMode { get; set; }
+
+    /// <summary>
+    /// A flag indicating whether register should be primary source for user profiles, with fallback to legacy source.
+    /// </summary>
+    public bool RegisterAsPrimaryUserProfileSource { get; set; }
 }

--- a/src/Altinn.Profile.Core/Integrations/IProfileSettingsRepository.cs
+++ b/src/Altinn.Profile.Core/Integrations/IProfileSettingsRepository.cs
@@ -24,8 +24,11 @@ namespace Altinn.Profile.Core.Integrations
         Task<ProfileSettings?> PatchProfileSettings(ProfileSettingsPatchModel profileSettings, CancellationToken cancellationToken);
 
         /// <summary>
-        /// Gets the local profile settings for a given user ID.
+        /// Retrieves the profile settings for a given user ID.
         /// </summary>
-        Task<ProfileSettings?> GetProfileSettings(int userId);
+        /// <param name="userId">The id of the user</param>
+        /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
+        /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
+        Task<ProfileSettings?> GetProfileSettings(int userId, CancellationToken cancellationToken);
     }
 }

--- a/src/Altinn.Profile.Core/ProfessionalNotificationAddresses/ProfessionalNotificationsService.cs
+++ b/src/Altinn.Profile.Core/ProfessionalNotificationAddresses/ProfessionalNotificationsService.cs
@@ -148,7 +148,7 @@ namespace Altinn.Profile.Core.ProfessionalNotificationAddresses
             foreach (var contactInfo in contactInfos)
             {
                 // Note: IUserProfileService.GetUser does not support cancellation token at this time
-                var userProfileResult = await _userProfileService.GetUser(contactInfo.UserId);
+                var userProfileResult = await _userProfileService.GetUser(contactInfo.UserId, cancellationToken);
 
                 userProfileResult.Match(
                     profile =>
@@ -218,7 +218,7 @@ namespace Altinn.Profile.Core.ProfessionalNotificationAddresses
                 var orgNumber = await _registerClient.GetOrganizationNumberByPartyUuid(contactInfo.PartyUuid, cancellationToken);
 
                 // Note: IUserProfileService.GetUser does not support cancellation token at this time
-                var userProfileResult = await _userProfileService.GetUser(contactInfo.UserId);
+                var userProfileResult = await _userProfileService.GetUser(contactInfo.UserId, cancellationToken);
 
                 userProfileResult.Match(
                     profile =>

--- a/src/Altinn.Profile.Core/ProfessionalNotificationAddresses/ProfessionalNotificationsService.cs
+++ b/src/Altinn.Profile.Core/ProfessionalNotificationAddresses/ProfessionalNotificationsService.cs
@@ -33,7 +33,7 @@ namespace Altinn.Profile.Core.ProfessionalNotificationAddresses
             }
 
             var (emailVerificationStatus, smsVerificationStatus) = await _addressVerificationService.GetVerificationStatusAsync(notificationSettings.UserId, notificationSettings.EmailAddress, notificationSettings.PhoneNumber, cancellationToken);
-            var ignoreUnitProfileDateTime = await _userProfileService.GetIgnoreUnitProfileDateTime(userId);
+            var ignoreUnitProfileDateTime = await _userProfileService.GetIgnoreUnitProfileDateTime(userId, cancellationToken);
 
             var needsConfirmation = NeedsConfirmation(notificationSettings, ignoreUnitProfileDateTime);
             var extendedInfo = new ExtendedUserPartyContactInfo(
@@ -48,7 +48,7 @@ namespace Altinn.Profile.Core.ProfessionalNotificationAddresses
         /// <inheritdoc/>
         public async Task<IReadOnlyList<ExtendedUserPartyContactInfo>> GetAllNotificationAddressesAsync(int userId, CancellationToken cancellationToken)
         {
-            var ignoreUnitProfileDateTime = await _userProfileService.GetIgnoreUnitProfileDateTime(userId);
+            var ignoreUnitProfileDateTime = await _userProfileService.GetIgnoreUnitProfileDateTime(userId, cancellationToken);
 
             var notificationSettings = await _professionalNotificationsRepository.GetAllNotificationAddressesForUserAsync(userId, cancellationToken);
 

--- a/src/Altinn.Profile.Core/User.ContactPoints/IUserContactPointsService.cs
+++ b/src/Altinn.Profile.Core/User.ContactPoints/IUserContactPointsService.cs
@@ -29,6 +29,7 @@ public interface IUserContactPointsService
     /// Method for retriveing information about the availability of contact points for a user 
     /// </summary>
     /// <param name="nationalIdentityNumbers">A list of national identity numbers to look up availability for</param>
+    /// <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
     /// <returns>Information on the existense of the users' contact points and reservation status or a boolean if failure.</returns>
-    Task<UserContactPointAvailabilityList> GetContactPointAvailability(List<string> nationalIdentityNumbers);
+    Task<UserContactPointAvailabilityList> GetContactPointAvailability(List<string> nationalIdentityNumbers, CancellationToken cancellationToken);
 }

--- a/src/Altinn.Profile.Core/User.ContactPoints/UserContactPointService.cs
+++ b/src/Altinn.Profile.Core/User.ContactPoints/UserContactPointService.cs
@@ -24,13 +24,13 @@ public class UserContactPointService : IUserContactPointsService
     }
 
     /// <inheritdoc/>
-    public async Task<UserContactPointAvailabilityList> GetContactPointAvailability(List<string> nationalIdentityNumbers)
+    public async Task<UserContactPointAvailabilityList> GetContactPointAvailability(List<string> nationalIdentityNumbers, CancellationToken cancellationToken)
     {
         UserContactPointAvailabilityList availabilityResult = new();
 
         foreach (var nationalIdentityNumber in nationalIdentityNumbers)
         {
-            Result<UserProfile, bool> result = await _userProfileService.GetUser(nationalIdentityNumber);
+            Result<UserProfile, bool> result = await _userProfileService.GetUser(nationalIdentityNumber, cancellationToken);
 
             result.Match(
                 profile =>
@@ -85,8 +85,8 @@ public class UserContactPointService : IUserContactPointsService
 
             var contactPoint = parsedUrn switch
             {
-                IDPortenEmail idportenEmail => await ProcessIdPortenEmail(idportenEmail, urnIdentifier),
-                Username username => await ProcessUsername(username, urnIdentifier),
+                IDPortenEmail idportenEmail => await ProcessIdPortenEmail(idportenEmail, urnIdentifier, cancellationToken),
+                Username username => await ProcessUsername(username, urnIdentifier, cancellationToken),
                 _ => null
             };
 
@@ -99,14 +99,14 @@ public class UserContactPointService : IUserContactPointsService
         return contactPointsList;
     }
 
-    private async Task<SiUserContactPoints?> ProcessIdPortenEmail(IDPortenEmail idportenEmail, string urnIdentifier)
+    private async Task<SiUserContactPoints?> ProcessIdPortenEmail(IDPortenEmail idportenEmail, string urnIdentifier, CancellationToken cancellationToken)
     {
         if (string.IsNullOrWhiteSpace(idportenEmail.Value.Value))
         {
             return null;
         }
 
-        var result = await _userProfileService.GetUserByUsername("epost:" + idportenEmail.Value.Value);
+        var result = await _userProfileService.GetUserByUsername("epost:" + idportenEmail.Value.Value, cancellationToken);
 
         return result.Match(
             profile => new SiUserContactPoints()
@@ -123,9 +123,9 @@ public class UserContactPointService : IUserContactPointsService
             });
     }
 
-    private async Task<SiUserContactPoints?> ProcessUsername(Username username, string urnIdentifier)
+    private async Task<SiUserContactPoints?> ProcessUsername(Username username, string urnIdentifier, CancellationToken cancellationToken)
     {
-        var result = await _userProfileService.GetUserByUsername(username.Value.Value);
+        var result = await _userProfileService.GetUserByUsername(username.Value.Value, cancellationToken);
 
         return result.Match(
             profile =>

--- a/src/Altinn.Profile.Core/User/IUserProfileService.cs
+++ b/src/Altinn.Profile.Core/User/IUserProfileService.cs
@@ -67,10 +67,10 @@ public interface IUserProfileService
     /// <summary>
     /// Gets the profile's preferred language (or, if not set, a default) for a given user ID.
     /// </summary>
-    Task<string> GetPreferredLanguage(int userId);
+    Task<string> GetPreferredLanguage(int userId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets the timestamp for the event (if it has occurred, otherwise null) when the user chose to ignore updates to unit profiles.
     /// </summary>
-    Task<DateTime?> GetIgnoreUnitProfileDateTime(int userId);
+    Task<DateTime?> GetIgnoreUnitProfileDateTime(int userId, CancellationToken cancellationToken = default);
 }

--- a/src/Altinn.Profile.Core/User/IUserProfileService.cs
+++ b/src/Altinn.Profile.Core/User/IUserProfileService.cs
@@ -12,36 +12,41 @@ public interface IUserProfileService
     /// Method that fetches a user based on a user id
     /// </summary>
     /// <param name="userId">The user id</param>
+    /// <param name="cancellationToken">The cancellation token</param>
     /// <returns>User profile with given user id or a boolean if failure.</returns>
-    Task<Result<UserProfile, bool>> GetUser(int userId);
+    Task<Result<UserProfile, bool>> GetUser(int userId, CancellationToken cancellationToken);
 
     /// <summary>
     /// Method that fetches a user based on ssn.
     /// </summary>
     /// <param name="ssn">The user's ssn.</param>
+    /// <param name="cancellationToken">The cancellation token</param>
     /// <returns>User profile connected to given ssn or a boolean if failure.</returns>
-    Task<Result<UserProfile, bool>> GetUser(string ssn);
+    Task<Result<UserProfile, bool>> GetUser(string ssn, CancellationToken cancellationToken);
 
     /// <summary>
     /// Method that fetches a user based on a user uuid
     /// </summary>
     /// <param name="userUuid">The user uuid</param>
+    /// <param name="cancellationToken">The cancellation token</param>
     /// <returns>User profile with given user uuid or a boolean if failure.</returns>
-    Task<Result<UserProfile, bool>> GetUserByUuid(Guid userUuid);
+    Task<Result<UserProfile, bool>> GetUserByUuid(Guid userUuid, CancellationToken cancellationToken);
 
     /// <summary>
     /// Method that fetches a list of users based on a list of user uuid
     /// </summary>
     /// <param name="userUuidList">The list of user uuids</param>
+    /// <param name="cancellationToken">The cancellation token</param>
     /// <returns>List of User profiles with given user uuids or a boolean if failure.</returns>
-    Task<Result<List<UserProfile>, bool>> GetUserListByUuid(List<Guid> userUuidList);
+    Task<Result<List<UserProfile>, bool>> GetUserListByUuid(List<Guid> userUuidList, CancellationToken cancellationToken);
 
     /// <summary>
     /// Method that fetches a user based on username.
     /// </summary>
     /// <param name="username">The user's username.</param>
+    /// <param name="cancellationToken">The cancellation token</param>
     /// <returns>User profile connected to given username or a boolean if failure.</returns>
-    Task<Result<UserProfile, bool>> GetUserByUsername(string username);
+    Task<Result<UserProfile, bool>> GetUserByUsername(string username, CancellationToken cancellationToken);
 
     /// <summary>
     /// Updates the profile settings for a user.

--- a/src/Altinn.Profile.Core/User/UserProfileService.cs
+++ b/src/Altinn.Profile.Core/User/UserProfileService.cs
@@ -45,7 +45,8 @@ public class UserProfileService : IUserProfileService
     {
         return await GetUserWithSourceSelection(
             () => _userProfileClient.GetUser(userId),
-            () => GetUserFromRegister(_registerClient.GetUserParty(userId, cancellationToken), cancellationToken));
+            () => _registerClient.GetUserParty(userId, cancellationToken),
+            cancellationToken);
     }
 
     /// <inheritdoc/>
@@ -53,7 +54,8 @@ public class UserProfileService : IUserProfileService
     {
         return await GetUserWithSourceSelection(
             () => _userProfileClient.GetUser(ssn),
-            () => GetUserFromRegister(_registerClient.GetUserPartyBySsn(ssn, cancellationToken), cancellationToken));
+            () => _registerClient.GetUserPartyBySsn(ssn, cancellationToken),
+            cancellationToken);
     }
 
     /// <inheritdoc/>
@@ -61,7 +63,8 @@ public class UserProfileService : IUserProfileService
     {
         return await GetUserWithSourceSelection(
             () => _userProfileClient.GetUserByUsername(username),
-            () => GetUserFromRegister(_registerClient.GetUserPartyByUsername(username, cancellationToken), cancellationToken));
+            () => _registerClient.GetUserPartyByUsername(username, cancellationToken),
+            cancellationToken);
     }
 
     /// <inheritdoc/>
@@ -69,7 +72,8 @@ public class UserProfileService : IUserProfileService
     {
         return await GetUserWithSourceSelection(
             () => _userProfileClient.GetUserByUuid(userUuid),
-            () => GetUserFromRegister(_registerClient.GetUserParty(userUuid, cancellationToken), cancellationToken));
+            () => _registerClient.GetUserParty(userUuid, cancellationToken),
+            cancellationToken);
     }
 
     /// <inheritdoc/>
@@ -115,11 +119,12 @@ public class UserProfileService : IUserProfileService
 
     private async Task<Result<UserProfile, bool>> GetUserWithSourceSelection(
         Func<Task<Result<UserProfile, bool>>> getLegacy,
-        Func<Task<UserProfile?>> getRegister)
+        Func<Task<Party?>> getRegisterParty,
+        CancellationToken cancellationToken)
     {
         if (_settings.RegisterAsPrimaryUserProfileSource)
         {
-            UserProfile? registerProfile = await TryGetEligibleRegisterProfile(getRegister);
+            UserProfile? registerProfile = await TryGetEligibleRegisterProfile(getRegisterParty(), cancellationToken);
             if (registerProfile is not null)
             {
                 return registerProfile;
@@ -132,7 +137,7 @@ public class UserProfileService : IUserProfileService
         if (_settings.RegisterLookupInShadowMode)
         {
             Task<Result<UserProfile, bool>> legacyTask = getLegacy();
-            Task<UserProfile?> registerTask = getRegister();
+            Task<UserProfile?> registerTask = GetUserFromRegister(getRegisterParty(), cancellationToken);
 
             await Task.WhenAll(legacyTask, registerTask);
 
@@ -158,30 +163,38 @@ public class UserProfileService : IUserProfileService
         return userProfile;
     }
 
-    private static bool IsEligibleRegisterProfile(UserProfile userProfile)
+    private static bool IsEligibleRegisterProfile(Party? party)
     {
         // To ensure that we only use register profiles that can be enriched with KRR data, we require that the profile has a non-empty SSN.
         // This is because KRR data is linked to the user's SSN, and without it, we cannot enrich the profile with contact information from KRR.
-        return !string.IsNullOrWhiteSpace(userProfile.Party?.SSN);
+        // All ssn users are returned as Person type from the register.
+        return party is Register.Contracts.Person;
     }
 
-    private static async Task<UserProfile?> TryGetEligibleRegisterProfile(Func<Task<UserProfile?>> getRegister)
+    private async Task<UserProfile?> TryGetEligibleRegisterProfile(Task<Party?> registerPartyTask, CancellationToken cancellationToken)
     {
+        Party? registerParty;
+
         try
         {
-            UserProfile? profile = await getRegister();
-            if (profile is null)
-            {
-                return null;
-            }
-
-            return IsEligibleRegisterProfile(profile) ? profile : null;
+            registerParty = await registerPartyTask;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch (Exception)
         {
             // fallback to legacy
             return null;
         }
+
+        if (IsEligibleRegisterProfile(registerParty))
+        {
+            return await CreateAndEnrichProfileFromParty(registerParty, cancellationToken);
+        }
+
+        return null;
     }
 
     private async Task<UserProfile?> GetEnrichedLegacyUserProfile(Task<Result<UserProfile, bool>> legacyTask)
@@ -254,16 +267,23 @@ public class UserProfileService : IUserProfileService
 
     private async Task<UserProfile?> GetUserFromRegister(Task<Party?> registerPartyTask, CancellationToken cancellationToken)
     {
+        Party? registerParty;
+
         try
         {
-            Party? registerParty = await registerPartyTask;
-            return await CreateAndEnrichProfileFromParty(registerParty, cancellationToken);
+            registerParty = await registerPartyTask;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch (Exception)
         {
             // in shadow mode, exceptions from the register client should not affect the user experience.
             return null;
         }
+
+        return await CreateAndEnrichProfileFromParty(registerParty, cancellationToken);
     }
 
     private async Task<UserProfile?> CreateAndEnrichProfileFromParty(Party? party, CancellationToken cancellationToken)

--- a/src/Altinn.Profile.Core/User/UserProfileService.cs
+++ b/src/Altinn.Profile.Core/User/UserProfileService.cs
@@ -206,7 +206,7 @@ public class UserProfileService : IUserProfileService
         }
 
         UserProfile legacyProfile = legacyResult.Match(userProfile => userProfile, _ => default!);
-        legacyProfile = await EnrichWithProfileSettings(legacyProfile, false, default);
+        legacyProfile = await EnrichWithProfileSettings(legacyProfile, default);
         legacyProfile = await EnrichWithKrrData(legacyProfile);
 
         return legacyProfile;
@@ -218,7 +218,7 @@ public class UserProfileService : IUserProfileService
         foreach (UserProfile userProfile in legacyProfiles)
         {
             UserProfile enrichedUser = await EnrichWithKrrData(userProfile, default);
-            enriched.Add(await EnrichWithProfileSettings(enrichedUser, false, default));
+            enriched.Add(await EnrichWithProfileSettings(enrichedUser, default));
         }
 
         return enriched;
@@ -294,7 +294,7 @@ public class UserProfileService : IUserProfileService
             return null;
         }
 
-        userProfile = await EnrichWithProfileSettings(userProfile, true, cancellationToken);
+        userProfile = await EnrichWithProfileSettings(userProfile, cancellationToken);
         userProfile = await EnrichWithKrrData(userProfile, cancellationToken);
 
         return userProfile;
@@ -326,7 +326,7 @@ public class UserProfileService : IUserProfileService
         return await _profileSettingsRepository.PatchProfileSettings(profileSettings, cancellationToken);
     }
 
-    private async Task<UserProfile> EnrichWithProfileSettings(UserProfile userProfile, bool useRegisterLookup, CancellationToken cancellationToken)
+    private async Task<UserProfile> EnrichWithProfileSettings(UserProfile userProfile, CancellationToken cancellationToken)
     {
         ProfileSettings.ProfileSettings? profileSettings = await _profileSettingsRepository.GetProfileSettings(userProfile.UserId, cancellationToken);
         if (profileSettings != null)
@@ -345,7 +345,7 @@ public class UserProfileService : IUserProfileService
             userProfile.ProfileSettingPreference ??= ProfileSettingPreference.GetDefaultValues();
         }
 
-        if (userProfile.ProfileSettingPreference.PreselectedPartyUuid != null && (useRegisterLookup || _settings.LookupPreselectedPartyIdAtRegister))
+        if (userProfile.ProfileSettingPreference.PreselectedPartyUuid != null && _settings.LookupPreselectedPartyIdAtRegister)
         {
             // If a preselected party UUID is provided, we need to fetch the corresponding party ID from the register to ensure data consistency.
             int? partyId = await _registerClient.GetPartyId(userProfile.ProfileSettingPreference.PreselectedPartyUuid.Value, default);

--- a/src/Altinn.Profile.Core/User/UserProfileService.cs
+++ b/src/Altinn.Profile.Core/User/UserProfileService.cs
@@ -43,33 +43,33 @@ public class UserProfileService : IUserProfileService
     /// <inheritdoc/>
     public async Task<Result<UserProfile, bool>> GetUser(int userId, CancellationToken cancellationToken)
     {
-        return await GetUserWithOptionalRegisterLookup(
-            _userProfileClient.GetUser(userId),
-            GetUserFromRegister(_registerClient.GetUserParty(userId, cancellationToken)));
+        return await GetUserWithSourceSelection(
+            () => _userProfileClient.GetUser(userId),
+            () => GetUserFromRegister(_registerClient.GetUserParty(userId, cancellationToken)));
     }
 
     /// <inheritdoc/>
     public async Task<Result<UserProfile, bool>> GetUser(string ssn, CancellationToken cancellationToken)
     {
-        return await GetUserWithOptionalRegisterLookup(
-            _userProfileClient.GetUser(ssn),
-            GetUserFromRegister(_registerClient.GetUserPartyBySsn(ssn, cancellationToken)));
+        return await GetUserWithSourceSelection(
+            () => _userProfileClient.GetUser(ssn),
+            () => GetUserFromRegister(_registerClient.GetUserPartyBySsn(ssn, cancellationToken)));
     }
 
     /// <inheritdoc/>
     public async Task<Result<UserProfile, bool>> GetUserByUsername(string username, CancellationToken cancellationToken)
     {
-        return await GetUserWithOptionalRegisterLookup(
-            _userProfileClient.GetUserByUsername(username),
-            GetUserFromRegister(_registerClient.GetUserPartyByUsername(username, cancellationToken)));
+        return await GetUserWithSourceSelection(
+            () => _userProfileClient.GetUserByUsername(username),
+            () => GetUserFromRegister(_registerClient.GetUserPartyByUsername(username, cancellationToken)));
     }
 
     /// <inheritdoc/>
     public async Task<Result<UserProfile, bool>> GetUserByUuid(Guid userUuid, CancellationToken cancellationToken)
     {
-        return await GetUserWithOptionalRegisterLookup(
-            _userProfileClient.GetUserByUuid(userUuid),
-            GetUserFromRegister(_registerClient.GetUserParty(userUuid, cancellationToken)));
+        return await GetUserWithSourceSelection(
+            () => _userProfileClient.GetUserByUuid(userUuid),
+            () => GetUserFromRegister(_registerClient.GetUserParty(userUuid, cancellationToken)));
     }
 
     /// <inheritdoc/>
@@ -113,32 +113,65 @@ public class UserProfileService : IUserProfileService
         return legacyProfilesWithEnrichment;
     }
 
-    private async Task<Result<UserProfile, bool>> GetUserWithOptionalRegisterLookup(Task<Result<UserProfile, bool>> legacyTask, Task<UserProfile?> registerTask)
+    private async Task<Result<UserProfile, bool>> GetUserWithSourceSelection(
+        Func<Task<Result<UserProfile, bool>>> getLegacy,
+        Func<Task<UserProfile?>> getRegister)
     {
-        if (!_settings.RegisterLookupInShadowMode)
+        if (_settings.RegisterAsPrimaryUserProfileSource)
         {
-            UserProfile? userProfile = await GetEnrichedLegacyUserProfile(legacyTask);
-            if (userProfile is null)
+            UserProfile? registerProfile = await TryGetEligibleRegisterProfile(getRegister);
+            if (registerProfile is not null)
             {
-                return false;
+                return registerProfile;
             }
 
-            return userProfile;
+            UserProfile? fallbackLegacy = await GetEnrichedLegacyUserProfile(getLegacy());
+            return fallbackLegacy is null ? false : fallbackLegacy;
         }
 
-        await Task.WhenAll(legacyTask, registerTask);
-
-        UserProfile? registerProfile = await registerTask;
-        UserProfile? legacyProfile = await GetEnrichedLegacyUserProfile(legacyTask);
-
-        _userProfileComparer.CompareAndLog(legacyProfile, registerProfile);
-
-        if (legacyProfile is null)
+        if (_settings.RegisterLookupInShadowMode)
         {
-            return false;
+            Task<Result<UserProfile, bool>> legacyTask = getLegacy();
+            Task<UserProfile?> registerTask = getRegister();
+
+            await Task.WhenAll(legacyTask, registerTask);
+
+            UserProfile? registerProfile = await registerTask;
+            UserProfile? legacyProfile = await GetEnrichedLegacyUserProfile(legacyTask);
+
+            _userProfileComparer.CompareAndLog(legacyProfile, registerProfile);
+
+            return legacyProfile is null ? false : legacyProfile;
         }
 
-        return legacyProfile;
+        UserProfile? legacyOnly = await GetEnrichedLegacyUserProfile(getLegacy());
+        return legacyOnly is null ? false : legacyOnly;
+    }
+
+    private static bool IsEligibleRegisterProfile(UserProfile userProfile)
+    {
+        // To ensure that we only use register profiles that can be enriched with KRR data, we require that the profile has a non-empty SSN.
+        // This is because KRR data is linked to the user's SSN, and without it, we cannot enrich the profile with contact information from KRR.
+        return !string.IsNullOrWhiteSpace(userProfile.Party?.SSN);
+    }
+
+    private async Task<UserProfile?> TryGetEligibleRegisterProfile(Func<Task<UserProfile?>> getRegister)
+    {
+        try
+        {
+            UserProfile? profile = await getRegister();
+            if (profile is null)
+            {
+                return null;
+            }
+
+            return IsEligibleRegisterProfile(profile) ? profile : null;
+        }
+        catch (Exception)
+        {
+            // fallback to legacy
+            return null;
+        }
     }
 
     private async Task<UserProfile?> GetEnrichedLegacyUserProfile(Task<Result<UserProfile, bool>> legacyTask)
@@ -150,7 +183,7 @@ public class UserProfileService : IUserProfileService
         }
 
         UserProfile legacyProfile = legacyResult.Match(userProfile => userProfile, _ => default!);
-        legacyProfile = await EnrichWithProfileSettings(legacyProfile);
+        legacyProfile = await EnrichWithProfileSettings(legacyProfile, false);
         legacyProfile = await EnrichWithKrrData(legacyProfile);
 
         return legacyProfile;
@@ -162,7 +195,7 @@ public class UserProfileService : IUserProfileService
         foreach (UserProfile userProfile in legacyProfiles)
         {
             UserProfile enrichedUser = await EnrichWithKrrData(userProfile);
-            enriched.Add(await EnrichWithProfileSettings(enrichedUser));
+            enriched.Add(await EnrichWithProfileSettings(enrichedUser, false));
         }
 
         return enriched;
@@ -231,7 +264,7 @@ public class UserProfileService : IUserProfileService
             return null;
         }
 
-        userProfile = await EnrichWithProfileSettings(userProfile);
+        userProfile = await EnrichWithProfileSettings(userProfile, true);
         userProfile = await EnrichWithKrrData(userProfile);
 
         return userProfile;
@@ -263,7 +296,7 @@ public class UserProfileService : IUserProfileService
         return await _profileSettingsRepository.PatchProfileSettings(profileSettings, cancellationToken);
     }
 
-    private async Task<UserProfile> EnrichWithProfileSettings(UserProfile userProfile)
+    private async Task<UserProfile> EnrichWithProfileSettings(UserProfile userProfile, bool useRegisterLookup)
     {
         ProfileSettings.ProfileSettings? profileSettings = await _profileSettingsRepository.GetProfileSettings(userProfile.UserId);
         if (profileSettings != null)
@@ -282,7 +315,7 @@ public class UserProfileService : IUserProfileService
             userProfile.ProfileSettingPreference ??= ProfileSettingPreference.GetDefaultValues();
         }
 
-        if (userProfile.ProfileSettingPreference.PreselectedPartyUuid != null && _settings.LookupPreselectedPartyIdAtRegister)
+        if (userProfile.ProfileSettingPreference.PreselectedPartyUuid != null && (useRegisterLookup || _settings.LookupPreselectedPartyIdAtRegister))
         {
             // If a preselected party UUID is provided, we need to fetch the corresponding party ID from the register to ensure data consistency.
             int? partyId = await _registerClient.GetPartyId(userProfile.ProfileSettingPreference.PreselectedPartyUuid.Value, default);

--- a/src/Altinn.Profile.Core/User/UserProfileService.cs
+++ b/src/Altinn.Profile.Core/User/UserProfileService.cs
@@ -126,7 +126,7 @@ public class UserProfileService : IUserProfileService
             }
 
             UserProfile? fallbackLegacy = await GetEnrichedLegacyUserProfile(getLegacy());
-            return fallbackLegacy is null ? false : fallbackLegacy;
+            return CreateUserProfileResult(fallbackLegacy);
         }
 
         if (_settings.RegisterLookupInShadowMode)
@@ -141,11 +141,21 @@ public class UserProfileService : IUserProfileService
 
             _userProfileComparer.CompareAndLog(legacyProfile, registerProfile);
 
-            return legacyProfile is null ? false : legacyProfile;
+            return CreateUserProfileResult(legacyProfile);
         }
 
         UserProfile? legacyOnly = await GetEnrichedLegacyUserProfile(getLegacy());
-        return legacyOnly is null ? false : legacyOnly;
+        return CreateUserProfileResult(legacyOnly);
+    }
+
+    private static Result<UserProfile, bool> CreateUserProfileResult(UserProfile? userProfile)
+    {
+        if (userProfile is null)
+        {
+            return false;
+        }
+
+        return userProfile;
     }
 
     private static bool IsEligibleRegisterProfile(UserProfile userProfile)
@@ -155,7 +165,7 @@ public class UserProfileService : IUserProfileService
         return !string.IsNullOrWhiteSpace(userProfile.Party?.SSN);
     }
 
-    private async Task<UserProfile?> TryGetEligibleRegisterProfile(Func<Task<UserProfile?>> getRegister)
+    private static async Task<UserProfile?> TryGetEligibleRegisterProfile(Func<Task<UserProfile?>> getRegister)
     {
         try
         {

--- a/src/Altinn.Profile.Core/User/UserProfileService.cs
+++ b/src/Altinn.Profile.Core/User/UserProfileService.cs
@@ -45,7 +45,7 @@ public class UserProfileService : IUserProfileService
     {
         return await GetUserWithOptionalRegisterLookup(
             _userProfileClient.GetUser(userId),
-            () => GetUserFromRegister(_registerClient.GetUserParty(userId, default)));
+            GetUserFromRegister(_registerClient.GetUserParty(userId, default)));
     }
 
     /// <inheritdoc/>
@@ -53,7 +53,7 @@ public class UserProfileService : IUserProfileService
     {
         return await GetUserWithOptionalRegisterLookup(
             _userProfileClient.GetUser(ssn),
-            () => GetUserFromRegister(_registerClient.GetUserPartyBySsn(ssn, default)));
+            GetUserFromRegister(_registerClient.GetUserPartyBySsn(ssn, default)));
     }
 
     /// <inheritdoc/>
@@ -61,7 +61,7 @@ public class UserProfileService : IUserProfileService
     {
         return await GetUserWithOptionalRegisterLookup(
             _userProfileClient.GetUserByUsername(username),
-            () => GetUserFromRegister(_registerClient.GetUserPartyByUsername(username, default)));
+            GetUserFromRegister(_registerClient.GetUserPartyByUsername(username, default)));
     }
 
     /// <inheritdoc/>
@@ -69,7 +69,7 @@ public class UserProfileService : IUserProfileService
     {
         return await GetUserWithOptionalRegisterLookup(
             _userProfileClient.GetUserByUuid(userUuid),
-            () => GetUserFromRegister(_registerClient.GetUserParty(userUuid, default)));
+            GetUserFromRegister(_registerClient.GetUserParty(userUuid, default)));
     }
 
     /// <inheritdoc/>
@@ -113,14 +113,19 @@ public class UserProfileService : IUserProfileService
         return legacyProfilesWithEnrichment;
     }
 
-    private async Task<Result<UserProfile, bool>> GetUserWithOptionalRegisterLookup(Task<Result<UserProfile, bool>> legacyTask, Func<Task<UserProfile?>> registerLookup)
+    private async Task<Result<UserProfile, bool>> GetUserWithOptionalRegisterLookup(Task<Result<UserProfile, bool>> legacyTask, Task<UserProfile?> registerTask)
     {
         if (!_settings.RegisterLookupInShadowMode)
         {
-            return await GetLegacyUserResult(legacyTask);
+            UserProfile? userProfile = await GetEnrichedLegacyUserProfile(legacyTask);
+            if (userProfile is null)
+            {
+                return false;
+            }
+
+            return userProfile;
         }
 
-        Task<UserProfile?> registerTask = registerLookup();
         await Task.WhenAll(legacyTask, registerTask);
 
         UserProfile? registerProfile = await registerTask;
@@ -128,17 +133,6 @@ public class UserProfileService : IUserProfileService
 
         _userProfileComparer.CompareAndLog(legacyProfile, registerProfile);
 
-        if (legacyProfile is null)
-        {
-            return false;
-        }
-
-        return legacyProfile;
-    }
-
-    private async Task<Result<UserProfile, bool>> GetLegacyUserResult(Task<Result<UserProfile, bool>> legacyTask)
-    {
-        UserProfile? legacyProfile = await GetEnrichedLegacyUserProfile(legacyTask);
         if (legacyProfile is null)
         {
             return false;
@@ -196,14 +190,14 @@ public class UserProfileService : IUserProfileService
 
     private async Task<List<UserProfile>> GetUserListFromRegister(List<Guid> userUuidList)
     {
-        IReadOnlyList<Register.Contracts.Party> registerParties = await _registerClient.GetUserParties(userUuidList, default);
+        IReadOnlyList<Party> registerParties = await _registerClient.GetUserParties(userUuidList, default);
         List<UserProfile> registerProfiles = new(registerParties?.Count ?? 0);
         if (registerParties == null)
         {
             return registerProfiles;
         }
 
-        foreach (Register.Contracts.Party registerParty in registerParties)
+        foreach (Party registerParty in registerParties)
         {
             UserProfile? userProfile = await CreateAndEnrichProfileFromParty(registerParty);
             if (userProfile != null)

--- a/src/Altinn.Profile.Core/User/UserProfileService.cs
+++ b/src/Altinn.Profile.Core/User/UserProfileService.cs
@@ -41,39 +41,39 @@ public class UserProfileService : IUserProfileService
     }
 
     /// <inheritdoc/>
-    public async Task<Result<UserProfile, bool>> GetUser(int userId)
+    public async Task<Result<UserProfile, bool>> GetUser(int userId, CancellationToken cancellationToken)
     {
         return await GetUserWithOptionalRegisterLookup(
             _userProfileClient.GetUser(userId),
-            GetUserFromRegister(_registerClient.GetUserParty(userId, default)));
+            GetUserFromRegister(_registerClient.GetUserParty(userId, cancellationToken)));
     }
 
     /// <inheritdoc/>
-    public async Task<Result<UserProfile, bool>> GetUser(string ssn)
+    public async Task<Result<UserProfile, bool>> GetUser(string ssn, CancellationToken cancellationToken)
     {
         return await GetUserWithOptionalRegisterLookup(
             _userProfileClient.GetUser(ssn),
-            GetUserFromRegister(_registerClient.GetUserPartyBySsn(ssn, default)));
+            GetUserFromRegister(_registerClient.GetUserPartyBySsn(ssn, cancellationToken)));
     }
 
     /// <inheritdoc/>
-    public async Task<Result<UserProfile, bool>> GetUserByUsername(string username)
+    public async Task<Result<UserProfile, bool>> GetUserByUsername(string username, CancellationToken cancellationToken)
     {
         return await GetUserWithOptionalRegisterLookup(
             _userProfileClient.GetUserByUsername(username),
-            GetUserFromRegister(_registerClient.GetUserPartyByUsername(username, default)));
+            GetUserFromRegister(_registerClient.GetUserPartyByUsername(username, cancellationToken)));
     }
 
     /// <inheritdoc/>
-    public async Task<Result<UserProfile, bool>> GetUserByUuid(Guid userUuid)
+    public async Task<Result<UserProfile, bool>> GetUserByUuid(Guid userUuid, CancellationToken cancellationToken)
     {
         return await GetUserWithOptionalRegisterLookup(
             _userProfileClient.GetUserByUuid(userUuid),
-            GetUserFromRegister(_registerClient.GetUserParty(userUuid, default)));
+            GetUserFromRegister(_registerClient.GetUserParty(userUuid, cancellationToken)));
     }
 
     /// <inheritdoc/>
-    public async Task<Result<List<UserProfile>, bool>> GetUserListByUuid(List<Guid> userUuidList)
+    public async Task<Result<List<UserProfile>, bool>> GetUserListByUuid(List<Guid> userUuidList, CancellationToken cancellationToken)
     {
         Task<Result<List<UserProfile>, bool>> legacyTask = _userProfileClient.GetUserListByUuid(userUuidList);
 
@@ -89,7 +89,7 @@ public class UserProfileService : IUserProfileService
             return await EnrichWithKrrDataAndProfileSettings(legacyProfiles);
         }
 
-        Task<List<UserProfile>> registerTask = GetUserListFromRegister(userUuidList);
+        Task<List<UserProfile>> registerTask = GetUserListFromRegister(userUuidList, cancellationToken);
 
         await Task.WhenAll(legacyTask, registerTask);
 
@@ -188,9 +188,9 @@ public class UserProfileService : IUserProfileService
         }
     }
 
-    private async Task<List<UserProfile>> GetUserListFromRegister(List<Guid> userUuidList)
+    private async Task<List<UserProfile>> GetUserListFromRegister(List<Guid> userUuidList, CancellationToken cancellationToken)
     {
-        IReadOnlyList<Party> registerParties = await _registerClient.GetUserParties(userUuidList, default);
+        IReadOnlyList<Party> registerParties = await _registerClient.GetUserParties(userUuidList, cancellationToken);
         List<UserProfile> registerProfiles = new(registerParties?.Count ?? 0);
         if (registerParties == null)
         {

--- a/src/Altinn.Profile.Core/User/UserProfileService.cs
+++ b/src/Altinn.Profile.Core/User/UserProfileService.cs
@@ -45,7 +45,7 @@ public class UserProfileService : IUserProfileService
     {
         return await GetUserWithSourceSelection(
             () => _userProfileClient.GetUser(userId),
-            () => GetUserFromRegister(_registerClient.GetUserParty(userId, cancellationToken)));
+            () => GetUserFromRegister(_registerClient.GetUserParty(userId, cancellationToken), cancellationToken));
     }
 
     /// <inheritdoc/>
@@ -53,7 +53,7 @@ public class UserProfileService : IUserProfileService
     {
         return await GetUserWithSourceSelection(
             () => _userProfileClient.GetUser(ssn),
-            () => GetUserFromRegister(_registerClient.GetUserPartyBySsn(ssn, cancellationToken)));
+            () => GetUserFromRegister(_registerClient.GetUserPartyBySsn(ssn, cancellationToken), cancellationToken));
     }
 
     /// <inheritdoc/>
@@ -61,7 +61,7 @@ public class UserProfileService : IUserProfileService
     {
         return await GetUserWithSourceSelection(
             () => _userProfileClient.GetUserByUsername(username),
-            () => GetUserFromRegister(_registerClient.GetUserPartyByUsername(username, cancellationToken)));
+            () => GetUserFromRegister(_registerClient.GetUserPartyByUsername(username, cancellationToken), cancellationToken));
     }
 
     /// <inheritdoc/>
@@ -69,7 +69,7 @@ public class UserProfileService : IUserProfileService
     {
         return await GetUserWithSourceSelection(
             () => _userProfileClient.GetUserByUuid(userUuid),
-            () => GetUserFromRegister(_registerClient.GetUserParty(userUuid, cancellationToken)));
+            () => GetUserFromRegister(_registerClient.GetUserParty(userUuid, cancellationToken), cancellationToken));
     }
 
     /// <inheritdoc/>
@@ -193,7 +193,7 @@ public class UserProfileService : IUserProfileService
         }
 
         UserProfile legacyProfile = legacyResult.Match(userProfile => userProfile, _ => default!);
-        legacyProfile = await EnrichWithProfileSettings(legacyProfile, false);
+        legacyProfile = await EnrichWithProfileSettings(legacyProfile, false, default);
         legacyProfile = await EnrichWithKrrData(legacyProfile);
 
         return legacyProfile;
@@ -204,8 +204,8 @@ public class UserProfileService : IUserProfileService
         List<UserProfile> enriched = new(legacyProfiles.Count);
         foreach (UserProfile userProfile in legacyProfiles)
         {
-            UserProfile enrichedUser = await EnrichWithKrrData(userProfile);
-            enriched.Add(await EnrichWithProfileSettings(enrichedUser, false));
+            UserProfile enrichedUser = await EnrichWithKrrData(userProfile, default);
+            enriched.Add(await EnrichWithProfileSettings(enrichedUser, false, default));
         }
 
         return enriched;
@@ -242,7 +242,7 @@ public class UserProfileService : IUserProfileService
 
         foreach (Party registerParty in registerParties)
         {
-            UserProfile? userProfile = await CreateAndEnrichProfileFromParty(registerParty);
+            UserProfile? userProfile = await CreateAndEnrichProfileFromParty(registerParty, cancellationToken);
             if (userProfile != null)
             {
                 registerProfiles.Add(userProfile);
@@ -252,12 +252,12 @@ public class UserProfileService : IUserProfileService
         return registerProfiles;
     }
 
-    private async Task<UserProfile?> GetUserFromRegister(Task<Party?> registerPartyTask)
+    private async Task<UserProfile?> GetUserFromRegister(Task<Party?> registerPartyTask, CancellationToken cancellationToken)
     {
         try
         {
             Party? registerParty = await registerPartyTask;
-            return await CreateAndEnrichProfileFromParty(registerParty);
+            return await CreateAndEnrichProfileFromParty(registerParty, cancellationToken);
         }
         catch (Exception)
         {
@@ -266,7 +266,7 @@ public class UserProfileService : IUserProfileService
         }
     }
 
-    private async Task<UserProfile?> CreateAndEnrichProfileFromParty(Party? party)
+    private async Task<UserProfile?> CreateAndEnrichProfileFromParty(Party? party, CancellationToken cancellationToken)
     {
         UserProfile? userProfile = UserProfileMapper.MapFromParty(party);
         if (userProfile is null)
@@ -274,23 +274,23 @@ public class UserProfileService : IUserProfileService
             return null;
         }
 
-        userProfile = await EnrichWithProfileSettings(userProfile, true);
-        userProfile = await EnrichWithKrrData(userProfile);
+        userProfile = await EnrichWithProfileSettings(userProfile, true, cancellationToken);
+        userProfile = await EnrichWithKrrData(userProfile, cancellationToken);
 
         return userProfile;
     }
 
     /// <inheritdoc/>
-    public async Task<string> GetPreferredLanguage(int userId)
+    public async Task<string> GetPreferredLanguage(int userId, CancellationToken cancellationToken = default)
     {
-        var profileSettings = await _profileSettingsRepository.GetProfileSettings(userId);
+        var profileSettings = await _profileSettingsRepository.GetProfileSettings(userId, cancellationToken);
         return profileSettings?.LanguageType ?? LanguageType.NB;
     }
 
     /// <inheritdoc/>
-    public async Task<DateTime?> GetIgnoreUnitProfileDateTime(int userId)
+    public async Task<DateTime?> GetIgnoreUnitProfileDateTime(int userId, CancellationToken cancellationToken = default)
     {
-        var profileSettings = await _profileSettingsRepository.GetProfileSettings(userId);
+        var profileSettings = await _profileSettingsRepository.GetProfileSettings(userId, cancellationToken);
         return profileSettings?.IgnoreUnitProfileDateTime;
     }
 
@@ -306,9 +306,9 @@ public class UserProfileService : IUserProfileService
         return await _profileSettingsRepository.PatchProfileSettings(profileSettings, cancellationToken);
     }
 
-    private async Task<UserProfile> EnrichWithProfileSettings(UserProfile userProfile, bool useRegisterLookup)
+    private async Task<UserProfile> EnrichWithProfileSettings(UserProfile userProfile, bool useRegisterLookup, CancellationToken cancellationToken)
     {
-        ProfileSettings.ProfileSettings? profileSettings = await _profileSettingsRepository.GetProfileSettings(userProfile.UserId);
+        ProfileSettings.ProfileSettings? profileSettings = await _profileSettingsRepository.GetProfileSettings(userProfile.UserId, cancellationToken);
         if (profileSettings != null)
         {
             userProfile.ProfileSettingPreference ??= new ProfileSettingPreference();

--- a/src/Altinn.Profile.Integrations/Repositories/ProfileSettingsRepository.cs
+++ b/src/Altinn.Profile.Integrations/Repositories/ProfileSettingsRepository.cs
@@ -64,17 +64,13 @@ namespace Altinn.Profile.Integrations.Repositories
             return existing;
         }
 
-        /// <summary>
-        /// Retrieves the profile settings for a given user ID.
-        /// </summary>
-        /// <param name="userId">The id of the user</param>
-        /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
-        public async Task<ProfileSettings?> GetProfileSettings(int userId)
+        /// <inheritdoc/>
+        public async Task<ProfileSettings?> GetProfileSettings(int userId, CancellationToken cancellationToken)
         {
-            using ProfileDbContext databaseContext = await _contextFactory.CreateDbContextAsync();
+            using ProfileDbContext databaseContext = await _contextFactory.CreateDbContextAsync(cancellationToken);
             return await databaseContext.ProfileSettings
                 .AsNoTracking()
-                .SingleOrDefaultAsync(g => g.UserId == userId);
+                .SingleOrDefaultAsync(g => g.UserId == userId, cancellationToken);
         }
     }
 }

--- a/src/Altinn.Profile/Controllers/UserContactPointController.cs
+++ b/src/Altinn.Profile/Controllers/UserContactPointController.cs
@@ -36,14 +36,14 @@ public class UserContactPointController : ControllerBase
     /// <returns>Returns an overview of the availability of various contact points for the user</returns>
     [HttpPost("availability")]
     [ProducesResponseType(StatusCodes.Status200OK)]
-    public async Task<ActionResult<UserContactPointAvailabilityList>> PostAvailabilityLookup([FromBody][Required] UserContactDetailsLookupCriteria userContactPointLookup)
+    public async Task<ActionResult<UserContactPointAvailabilityList>> PostAvailabilityLookup([FromBody][Required] UserContactDetailsLookupCriteria userContactPointLookup, CancellationToken cancellationToken)
     {
         if (userContactPointLookup.NationalIdentityNumbers.Count == 0)
         {
             return new UserContactPointAvailabilityList();
         }
 
-        UserContactPointAvailabilityList result = await _contactPointService.GetContactPointAvailability(userContactPointLookup.NationalIdentityNumbers);
+        UserContactPointAvailabilityList result = await _contactPointService.GetContactPointAvailability(userContactPointLookup.NationalIdentityNumbers, cancellationToken);
         return Ok(result);
     }
 

--- a/src/Altinn.Profile/Controllers/UserProfileInternalController.cs
+++ b/src/Altinn.Profile/Controllers/UserProfileInternalController.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Altinn.Profile.Core;
@@ -40,12 +41,13 @@ public class UserProfileInternalController : Controller
     ///     SSN/Dnr (from Freg)
     /// </summary>
     /// <param name="userProfileLookup">Input model for providing one of the supported lookup parameters</param>
+    /// <param name="cancellationToken">The cancellation token</param>
     /// <returns>User profile of the given user</returns>
     [HttpPost]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<ActionResult<UserProfile>> Get([FromBody][Required] UserProfileLookup userProfileLookup)
+    public async Task<ActionResult<UserProfile>> Get([FromBody][Required] UserProfileLookup userProfileLookup, CancellationToken cancellationToken)
     {
         if (!ModelState.IsValid)
         {
@@ -56,19 +58,19 @@ public class UserProfileInternalController : Controller
 
         if (userProfileLookup?.UserId.HasValue == true && userProfileLookup.UserId != 0)
         {
-            result = await _userProfileService.GetUser((int)userProfileLookup.UserId);
+            result = await _userProfileService.GetUser((int)userProfileLookup.UserId, cancellationToken);
         }
         else if (userProfileLookup?.UserUuid != null)
         {
-            result = await _userProfileService.GetUserByUuid(userProfileLookup.UserUuid.Value);
+            result = await _userProfileService.GetUserByUuid(userProfileLookup.UserUuid.Value, cancellationToken);
         }
         else if (!string.IsNullOrWhiteSpace(userProfileLookup?.Username))
         {
-            result = await _userProfileService.GetUserByUsername(userProfileLookup.Username);
+            result = await _userProfileService.GetUserByUsername(userProfileLookup.Username, cancellationToken);
         }
         else if (!string.IsNullOrWhiteSpace(userProfileLookup?.Ssn))
         {
-            result = await _userProfileService.GetUser(userProfileLookup.Ssn);
+            result = await _userProfileService.GetUser(userProfileLookup.Ssn, cancellationToken);
         }
         else
         {
@@ -84,6 +86,7 @@ public class UserProfileInternalController : Controller
     /// Gets a list of user profiles for a list of of users identified by userUuid.
     /// </summary>
     /// <param name="userUuidList">List of uuid identifying the users profiles to return</param>
+    /// <param name="cancellationToken">The cancellation token</param>
     /// <returns>List of user profiles</returns>
     [HttpPost]
     [Route("listbyuuid")]
@@ -91,7 +94,7 @@ public class UserProfileInternalController : Controller
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [Consumes("application/json")]
     [Produces("application/json")]
-    public async Task<ActionResult<List<UserProfile>>> GetList([FromBody][Required] List<Guid> userUuidList)
+    public async Task<ActionResult<List<UserProfile>>> GetList([FromBody][Required] List<Guid> userUuidList, CancellationToken cancellationToken)
     {
         if (!ModelState.IsValid)
         {
@@ -103,7 +106,7 @@ public class UserProfileInternalController : Controller
             return BadRequest();
         }
 
-        Result<List<UserProfile>, bool> result = await _userProfileService.GetUserListByUuid(userUuidList);
+        Result<List<UserProfile>, bool> result = await _userProfileService.GetUserListByUuid(userUuidList, cancellationToken);
         List<UserProfile> userProfiles = result.Match(
              userProfileList => userProfileList,
              _ => []);

--- a/src/Altinn.Profile/Controllers/UsersController.cs
+++ b/src/Altinn.Profile/Controllers/UsersController.cs
@@ -42,12 +42,13 @@ public class UsersController : Controller
     /// Gets the user profile for a given user id
     /// </summary>
     /// <param name="userID">The user id</param>
+    /// <param name="cancellationToken">The cancellation token</param>
     /// <returns>The information about a given user</returns>
     [HttpGet("{userID:int}")]
     [Authorize(Policy = AuthConstants.PlatformAccess)]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<ActionResult<UserProfile>> Get(int userID)
+    public async Task<ActionResult<UserProfile>> Get(int userID, CancellationToken cancellationToken)
     {
         if (!ModelState.IsValid)
         {
@@ -59,7 +60,7 @@ public class UsersController : Controller
             return NotFound();
         }
 
-        Result<UserProfile, bool> result = await _userProfileService.GetUser(userID);
+        Result<UserProfile, bool> result = await _userProfileService.GetUser(userID, cancellationToken);
 
         return result.Match<ActionResult<UserProfile>>(
             userProfile => Ok(userProfile),
@@ -70,19 +71,20 @@ public class UsersController : Controller
     /// Gets the user profile for a given user uuid
     /// </summary>
     /// <param name="userUuid">The user uuid</param>
+    /// <param name="cancellationToken">The cancellation token</param>
     /// <returns>The information about a given user</returns>
     [HttpGet("byuuid/{userUuid:Guid}")]
     [Authorize(Policy = AuthConstants.PlatformAccess)]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<ActionResult<UserProfile>> Get([FromRoute] Guid userUuid)
+    public async Task<ActionResult<UserProfile>> Get([FromRoute] Guid userUuid, CancellationToken cancellationToken)
     {
         if (!ModelState.IsValid)
         {
             return BadRequest(ModelState);
         }
 
-        Result<UserProfile, bool> result = await _userProfileService.GetUserByUuid(userUuid);
+        Result<UserProfile, bool> result = await _userProfileService.GetUserByUuid(userUuid, cancellationToken);
 
         return result.Match<ActionResult<UserProfile>>(
             userProfile => Ok(userProfile),
@@ -96,7 +98,7 @@ public class UsersController : Controller
     [HttpGet("current")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<ActionResult<UserProfile>> Get()
+    public async Task<ActionResult<UserProfile>> Get(CancellationToken cancellationToken)
     {
         string userIdString = Request.HttpContext.User.Claims
             .Where(c => c.Type == AltinnCoreClaimTypes.UserId)
@@ -109,26 +111,27 @@ public class UsersController : Controller
 
         int userId = int.Parse(userIdString);
 
-        return await Get(userId);
+        return await Get(userId, cancellationToken);
     }
 
     /// <summary>
     /// Gets the user profile for a given SSN
     /// </summary>
     /// <param name="ssn">The user's social security number</param>
+    /// <param name="cancellationToken">The cancellation token</param>
     /// <returns>User profile connected to given SSN </returns>
     [HttpPost]
     [Authorize(Policy = AuthConstants.PlatformAccess)]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<ActionResult<UserProfile>> GetUserFromSSN([FromBody][Required] string ssn)
+    public async Task<ActionResult<UserProfile>> GetUserFromSSN([FromBody][Required] string ssn, CancellationToken cancellationToken)
     {
         if (!ModelState.IsValid)
         {
             return BadRequest(ModelState);
         }
 
-        Result<UserProfile, bool> result = await _userProfileService.GetUser(ssn);
+        Result<UserProfile, bool> result = await _userProfileService.GetUser(ssn, cancellationToken);
 
         return result.Match<ActionResult<UserProfile>>(
             userProfile => Ok(userProfile),

--- a/src/Altinn.Profile/appsettings.json
+++ b/src/Altinn.Profile/appsettings.json
@@ -13,7 +13,8 @@
   "CoreSettings": {
     "ProfileCacheLifetimeSeconds": 600,
     "LookupPreselectedPartyIdAtRegister": true,
-    "RegisterLookupInShadowMode": true
+    "RegisterLookupInShadowMode": true,
+    "RegisterAsPrimaryUserProfileSource": false
   },
   "PostgreSqlSettings": {
     "MigrationScriptPath": "Migration",

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/NotificationsSettingsControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/NotificationsSettingsControllerTests.cs
@@ -64,7 +64,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
                 .Setup(x => x.GetNotificationAddressAsync(UserId, partyGuid, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(userPartyContactInfo);
             _factory.ProfileSettingsRepositoryMock
-                .Setup(x => x.GetProfileSettings(UserId))
+                .Setup(x => x.GetProfileSettings(UserId, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new ProfileSettings { UserId = UserId, IgnoreUnitProfileDateTime = null, LanguageType = "no" });
             _factory.AddressVerificationRepositoryMock
                 .Setup(x => x.GetVerificationStatusAsync(It.IsAny<int>(), AddressType.Email, It.Is<string>(e => e == "test@example.com"), It.IsAny<CancellationToken>()))
@@ -187,7 +187,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
                 .ReturnsAsync(infos);
             SetupSblMock();
             _factory.ProfileSettingsRepositoryMock
-                .Setup(x => x.GetProfileSettings(UserId))
+                .Setup(x => x.GetProfileSettings(UserId, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new ProfileSettings { UserId = UserId, IgnoreUnitProfileDateTime = DateTime.Today, LanguageType = "no" });
             _factory.AddressVerificationRepositoryMock
                 .Setup(x => x.GetVerificationStatusAsync(It.IsAny<int>(), AddressType.Email, It.Is<string>(e => e == "a@b.com"), It.IsAny<CancellationToken>()))

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/UserProfileInternalControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/UserProfileInternalControllerTests.cs
@@ -749,7 +749,7 @@ public class UserProfileInternalControllerTests : IClassFixture<ProfileWebApplic
         {
             builder.ConfigureAppConfiguration((_, config) =>
             {
-                config.AddInMemoryCollection(new Dictionary<string, string?>
+                config.AddInMemoryCollection(new Dictionary<string, string>
                 {
                     ["CoreSettings:RegisterAsPrimaryUserProfileSource"] = "true",
                     ["CoreSettings:RegisterLookupInShadowMode"] = "false",

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/UserProfileInternalControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/UserProfileInternalControllerTests.cs
@@ -499,7 +499,7 @@ public class UserProfileInternalControllerTests : IClassFixture<ProfileWebApplic
             UserProfile userProfile = await TestDataLoader.Load<UserProfile>(UserId.ToString());
             return new HttpResponseMessage() { Content = JsonContent.Create(userProfile) };
         });
-        _factory.ProfileSettingsRepositoryMock.Setup(m => m.GetProfileSettings(UserId))
+        _factory.ProfileSettingsRepositoryMock.Setup(m => m.GetProfileSettings(UserId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((ProfileSettings)null);
 
         HttpRequestMessage httpRequestMessage = CreatePostRequest($"/profile/api/v1/internal/user/", new UserProfileLookup { Username = username });

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/UserProfileInternalControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/UserProfileInternalControllerTests.cs
@@ -6,17 +6,17 @@ using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Threading;
 using System.Threading.Tasks;
-
 using Altinn.Profile.Core.User.ProfileSettings;
 using Altinn.Profile.Models;
-
 using Altinn.Profile.Tests.Testdata;
-
+using Altinn.Register.Contracts;
+using Altinn.Register.Contracts.Testing;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
 using Moq;
-
 using Xunit;
-
 using static Altinn.Register.Contracts.PartyUrn;
 
 namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers;
@@ -623,6 +623,139 @@ public class UserProfileInternalControllerTests : IClassFixture<ProfileWebApplic
 
         // Assert
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetUserById_RegisterAsPrimaryEnabled_RegisterHasSsn_UsesRegisterAndSkipsSbl()
+    {
+        // Arrange
+        const int userId = 2516356;
+
+        HttpRequestMessage sblRequest = null;
+        _factory.SblBridgeHttpMessageHandler.ChangeHandlerFunction((request, token) =>
+        {
+            sblRequest = request;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+        });
+
+        Person registerPerson = Person.Minimal("14836498780") with
+        {
+            PartyId = 987654,
+            Uuid = Guid.NewGuid(),
+            ShortName = "Register Person",
+            FirstName = "Register",
+            LastName = "Person",
+            ModifiedAt = DateTimeOffset.UtcNow,
+            IsDeleted = false,
+        };
+
+        _factory.RegisterClientMock
+            .Setup(m => m.GetUserParty(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(registerPerson);
+
+        using WebApplicationFactory<Program> registerPrimaryFactory = CreateFactoryWithRegisterAsPrimaryEnabled();
+        HttpClient client = registerPrimaryFactory.CreateClient();
+
+        HttpRequestMessage httpRequestMessage = CreatePostRequest("/profile/api/v1/internal/user/", new UserProfileLookup { UserId = userId });
+
+        // Act
+        HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Null(sblRequest);
+
+        string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        UserProfile actualUser = JsonSerializer.Deserialize<UserProfile>(responseContent, serializerOptionsCamelCase);
+
+        Assert.NotNull(actualUser);
+        Assert.Equal("Register Person", actualUser.Party.Name);
+        Assert.Equal("14836498780", actualUser.Party.SSN);
+
+        _factory.RegisterClientMock.Verify(m => m.GetUserParty(userId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetUserByUsername_RegisterAsPrimaryEnabled_RegisterThrows_FallsBackToSbl()
+    {
+        // Arrange
+        const string username = "OrstaECUser";
+
+        HttpRequestMessage sblRequest = null;
+        _factory.SblBridgeHttpMessageHandler.ChangeHandlerFunction(async (request, token) =>
+        {
+            sblRequest = request;
+            UserProfile userProfile = await TestDataLoader.Load<UserProfile>(username);
+            return new HttpResponseMessage() { Content = JsonContent.Create(userProfile) };
+        });
+
+        _factory.RegisterClientMock
+            .Setup(m => m.GetUserPartyByUsername(username, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("Register unavailable"));
+
+        using WebApplicationFactory<Program> registerPrimaryFactory = CreateFactoryWithRegisterAsPrimaryEnabled();
+        HttpClient client = registerPrimaryFactory.CreateClient();
+
+        HttpRequestMessage httpRequestMessage = CreatePostRequest("/profile/api/v1/internal/user/", new UserProfileLookup { Username = username });
+
+        // Act
+        HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(sblRequest);
+        Assert.Equal(HttpMethod.Get, sblRequest.Method);
+        Assert.EndsWith($"sblbridge/profile/api/users/?username={username}", sblRequest.RequestUri.ToString());
+    }
+
+    [Fact]
+    public async Task GetUserBySsn_RegisterAsPrimaryEnabled_RegisterReturnsSelfIdentified_FallsBackToSbl()
+    {
+        // Arrange
+        const string ssn = "01017512345";
+
+        HttpRequestMessage sblRequest = null;
+        _factory.SblBridgeHttpMessageHandler.ChangeHandlerFunction(async (request, token) =>
+        {
+            sblRequest = request;
+            UserProfile userProfile = await TestDataLoader.Load<UserProfile>("2516356");
+            return new HttpResponseMessage() { Content = JsonContent.Create(userProfile) };
+        });
+
+        SelfIdentifiedUser selfIdentifiedFromRegister = await TestDataLoader.Load<SelfIdentifiedUser>("siuser-input");
+
+        _factory.RegisterClientMock
+            .Setup(m => m.GetUserPartyBySsn(ssn, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(selfIdentifiedFromRegister);
+
+        using WebApplicationFactory<Program> registerPrimaryFactory = CreateFactoryWithRegisterAsPrimaryEnabled();
+        HttpClient client = registerPrimaryFactory.CreateClient();
+
+        HttpRequestMessage httpRequestMessage = CreatePostRequest("/profile/api/v1/internal/user/", new UserProfileLookup { Ssn = ssn });
+
+        // Act
+        HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(sblRequest);
+        Assert.Equal(HttpMethod.Post, sblRequest.Method);
+        Assert.EndsWith("sblbridge/profile/api/users", sblRequest.RequestUri.ToString());
+    }
+
+    private WebApplicationFactory<Program> CreateFactoryWithRegisterAsPrimaryEnabled()
+    {
+        return _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureAppConfiguration((_, config) =>
+            {
+                config.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["CoreSettings:RegisterAsPrimaryUserProfileSource"] = "true",
+                    ["CoreSettings:RegisterLookupInShadowMode"] = "false",
+                });
+            });
+        });
     }
 
     private static HttpRequestMessage CreatePostRequest(string requestUri, UserProfileLookup lookupRequest)

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/UserProfileInternalControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/UserProfileInternalControllerTests.cs
@@ -35,6 +35,7 @@ public class UserProfileInternalControllerTests : IClassFixture<ProfileWebApplic
     {
         _factory = factory;
         _factory.MemoryCache.Clear();
+        _factory.RegisterClientMock.Reset();
     }
 
     [Fact]

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/UsersControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/UsersControllerTests.cs
@@ -17,6 +17,11 @@ using Altinn.Profile.Core.User.ProfileSettings;
 using Altinn.Profile.Models;
 using Altinn.Profile.Tests.IntegrationTests.Utils;
 using Altinn.Profile.Tests.Testdata;
+using Altinn.Register.Contracts;
+using Altinn.Register.Contracts.Testing;
+
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
 
 using Moq;
 
@@ -39,6 +44,7 @@ public class UsersControllerTests : IClassFixture<ProfileWebApplicationFactory<P
         _factory = factory;
         _factory.MemoryCache.Clear();
         _factory.PersonServiceMock.Reset();
+        _factory.RegisterClientMock.Reset();
     }
 
     [Fact]
@@ -902,5 +908,163 @@ public class UsersControllerTests : IClassFixture<ProfileWebApplicationFactory<P
         httpRequestMessage.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
         httpRequestMessage.Content = content;
         return httpRequestMessage;
+    }
+
+    private WebApplicationFactory<Program> CreateFactoryWithRegisterAsPrimaryEnabled()
+    {
+        return _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureAppConfiguration((_, config) =>
+            {
+                config.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["CoreSettings:RegisterAsPrimaryUserProfileSource"] = "true",
+                    ["CoreSettings:RegisterLookupInShadowMode"] = "false",
+                });
+            });
+        });
+    }
+
+    [Fact]
+    public async Task GetUsersById_AsUser_RegisterAsPrimaryEnabled_RegisterHasSsn_UsesRegisterAndSkipsSbl()
+    {
+        // Arrange
+        const int userId = 2516356;
+
+        HttpRequestMessage? sblRequest = null;
+        _factory.SblBridgeHttpMessageHandler.ChangeHandlerFunction((request, token) =>
+        {
+            sblRequest = request;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+        });
+
+        Person registerPerson = Person.Minimal("14836498780") with
+        {
+            PartyId = 987654,
+            Uuid = Guid.NewGuid(),
+            ShortName = "Register Person",
+            FirstName = "Register",
+            LastName = "Person",
+            ModifiedAt = DateTimeOffset.UtcNow,
+            IsDeleted = false,
+        };
+
+        _factory.RegisterClientMock
+            .Setup(m => m.GetUserParty(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(registerPerson);
+
+        _factory.ProfileSettingsRepositoryMock
+            .Setup(m => m.GetProfileSettings(It.IsAny<int>()))
+            .ReturnsAsync((ProfileSettings?)null);
+
+        _factory.PersonServiceMock
+            .Setup(m => m.GetContactPreferencesAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        using WebApplicationFactory<Program> registerPrimaryFactory = CreateFactoryWithRegisterAsPrimaryEnabled();
+        HttpClient client = registerPrimaryFactory.CreateClient();
+
+        HttpRequestMessage httpRequestMessage = CreateGetRequest(userId, $"/profile/api/v1/users/{userId}");
+        httpRequestMessage.Headers.Add("PlatformAccessToken", PrincipalUtil.GetAccessToken("ttd", "unittest"));
+
+        // Act
+        HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Null(sblRequest); // register path should not call legacy
+
+        string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        UserProfile? actualUser = JsonSerializer.Deserialize<UserProfile>(responseContent, _serializerOptionsCamelCase);
+
+        Assert.NotNull(actualUser);
+        Assert.Equal("Register Person", actualUser.Party.Name);
+        Assert.Equal("14836498780", actualUser.Party.SSN);
+
+        _factory.RegisterClientMock.Verify(m => m.GetUserParty(userId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetUsersById_AsUser_RegisterAsPrimaryEnabled_RegisterThrows_FallsBackToSbl()
+    {
+        // Arrange
+        const int userId = 2516356;
+
+        HttpRequestMessage? sblRequest = null;
+        _factory.SblBridgeHttpMessageHandler.ChangeHandlerFunction(async (request, token) =>
+        {
+            sblRequest = request;
+            UserProfile userProfile = await TestDataLoader.Load<UserProfile>(userId.ToString());
+            return new HttpResponseMessage() { Content = JsonContent.Create(userProfile) };
+        });
+
+        _factory.RegisterClientMock
+            .Setup(m => m.GetUserParty(userId, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("Register unavailable"));
+
+        _factory.ProfileSettingsRepositoryMock
+            .Setup(m => m.GetProfileSettings(It.IsAny<int>()))
+            .ReturnsAsync((ProfileSettings?)null);
+
+        _factory.PersonServiceMock
+            .Setup(m => m.GetContactPreferencesAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        using WebApplicationFactory<Program> registerPrimaryFactory = CreateFactoryWithRegisterAsPrimaryEnabled();
+        HttpClient client = registerPrimaryFactory.CreateClient();
+
+        HttpRequestMessage httpRequestMessage = CreateGetRequest(userId, $"/profile/api/v1/users/{userId}");
+        httpRequestMessage.Headers.Add("PlatformAccessToken", PrincipalUtil.GetAccessToken("ttd", "unittest"));
+
+        // Act
+        HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(sblRequest); // fallback path must call legacy
+        Assert.EndsWith($"users/{userId}", sblRequest!.RequestUri?.ToString());
+    }
+
+    [Fact]
+    public async Task GetUsersById_AsUser_RegisterAsPrimaryEnabled_RegisterReturnsSelfIdentified_FallsBackToSbl()
+    {
+        // Arrange
+        const int userId = 2516356;
+
+        HttpRequestMessage? sblRequest = null;
+        _factory.SblBridgeHttpMessageHandler.ChangeHandlerFunction(async (request, token) =>
+        {
+            sblRequest = request;
+            UserProfile userProfile = await TestDataLoader.Load<UserProfile>(userId.ToString());
+            return new HttpResponseMessage() { Content = JsonContent.Create(userProfile) };
+        });
+
+        SelfIdentifiedUser selfIdentifiedFromRegister = await TestDataLoader.Load<SelfIdentifiedUser>("siuser-input");
+
+        _factory.RegisterClientMock
+            .Setup(m => m.GetUserParty(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(selfIdentifiedFromRegister);
+
+        _factory.ProfileSettingsRepositoryMock
+            .Setup(m => m.GetProfileSettings(It.IsAny<int>()))
+            .ReturnsAsync((ProfileSettings?)null);
+
+        _factory.PersonServiceMock
+            .Setup(m => m.GetContactPreferencesAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        using WebApplicationFactory<Program> registerPrimaryFactory = CreateFactoryWithRegisterAsPrimaryEnabled();
+        HttpClient client = registerPrimaryFactory.CreateClient();
+
+        HttpRequestMessage httpRequestMessage = CreateGetRequest(userId, $"/profile/api/v1/users/{userId}");
+        httpRequestMessage.Headers.Add("PlatformAccessToken", PrincipalUtil.GetAccessToken("ttd", "unittest"));
+
+        // Act
+        HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(sblRequest); // no SSN => should fallback
+        Assert.EndsWith($"users/{userId}", sblRequest!.RequestUri?.ToString());
     }
 }

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/UsersControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/UsersControllerTests.cs
@@ -64,7 +64,7 @@ public class UsersControllerTests : IClassFixture<ProfileWebApplicationFactory<P
         });
         _factory.PersonServiceMock.Setup(m => m.GetContactPreferencesAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync([new PersonContactPreferences { Email = "test@mail.com", NationalIdentityNumber = "1", MobileNumber = "+4798765432", IsReserved = true }]);
-        _factory.ProfileSettingsRepositoryMock.Setup(m => m.GetProfileSettings(UserId))
+        _factory.ProfileSettingsRepositoryMock.Setup(m => m.GetProfileSettings(UserId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ProfileSettings
             {
                 UserId = UserId,
@@ -126,7 +126,7 @@ public class UsersControllerTests : IClassFixture<ProfileWebApplicationFactory<P
             UserProfile userProfile = await TestDataLoader.Load<UserProfile>(UserId.ToString());
             return new HttpResponseMessage() { Content = JsonContent.Create(userProfile) };
         });
-        _factory.ProfileSettingsRepositoryMock.Setup(m => m.GetProfileSettings(UserId))
+        _factory.ProfileSettingsRepositoryMock.Setup(m => m.GetProfileSettings(UserId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((ProfileSettings?)null);
 
         HttpRequestMessage httpRequestMessage = CreateGetRequest(UserId, $"/profile/api/v1/users/current");
@@ -226,7 +226,7 @@ public class UsersControllerTests : IClassFixture<ProfileWebApplicationFactory<P
             UserProfile userProfile = await TestDataLoader.Load<UserProfile>(UserId.ToString());
             return new HttpResponseMessage() { Content = JsonContent.Create(userProfile) };
         });
-        _factory.ProfileSettingsRepositoryMock.Setup(m => m.GetProfileSettings(UserId))
+        _factory.ProfileSettingsRepositoryMock.Setup(m => m.GetProfileSettings(UserId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ProfileSettings
             {
                 UserId = UserId,
@@ -295,7 +295,7 @@ public class UsersControllerTests : IClassFixture<ProfileWebApplicationFactory<P
             UserProfile userProfile = await TestDataLoader.Load<UserProfile>(UserId.ToString());
             return new HttpResponseMessage() { Content = JsonContent.Create(userProfile) };
         });
-        _factory.ProfileSettingsRepositoryMock.Setup(m => m.GetProfileSettings(UserId))
+        _factory.ProfileSettingsRepositoryMock.Setup(m => m.GetProfileSettings(UserId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((ProfileSettings?)null);
 
         HttpRequestMessage httpRequestMessage = CreateGetRequest(UserId, $"/profile/api/v1/users/{UserId}");
@@ -473,7 +473,7 @@ public class UsersControllerTests : IClassFixture<ProfileWebApplicationFactory<P
             UserProfile userProfile = await TestDataLoader.Load<UserProfile>(userUuid.ToString());
             return new HttpResponseMessage() { Content = JsonContent.Create(userProfile) };
         });
-        _factory.ProfileSettingsRepositoryMock.Setup(m => m.GetProfileSettings(userId))
+        _factory.ProfileSettingsRepositoryMock.Setup(m => m.GetProfileSettings(userId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ProfileSettings
             {
                 UserId = userId,
@@ -534,7 +534,7 @@ public class UsersControllerTests : IClassFixture<ProfileWebApplicationFactory<P
             UserProfile userProfile = await TestDataLoader.Load<UserProfile>(UserId.ToString());
             return new HttpResponseMessage() { Content = JsonContent.Create(userProfile) };
         });
-        _factory.ProfileSettingsRepositoryMock.Setup(m => m.GetProfileSettings(UserId))
+        _factory.ProfileSettingsRepositoryMock.Setup(m => m.GetProfileSettings(UserId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((ProfileSettings?)null);
 
         HttpRequestMessage httpRequestMessage = CreateGetRequest(UserId, $"/profile/api/v1/users/byuuid/{userUuid}");
@@ -717,7 +717,7 @@ public class UsersControllerTests : IClassFixture<ProfileWebApplicationFactory<P
             return new HttpResponseMessage() { Content = JsonContent.Create(userProfile) };
         });
 
-        _factory.ProfileSettingsRepositoryMock.Setup(m => m.GetProfileSettings(UserId))
+        _factory.ProfileSettingsRepositoryMock.Setup(m => m.GetProfileSettings(UserId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ProfileSettings
             {
                 UserId = UserId,
@@ -783,7 +783,7 @@ public class UsersControllerTests : IClassFixture<ProfileWebApplicationFactory<P
             UserProfile userProfile = await TestDataLoader.Load<UserProfile>(UserId.ToString());
             return new HttpResponseMessage() { Content = JsonContent.Create(userProfile) };
         });
-        _factory.ProfileSettingsRepositoryMock.Setup(m => m.GetProfileSettings(UserId))
+        _factory.ProfileSettingsRepositoryMock.Setup(m => m.GetProfileSettings(UserId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((ProfileSettings?)null);
 
         StringContent content = new("\"01017512345\"", Encoding.UTF8, "application/json");
@@ -954,7 +954,7 @@ public class UsersControllerTests : IClassFixture<ProfileWebApplicationFactory<P
             .ReturnsAsync(registerPerson);
 
         _factory.ProfileSettingsRepositoryMock
-            .Setup(m => m.GetProfileSettings(It.IsAny<int>()))
+            .Setup(m => m.GetProfileSettings(It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((ProfileSettings?)null);
 
         _factory.PersonServiceMock
@@ -1003,7 +1003,7 @@ public class UsersControllerTests : IClassFixture<ProfileWebApplicationFactory<P
             .ThrowsAsync(new HttpRequestException("Register unavailable"));
 
         _factory.ProfileSettingsRepositoryMock
-            .Setup(m => m.GetProfileSettings(It.IsAny<int>()))
+            .Setup(m => m.GetProfileSettings(It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((ProfileSettings?)null);
 
         _factory.PersonServiceMock
@@ -1046,7 +1046,7 @@ public class UsersControllerTests : IClassFixture<ProfileWebApplicationFactory<P
             .ReturnsAsync(selfIdentifiedFromRegister);
 
         _factory.ProfileSettingsRepositoryMock
-            .Setup(m => m.GetProfileSettings(It.IsAny<int>()))
+            .Setup(m => m.GetProfileSettings(It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((ProfileSettings?)null);
 
         _factory.PersonServiceMock

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/UsersControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/UsersControllerTests.cs
@@ -893,38 +893,6 @@ public class UsersControllerTests : IClassFixture<ProfileWebApplicationFactory<P
         Assert.Equal("\"01017512345\"", requestContent);
     }
 
-    private static HttpRequestMessage CreateGetRequest(int userId, string requestUri)
-    {
-        HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, requestUri);
-        string token = PrincipalUtil.GetToken(userId);
-        httpRequestMessage.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
-        return httpRequestMessage;
-    }
-
-    private static HttpRequestMessage CreatePostRequest(int userId, string requestUri, StringContent content)
-    {
-        HttpRequestMessage httpRequestMessage = new(HttpMethod.Post, requestUri);
-        string token = PrincipalUtil.GetToken(userId);
-        httpRequestMessage.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
-        httpRequestMessage.Content = content;
-        return httpRequestMessage;
-    }
-
-    private WebApplicationFactory<Program> CreateFactoryWithRegisterAsPrimaryEnabled()
-    {
-        return _factory.WithWebHostBuilder(builder =>
-        {
-            builder.ConfigureAppConfiguration((_, config) =>
-            {
-                config.AddInMemoryCollection(new Dictionary<string, string?>
-                {
-                    ["CoreSettings:RegisterAsPrimaryUserProfileSource"] = "true",
-                    ["CoreSettings:RegisterLookupInShadowMode"] = "false",
-                });
-            });
-        });
-    }
-
     [Fact]
     public async Task GetUsersById_AsUser_RegisterAsPrimaryEnabled_RegisterHasSsn_UsesRegisterAndSkipsSbl()
     {
@@ -1066,5 +1034,37 @@ public class UsersControllerTests : IClassFixture<ProfileWebApplicationFactory<P
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         Assert.NotNull(sblRequest); // no SSN => should fallback
         Assert.EndsWith($"users/{userId}", sblRequest!.RequestUri?.ToString());
+    }
+
+    private static HttpRequestMessage CreateGetRequest(int userId, string requestUri)
+    {
+        HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, requestUri);
+        string token = PrincipalUtil.GetToken(userId);
+        httpRequestMessage.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return httpRequestMessage;
+    }
+
+    private static HttpRequestMessage CreatePostRequest(int userId, string requestUri, StringContent content)
+    {
+        HttpRequestMessage httpRequestMessage = new(HttpMethod.Post, requestUri);
+        string token = PrincipalUtil.GetToken(userId);
+        httpRequestMessage.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        httpRequestMessage.Content = content;
+        return httpRequestMessage;
+    }
+
+    private WebApplicationFactory<Program> CreateFactoryWithRegisterAsPrimaryEnabled()
+    {
+        return _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureAppConfiguration((_, config) =>
+            {
+                config.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["CoreSettings:RegisterAsPrimaryUserProfileSource"] = "true",
+                    ["CoreSettings:RegisterLookupInShadowMode"] = "false",
+                });
+            });
+        });
     }
 }

--- a/test/Altinn.Profile.Tests/IntegrationTests/ProfileWebApplicationFactory.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/ProfileWebApplicationFactory.cs
@@ -95,6 +95,12 @@ public sealed class ProfileWebApplicationFactory<TProgram> : WebApplicationFacto
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
+        builder.ConfigureLogging(logging =>
+        {
+            logging.ClearProviders();
+            logging.SetMinimumLevel(LogLevel.Warning);
+        });
+
         builder.ConfigureAppConfiguration((context, config) =>
         {
             config.SetBasePath(Directory.GetCurrentDirectory());

--- a/test/Altinn.Profile.Tests/Profile.Core/User/UserContactPointServiceTest.cs
+++ b/test/Altinn.Profile.Tests/Profile.Core/User/UserContactPointServiceTest.cs
@@ -62,8 +62,8 @@ public class UserContactPointServiceTest
             IsReserved = userProfileB.IsReserved,
             MobileNumber = userProfileB.PhoneNumber,
         };
-        _userProfileServiceMock.Setup(m => m.GetUser(userProfileA.Party.SSN)).ReturnsAsync(userProfileA);
-        _userProfileServiceMock.Setup(m => m.GetUser(userProfileB.Party.SSN)).ReturnsAsync(userProfileB);
+        _userProfileServiceMock.Setup(m => m.GetUser(userProfileA.Party.SSN, It.IsAny<CancellationToken>())).ReturnsAsync(userProfileA);
+        _userProfileServiceMock.Setup(m => m.GetUser(userProfileB.Party.SSN, It.IsAny<CancellationToken>())).ReturnsAsync(userProfileB);
         _personServiceMock.Setup(m => m.GetContactPreferencesAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>())).ReturnsAsync([contactPreferencesA, contactPreferencesB]);
 
         return [expectedUserContactPointA, expectedUserContactPointB];
@@ -82,7 +82,7 @@ public class UserContactPointServiceTest
                 expectedUsers[0].NationalIdentityNumber,
                 expectedUsers[1].NationalIdentityNumber
             ],
-            CancellationToken.None);
+            TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.IsSuccess, "Expected a success result");
@@ -141,12 +141,12 @@ public class UserContactPointServiceTest
             "urn:altinn:person:idporten-email:user2@test.no",
             "urn:altinn:person:idporten-email:admin@altinn.no"
         };
-        _userProfileServiceMock.Setup(service => service.GetUserByUsername(It.IsAny<string>())).ReturnsAsync(false);
+        _userProfileServiceMock.Setup(service => service.GetUserByUsername(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(false);
 
         var target = new UserContactPointService(_userProfileServiceMock.Object, _personServiceMock.Object);
 
         // Act
-        SelfIdentifiedUserContactPointsList result = await target.GetSiContactPoints(identities, CancellationToken.None);
+        SelfIdentifiedUserContactPointsList result = await target.GetSiContactPoints(identities, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -179,16 +179,16 @@ public class UserContactPointServiceTest
             "urn:altinn:person:idporten-email:user3@test.no",
             "urn:altinn:person:idporten-email:admin@altinn.no",
         };
-        _userProfileServiceMock.Setup(service => service.GetUserByUsername(It.IsAny<string>())).ReturnsAsync(false);
-        _userProfileServiceMock.Setup(service => service.GetUserByUsername("epost:user2@test.no")).ReturnsAsync(new UserProfile
+        _userProfileServiceMock.Setup(service => service.GetUserByUsername(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(false);
+        _userProfileServiceMock.Setup(service => service.GetUserByUsername("epost:user2@test.no", It.IsAny<CancellationToken>())).ReturnsAsync(new UserProfile
         {
             Email = "other-user2@email.com",
         });
-        _userProfileServiceMock.Setup(service => service.GetUserByUsername("epost:user3@test.no")).ReturnsAsync(new UserProfile
+        _userProfileServiceMock.Setup(service => service.GetUserByUsername("epost:user3@test.no", It.IsAny<CancellationToken>())).ReturnsAsync(new UserProfile
         {
             PhoneNumber = "+4799999998",
         });
-        _userProfileServiceMock.Setup(service => service.GetUserByUsername("epost:admin@altinn.no")).ReturnsAsync(new UserProfile
+        _userProfileServiceMock.Setup(service => service.GetUserByUsername("epost:admin@altinn.no", It.IsAny<CancellationToken>())).ReturnsAsync(new UserProfile
         {
             Email = "other-email@email.com",
             PhoneNumber = "+4799999999",
@@ -197,7 +197,7 @@ public class UserContactPointServiceTest
         var target = new UserContactPointService(_userProfileServiceMock.Object, _personServiceMock.Object);
 
         // Act
-        SelfIdentifiedUserContactPointsList result = await target.GetSiContactPoints(identities, CancellationToken.None);
+        SelfIdentifiedUserContactPointsList result = await target.GetSiContactPoints(identities, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -235,23 +235,23 @@ public class UserContactPointServiceTest
             "unprefixed@test.no",
             "urn:altinn:party:username:myusername",
         };
-        _userProfileServiceMock.Setup(service => service.GetUserByUsername("myusername")).ReturnsAsync(new UserProfile()
+        _userProfileServiceMock.Setup(service => service.GetUserByUsername("myusername", It.IsAny<CancellationToken>())).ReturnsAsync(new UserProfile()
         {
             Email = "user4@email.com",
             PhoneNumber = "+4799999999",
         });
 
-        _userProfileServiceMock.Setup(service => service.GetUserByUsername("epost:user1@altinn.no")).ReturnsAsync(new UserProfile()
+        _userProfileServiceMock.Setup(service => service.GetUserByUsername("epost:user1@altinn.no", It.IsAny<CancellationToken>())).ReturnsAsync(new UserProfile()
         {
             Email = "user1@email.com",
         });
 
-        _userProfileServiceMock.Setup(service => service.GetUserByUsername("epost:user2@altinn.no")).ReturnsAsync(false);
+        _userProfileServiceMock.Setup(service => service.GetUserByUsername("epost:user2@altinn.no", It.IsAny<CancellationToken>())).ReturnsAsync(false);
 
         var target = new UserContactPointService(_userProfileServiceMock.Object, _personServiceMock.Object);
 
         // Act
-        SelfIdentifiedUserContactPointsList result = await target.GetSiContactPoints(identities, CancellationToken.None);
+        SelfIdentifiedUserContactPointsList result = await target.GetSiContactPoints(identities, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -281,7 +281,7 @@ public class UserContactPointServiceTest
         var target = new UserContactPointService(_userProfileServiceMock.Object, _personServiceMock.Object);
 
         // Act
-        SelfIdentifiedUserContactPointsList result = await target.GetSiContactPoints(emailIdentifiers, CancellationToken.None);
+        SelfIdentifiedUserContactPointsList result = await target.GetSiContactPoints(emailIdentifiers, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -312,12 +312,12 @@ public class UserContactPointServiceTest
             // Ampersand (&) encoded as %26
             "urn:altinn:person:idporten-email:user%26company@test.org"
         };
-        _userProfileServiceMock.Setup(service => service.GetUserByUsername(It.IsAny<string>())).ReturnsAsync(false);
+        _userProfileServiceMock.Setup(service => service.GetUserByUsername(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(false);
 
         var target = new UserContactPointService(_userProfileServiceMock.Object, _personServiceMock.Object);
 
         // Act
-        SelfIdentifiedUserContactPointsList result = await target.GetSiContactPoints(identities, CancellationToken.None);
+        SelfIdentifiedUserContactPointsList result = await target.GetSiContactPoints(identities, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -365,17 +365,17 @@ public class UserContactPointServiceTest
             "urn:altinn:username:mysecondusername",
             "urn:altinn:person:legacy-selfidentified:mythirdusername"
         };
-        _userProfileServiceMock.Setup(service => service.GetUserByUsername("myusername")).ReturnsAsync(new UserProfile()
+        _userProfileServiceMock.Setup(service => service.GetUserByUsername("myusername", It.IsAny<CancellationToken>())).ReturnsAsync(new UserProfile()
         {
             Email = "user1@example.com",
             PhoneNumber = "+4799999999",
         });
-        _userProfileServiceMock.Setup(service => service.GetUserByUsername("mysecondusername")).ReturnsAsync(new UserProfile()
+        _userProfileServiceMock.Setup(service => service.GetUserByUsername("mysecondusername", It.IsAny<CancellationToken>())).ReturnsAsync(new UserProfile()
         {
             Email = string.Empty,
             PhoneNumber = string.Empty,
         });
-        _userProfileServiceMock.Setup(service => service.GetUserByUsername("mythirdusername")).ReturnsAsync(new UserProfile()
+        _userProfileServiceMock.Setup(service => service.GetUserByUsername("mythirdusername", It.IsAny<CancellationToken>())).ReturnsAsync(new UserProfile()
         {
             Email = "admin@altinn.no",
             PhoneNumber = "+4799999999",
@@ -383,7 +383,7 @@ public class UserContactPointServiceTest
         var target = new UserContactPointService(_userProfileServiceMock.Object, _personServiceMock.Object);
 
         // Act
-        SelfIdentifiedUserContactPointsList result = await target.GetSiContactPoints(identities, CancellationToken.None);
+        SelfIdentifiedUserContactPointsList result = await target.GetSiContactPoints(identities, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);

--- a/test/Altinn.Profile.Tests/Profile.Integrations/Repositories/ProfileSettingsRepositoryTests.cs
+++ b/test/Altinn.Profile.Tests/Profile.Integrations/Repositories/ProfileSettingsRepositoryTests.cs
@@ -69,7 +69,7 @@ public class ProfileSettingsRepositoryTests
         // Act
         await repository.UpdateProfileSettings(profileSettings, TestContext.Current.CancellationToken);
 
-        var updated = await repository.GetProfileSettings(profileSettings.UserId);
+        var updated = await repository.GetProfileSettings(profileSettings.UserId, TestContext.Current.CancellationToken);
         Assert.NotNull(updated);
         Assert.Equal(profileSettings.UserId, updated.UserId);
         Assert.Equal(profileSettings.DoNotPromptForParty, updated.DoNotPromptForParty);
@@ -126,7 +126,7 @@ public class ProfileSettingsRepositoryTests
         // Act
         await repository.UpdateProfileSettings(updated, TestContext.Current.CancellationToken);
 
-        var stored = await repository.GetProfileSettings(existing.UserId);
+        var stored = await repository.GetProfileSettings(existing.UserId, TestContext.Current.CancellationToken);
         Assert.NotNull(stored);
         Assert.Equal(updated.UserId, stored.UserId);
         Assert.Equal(updated.DoNotPromptForParty, stored.DoNotPromptForParty);
@@ -149,7 +149,7 @@ public class ProfileSettingsRepositoryTests
     {
         var userId = 4;
 
-        var result = await _repository.GetProfileSettings(userId);
+        var result = await _repository.GetProfileSettings(userId, TestContext.Current.CancellationToken);
 
         Assert.Null(result);
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #785 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable option to treat the register as the primary user-profile source with automatic fallback to the legacy source.

* **Improvements**
  * Widespread cooperative cancellation support across profile lookups, contact-point lookups, controllers, and repository operations for more responsive request handling.
  * Register-vs-legacy selection now respects configuration and handles register errors by falling back.

* **Tests**
  * Expanded integration tests covering register-as-primary behavior, fallback scenarios, and cancellation-aware flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->