### PR TITLE
docs: Move Enum->String conversion for Swashbuckle detectability, and add example values for email&phone ✏️

### DIFF
--- a/src/Altinn.Profile.Core/AddressVerifications/Models/AddressType.cs
+++ b/src/Altinn.Profile.Core/AddressVerifications/Models/AddressType.cs
@@ -1,8 +1,12 @@
-﻿namespace Altinn.Profile.Core.AddressVerifications.Models
+﻿using System.Text.Json.Serialization;
+
+namespace Altinn.Profile.Core.AddressVerifications.Models
 {
     /// <summary>
     /// Specifies the type of address for verification.
     /// </summary>
+    /// 
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public enum AddressType
     {
         /// <summary>

--- a/src/Altinn.Profile.Core/AddressVerifications/Models/VerificationType.cs
+++ b/src/Altinn.Profile.Core/AddressVerifications/Models/VerificationType.cs
@@ -1,8 +1,11 @@
-﻿namespace Altinn.Profile.Core.AddressVerifications.Models
+﻿using System.Text.Json.Serialization;
+
+namespace Altinn.Profile.Core.AddressVerifications.Models
 {
     /// <summary>
     /// Specifies the type of address verification.
     /// </summary>
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public enum VerificationType
     {
         /// <summary>

--- a/src/Altinn.Profile/Models/AddressCodeResendRequest.cs
+++ b/src/Altinn.Profile/Models/AddressCodeResendRequest.cs
@@ -24,7 +24,6 @@ namespace Altinn.Profile.Models
         /// </summary>
         [Required]
         [JsonRequired]
-        [JsonConverter(typeof(JsonStringEnumConverter))]
         public required AddressType? Type { get; init; }
     }
 }

--- a/src/Altinn.Profile/Models/AddressCodeSendRequest.cs
+++ b/src/Altinn.Profile/Models/AddressCodeSendRequest.cs
@@ -28,7 +28,6 @@ namespace Altinn.Profile.Models
         /// </summary>
         [Required]
         [JsonRequired]
-        [JsonConverter(typeof(JsonStringEnumConverter))]
         public required AddressType? Type { get; init; }
 
         /// <inheritdoc/>

--- a/src/Altinn.Profile/Models/AddressVerificationRequest.cs
+++ b/src/Altinn.Profile/Models/AddressVerificationRequest.cs
@@ -24,7 +24,6 @@ namespace Altinn.Profile.Models
         /// </summary>
         [Required]
         [JsonRequired]
-        [JsonConverter(typeof(JsonStringEnumConverter))]
         public required AddressType? Type { get; init; }
 
         /// <summary>

--- a/src/Altinn.Profile/Models/NotificationAddressModel.cs
+++ b/src/Altinn.Profile/Models/NotificationAddressModel.cs
@@ -17,7 +17,7 @@ namespace Altinn.Profile.Models
         /// <summary>
         /// Email address
         /// </summary>
-        /// <example>example@domain.com</example>
+        /// <example>user@example.com</example>
         [CustomRegexForNotificationAddresses(ValidationRule.OrganizationEmail)]
         public string Email { get; set; }
 

--- a/src/Altinn.Profile/Models/NotificationAddressModel.cs
+++ b/src/Altinn.Profile/Models/NotificationAddressModel.cs
@@ -10,18 +10,21 @@ namespace Altinn.Profile.Models
         /// <summary>
         /// Country code for phone number
         /// </summary>
+        /// <example>+47</example>
         [CustomRegexForNotificationAddresses(ValidationRule.OrganizationCountryCode)]
         public string CountryCode { get; set; }
 
         /// <summary>
         /// Email address
         /// </summary>
+        /// <example>example@domain.com</example>
         [CustomRegexForNotificationAddresses(ValidationRule.OrganizationEmail)]
         public string Email { get; set; }
 
         /// <summary>
         /// Phone number
         /// </summary>
+        /// <example>98765432</example>        
         [CustomRegexForNotificationAddresses(ValidationRule.OrganizationPhone)]
         public string Phone { get; set; }
     }

--- a/src/Altinn.Profile/Models/NotificationSettingsResponse.cs
+++ b/src/Altinn.Profile/Models/NotificationSettingsResponse.cs
@@ -30,13 +30,11 @@ namespace Altinn.Profile.Models
         /// <summary>
         /// The verification status of the email address. Null if no email address is set.
         /// </summary>
-        [JsonConverter(typeof(JsonStringEnumConverter))]
         public VerificationType? EmailVerificationStatus { get; set; }
 
         /// <summary>
         /// The verification status of the phone number. Null if no phone number is set.
         /// </summary>
-        [JsonConverter(typeof(JsonStringEnumConverter))]
         public VerificationType? SmsVerificationStatus { get; set; }
     }
 }

