### PR TITLE
.NET image patching and Trivy-tweaking

### DIFF
--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -2,14 +2,14 @@ name: Profile Scan
 
 on:
   schedule:
-  - cron: '0 8 * * 1,4'
+    - cron: '0 8 * * 1,4'
   push:
-    branches: [ main ]
+    branches: [main]
     paths:
       - 'src/**'
       - 'Dockerfile'
   pull_request:
-    branches: [ main ]
+    branches: [main]
     types: [opened, synchronize, reopened]
     paths:
       - 'src/**'
@@ -20,19 +20,19 @@ jobs:
     permissions:
       contents: read
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-    - name: Build the Docker image
-      run: docker build . --tag altinn-profile:${{github.sha}}
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Build the Docker image
+        run: docker build . --tag altinn-profile:${{github.sha}}
 
-    - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
-      with:
-        image-ref: 'altinn-profile:${{ github.sha }}'
-        format: 'table'
-        exit-code: '1'
-        ignore-unfixed: true
-        vuln-type: 'os,library'
-        severity: 'CRITICAL,HIGH'
-      env:
-        TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db,aquasec/trivy-db,ghcr.io/aquasecurity/trivy-db
-        TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db,aquasec/trivy-java-db,ghcr.io/aquasecurity/trivy-java-db
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        with:
+          image-ref: 'altinn-profile:${{ github.sha }}'
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db,aquasec/trivy-db,ghcr.io/aquasecurity/trivy-db
+          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db,aquasec/trivy-java-db,ghcr.io/aquasecurity/trivy-java-db

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -8,12 +8,16 @@ on:
     paths:
       - 'src/**'
       - 'Dockerfile'
+      - '.trivyignore.yaml'
+      - '.github/workflows/container-scan.yml'
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened]
     paths:
       - 'src/**'
       - 'Dockerfile'
+      - '.trivyignore.yaml'
+      - '.github/workflows/container-scan.yml'
 jobs:
   scan:
     runs-on: ubuntu-latest

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -33,6 +33,7 @@ jobs:
           ignore-unfixed: true
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH'
+          trivyignores: '.trivyignore.yaml'
         env:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db,aquasec/trivy-db,ghcr.io/aquasecurity/trivy-db
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db,aquasec/trivy-java-db,ghcr.io/aquasecurity/trivy-java-db

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,0 +1,4 @@
+vulnerabilities:
+  - id: CVE-2026-28390 # libcrypto3/libssl3
+    statement: Not exploitable - application does not process attacker-controlled CMS data
+    expires: 2026-07-10 # revisit in 1 month, might have a patch by then

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,4 +1,4 @@
 vulnerabilities:
   - id: CVE-2026-28390 # libcrypto3/libssl3
     statement: Not exploitable - application does not process attacker-controlled CMS data
-    expires: 2026-07-10 # revisit in 1 month, might have a patch by then
+    expires: 2026-05-10 # revisit in 1 month, might have a patch by then

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:10.0.200-alpine3.23@sha256:a0116e63beedf9197c3d491eb224aea9ae7d1692079eda9eebe2809f06d580e3 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0.201-alpine3.23@sha256:a0116e63beedf9197c3d491eb224aea9ae7d1692079eda9eebe2809f06d580e3 AS build
 WORKDIR /app
 
 COPY src/Altinn.Profile/*.csproj ./src/Altinn.Profile/
@@ -11,7 +11,7 @@ RUN dotnet restore ./src/Altinn.Profile/Altinn.Profile.csproj
 COPY src ./src
 RUN dotnet publish -c Release -o /app_output ./src/Altinn.Profile/Altinn.Profile.csproj
 
-FROM mcr.microsoft.com/dotnet/aspnet:10.0.4-alpine3.23@sha256:512d643dce0e7daa25c85407eb4e14dbea33b72e4a7792427949666636934019 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:10.0.5-alpine3.23@sha256:512d643dce0e7daa25c85407eb4e14dbea33b72e4a7792427949666636934019 AS final
 EXPOSE 5030
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:10.0.201-alpine3.23@sha256:a0116e63beedf9197c3d491eb224aea9ae7d1692079eda9eebe2809f06d580e3 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0.201-alpine3.23@sha256:a65df8d9ad0661a1a785a4f26188b3a2826540d448df317ac69cfb6e801e1592 AS build
 WORKDIR /app
 
 COPY src/Altinn.Profile/*.csproj ./src/Altinn.Profile/
@@ -11,7 +11,7 @@ RUN dotnet restore ./src/Altinn.Profile/Altinn.Profile.csproj
 COPY src ./src
 RUN dotnet publish -c Release -o /app_output ./src/Altinn.Profile/Altinn.Profile.csproj
 
-FROM mcr.microsoft.com/dotnet/aspnet:10.0.5-alpine3.23@sha256:512d643dce0e7daa25c85407eb4e14dbea33b72e4a7792427949666636934019 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:10.0.5-alpine3.23@sha256:8c7671a6f0f984d0c102ee70d61e8010857de032b320561dea97cc5781aea5f8 AS final
 EXPOSE 5030
 WORKDIR /app
 


### PR DESCRIPTION
Move away from having a scanning workflow that constantly fails because of an unexploitable security vulnerability.

- Patching to latest dotnet Docker images, as these include a fix for the old `zlib `library vulnerability. 
- Adding a new `.trivyignore.yaml` file where we can keep records for unexploitable vulnerabilities that unnecessarily break our scanning job
  - Includes the latest vulnerability ([CVE-2026-28390](https://nvd.nist.gov/vuln/detail/CVE-2026-28390)) 
- Necessary extension of the trivy-action (tell it to use the new ignore-file)
- Adds a 'v' prefix to version tag for trivy-action

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated container base images to newer patch releases for improved security and stability.
  * Refined CI container-scan workflow and scan settings to ensure scans run reliably and include the workflow file and ignore list.
  * Added a time-limited security exception for a specific non-exploitable vulnerability (expires 2026-05-10).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->