### PR TITLE
Fix trivy-action expiration field and enable suppressed vulnerability output

### DIFF
--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -41,3 +41,4 @@ jobs:
         env:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db,aquasec/trivy-db,ghcr.io/aquasecurity/trivy-db
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db,aquasec/trivy-java-db,ghcr.io/aquasecurity/trivy-java-db
+          TRIVY_SHOW_SUPPRESSED: true

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,4 +1,4 @@
 vulnerabilities:
   - id: CVE-2026-28390 # libcrypto3/libssl3
     statement: Not exploitable - application does not process attacker-controlled CMS data
-    expires: 2026-05-10 # revisit in 1 month, might have a patch by then
+    expired_at: 2026-05-10 # revisit in 1 month, might have a patch by then


### PR DESCRIPTION
Trivy's YAML ignore schema expects `expired_at `(format: yyyy-mm-dd), not `expires`.
Additionally, the suppressed CVEs are by default hidden in the job output. To keep the CVEs and the relevant library written to the log, the new env var flag `TRIVY_SHOW_SUPPRESSED` must be added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced vulnerability scanning workflow to display suppressed findings in scan results
  * Updated vulnerability ignore rule configuration with improved field naming conventions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->