--- a/src/Altinn.Profile/Models/ProfessionalNotificationAddress.cs
+++ b/src/Altinn.Profile/Models/ProfessionalNotificationAddress.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Text.RegularExpressions;
+
 using Altinn.Profile.Validators;
 
 namespace Altinn.Profile.Models
@@ -12,13 +13,14 @@ namespace Altinn.Profile.Models
     /// <summary>
     /// Data model for the professional notification address for an organization, also called personal notification address.
     /// </summary>
-    public abstract partial class ProfessionalNotificationAddress :IValidatableObject
+    public abstract partial class ProfessionalNotificationAddress : IValidatableObject
     {
         private const string _resourceIdRegex = "^urn:altinn:resource:[a-z0-9_-]{4,}$";
 
         /// <summary>
         /// The email address. May be null if no email address is set.
         /// </summary>
+        /// <example>example@domain.com</example>
         [CustomRegexForNotificationAddresses(ValidationRule.EmailAddress)]
         public string? EmailAddress { get; set; }
 

--- a/src/Altinn.Profile/Models/ProfessionalNotificationAddress.cs
+++ b/src/Altinn.Profile/Models/ProfessionalNotificationAddress.cs
@@ -27,6 +27,7 @@ namespace Altinn.Profile.Models
         /// <summary>
         /// The phone number. May be null if no phone number is set. 
         /// </summary>
+        /// <example>+4798765432</example>
         [CustomRegexForNotificationAddresses(ValidationRule.PhoneNumber)]
         public string? PhoneNumber { get; set; }
 

--- a/src/Altinn.Profile/Models/ProfessionalNotificationAddress.cs
+++ b/src/Altinn.Profile/Models/ProfessionalNotificationAddress.cs
@@ -20,7 +20,7 @@ namespace Altinn.Profile.Models
         /// <summary>
         /// The email address. May be null if no email address is set.
         /// </summary>
-        /// <example>example@domain.com</example>
+        /// <example>user@example.com</example>
         [CustomRegexForNotificationAddresses(ValidationRule.EmailAddress)]
         public string? EmailAddress { get; set; }
 

--- a/src/Altinn.Profile/Models/VerifiedAddressResponse.cs
+++ b/src/Altinn.Profile/Models/VerifiedAddressResponse.cs
@@ -20,7 +20,6 @@ namespace Altinn.Profile.Models
         /// <summary>
         /// The type of the verified address. This indicates whether the address is an email address or a phone number.
         /// </summary>
-        [JsonConverter(typeof(JsonStringEnumConverter))]
         public AddressType Type { get; init; }
     }
 }

--- a/src/Altinn.Profile/Program.cs
+++ b/src/Altinn.Profile/Program.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Reflection;
+using System.Text.Json.Serialization;
 
 using Altinn.Authorization.ServiceDefaults.Leases;
 using Altinn.Common.AccessToken;
@@ -158,6 +159,7 @@ void ConfigureServices(IServiceCollection services, IConfiguration config)
         .AddJsonOptions(opts =>
     {
         opts.JsonSerializerOptions.Converters.Add(new OptionalJsonConverterFactory());
+        opts.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
     });
 
     services.AddMemoryCache();

--- a/src/Altinn.Profile/Program.cs
+++ b/src/Altinn.Profile/Program.cs
@@ -159,7 +159,6 @@ void ConfigureServices(IServiceCollection services, IConfiguration config)
         .AddJsonOptions(opts =>
     {
         opts.JsonSerializerOptions.Converters.Add(new OptionalJsonConverterFactory());
-        opts.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
     });
 
     services.AddMemoryCache();

--- a/src/Altinn.Profile/Program.cs
+++ b/src/Altinn.Profile/Program.cs
@@ -2,7 +2,6 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Reflection;
-using System.Text.Json.Serialization;
 
 using Altinn.Authorization.ServiceDefaults.Leases;
 using Altinn.Common.AccessToken;


### PR DESCRIPTION
Clarifies some (mostly verification-related) fields of the OpenAPI contract
- Add realistic <example>values for phone and email fields
- Add enum->string converter on enums `AddressType` and `VerificationType`
  - Necessary for Swashbuckle detection
  - Makes property-level converter attributes redundant, so they are now removed

## Related Issue(s)
- #835 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated JSON serialization configuration for address and verification type enums to use consistent formatting across API responses.

* **Documentation**
  * Added documentation examples for notification address and settings properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->