### PR TITLE
Only map external identity from external urn for email users

### DIFF
--- a/src/Altinn.Profile.Core/User/UserProfileMapper.cs
+++ b/src/Altinn.Profile.Core/User/UserProfileMapper.cs
@@ -97,10 +97,12 @@ namespace Altinn.Profile.Core.User
             var user = si.User.Value;
             var selfIdentifiedUserType = si.SelfIdentifiedUserType.Value;
             var displayName = si.DisplayName.Value;
+            var externalIdentity = string.Empty;
 
             if (selfIdentifiedUserType == SelfIdentifiedUserType.IdPortenEmail)
             {
                 displayName = "epost:" + displayName;
+                externalIdentity = si.ExternalUrn.Value?.ToString() ?? string.Empty;
             }
 
             return new UserProfile
@@ -109,7 +111,7 @@ namespace Altinn.Profile.Core.User
                 UserUuid = si.Uuid,
                 UserName = user?.Username.Value,
                 PartyId = (int)si.PartyId.Value,
-                ExternalIdentity = si.ExternalUrn.Value?.ToString(),
+                ExternalIdentity = externalIdentity,
                 PhoneNumber = string.Empty,
                 Party = new Register.Contracts.V1.Party
                 {

--- a/test/Altinn.Profile.Tests/Profile.Core/User/UserProfileMapperTests.cs
+++ b/test/Altinn.Profile.Tests/Profile.Core/User/UserProfileMapperTests.cs
@@ -181,7 +181,7 @@ namespace Altinn.Profile.Tests.Profile.Core.User
             Assert.Equal(expected.UserName, result.UserName);
             Assert.Equal(expected.PartyId, result.PartyId);
 
-            //// Assert.Equal(expected.ExternalIdentity, result.ExternalIdentity); // We don't have this value
+            Assert.Empty(result.ExternalIdentity); // Non-email SI users should not map external URN
             Assert.Equal(expected.UserType, result.UserType);
 
             // Party fields

--- a/test/Altinn.Profile.Tests/Profile.Core/User/UserProfileMapperTests.cs
+++ b/test/Altinn.Profile.Tests/Profile.Core/User/UserProfileMapperTests.cs
@@ -181,7 +181,7 @@ namespace Altinn.Profile.Tests.Profile.Core.User
             Assert.Equal(expected.UserName, result.UserName);
             Assert.Equal(expected.PartyId, result.PartyId);
 
-            //// Assert.Equal(expected.ExternalIdentity, result.ExternalIdentity); // SI-specific
+            //// Assert.Equal(expected.ExternalIdentity, result.ExternalIdentity); // We don't have this value
             Assert.Equal(expected.UserType, result.UserType);
 
             // Party fields
@@ -211,7 +211,7 @@ namespace Altinn.Profile.Tests.Profile.Core.User
             Assert.Equal(expected.UserUuid, result.UserUuid);
             Assert.Equal(expected.UserName, result.UserName);
             Assert.Equal(expected.PartyId, result.PartyId);
-            ////Assert.Equal(expected.ExternalIdentity, result.ExternalIdentity); // SI-specific
+            Assert.Equal(expected.ExternalIdentity, result.ExternalIdentity); // SI-specific
             Assert.Equal(expected.UserType, result.UserType);
 
             // Party fields


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced external identity handling in user profile mapping to ensure consistent initialization—values are now always set to either a valid identifier or an empty string, preventing null reference issues.

* **Tests**
  * Updated test coverage to validate external identity assignment for legacy user profiles, ensuring proper behavior across different user types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->