### PR TITLE
Patch to latest dotnet image digest

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,4 +1,1 @@
 vulnerabilities:
-  - id: CVE-2026-28390 # libcrypto3/libssl3
-    statement: Not exploitable - application does not process attacker-controlled CMS data
-    expired_at: 2026-05-10 # revisit in 1 month, might have a patch by then

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:10.0.202-alpine3.23@sha256:16fcd544bb71edae6abee5b2ea25bc5f372734f18568d81c64ebac74d6f00239 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0.202-alpine3.23@sha256:732cd42c6f659814c9804ad7b05c7f761e83ef8379c5b2fdc3af673353caff73 AS build
 WORKDIR /app
 
 COPY src/Altinn.Profile/*.csproj ./src/Altinn.Profile/
@@ -11,7 +11,7 @@ RUN dotnet restore ./src/Altinn.Profile/Altinn.Profile.csproj
 COPY src ./src
 RUN dotnet publish -c Release -o /app_output ./src/Altinn.Profile/Altinn.Profile.csproj
 
-FROM mcr.microsoft.com/dotnet/aspnet:10.0.6-alpine3.23@sha256:2a80ec9b84fed7ede84708e3e366a56b9790bbf7978e875a31bc01ae80689534 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:10.0.6-alpine3.23@sha256:1201dde897ab436b7c6b386f6dbd4f9a3ca0245f9c5a8aac8f8bcdccb4c7d484 AS final
 EXPOSE 5030
 WORKDIR /app
 


### PR DESCRIPTION
- Removes fixed CVE from trivyignore
- Patches to latest (of Thursday Apr 16th) digest of dotnet images, to get rid of the irrelevant `musl-utils` lib warning


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker base image digests to use the latest pinned versions for both the build and runtime stages, ensuring the application runs with current stable container images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->