### PR TITLE
Use register as source for si users and ssn users alike

### DIFF
--- a/src/Altinn.Profile.Core/User/UserProfileService.cs
+++ b/src/Altinn.Profile.Core/User/UserProfileService.cs
@@ -83,7 +83,7 @@ public class UserProfileService : IUserProfileService
     {
         if (_settings.RegisterAsPrimaryUserProfileSource)
         {
-            UserProfile? registerProfile = await TryGetEligibleRegisterProfile(getRegisterParty(), cancellationToken);
+            UserProfile? registerProfile = await TryGetRegisterProfile(getRegisterParty(), cancellationToken);
             if (registerProfile is not null)
             {
                 return registerProfile;
@@ -122,15 +122,7 @@ public class UserProfileService : IUserProfileService
         return userProfile;
     }
 
-    private static bool IsEligibleRegisterProfile(Party? party)
-    {
-        // To ensure that we only use register profiles that can be enriched with KRR data, we require that the profile has a non-empty SSN.
-        // This is because KRR data is linked to the user's SSN, and without it, we cannot enrich the profile with contact information from KRR.
-        // All ssn users are returned as Person type from the register.
-        return party is Register.Contracts.Person;
-    }
-
-    private async Task<UserProfile?> TryGetEligibleRegisterProfile(Task<Party?> registerPartyTask, CancellationToken cancellationToken)
+    private async Task<UserProfile?> TryGetRegisterProfile(Task<Party?> registerPartyTask, CancellationToken cancellationToken)
     {
         Party? registerParty;
 
@@ -148,12 +140,7 @@ public class UserProfileService : IUserProfileService
             return null;
         }
 
-        if (IsEligibleRegisterProfile(registerParty))
-        {
-            return await CreateAndEnrichProfileFromParty(registerParty, cancellationToken);
-        }
-
-        return null;
+        return await CreateAndEnrichProfileFromParty(registerParty, cancellationToken);
     }
 
     private async Task<UserProfile?> GetEnrichedLegacyUserProfile(Task<Result<UserProfile, bool>> legacyTask)

--- a/src/Altinn.Profile.Core/User/UserProfileService.cs
+++ b/src/Altinn.Profile.Core/User/UserProfileService.cs
@@ -83,7 +83,7 @@ public class UserProfileService : IUserProfileService
     {
         if (_settings.RegisterAsPrimaryUserProfileSource)
         {
-            UserProfile? registerProfile = await TryGetRegisterProfile(getRegisterParty(), cancellationToken);
+            UserProfile? registerProfile = await GetUserFromRegister(getRegisterParty(), cancellationToken);
             if (registerProfile is not null)
             {
                 return registerProfile;
@@ -120,27 +120,6 @@ public class UserProfileService : IUserProfileService
         }
 
         return userProfile;
-    }
-
-    private async Task<UserProfile?> TryGetRegisterProfile(Task<Party?> registerPartyTask, CancellationToken cancellationToken)
-    {
-        Party? registerParty;
-
-        try
-        {
-            registerParty = await registerPartyTask;
-        }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception)
-        {
-            // fallback to legacy
-            return null;
-        }
-
-        return await CreateAndEnrichProfileFromParty(registerParty, cancellationToken);
     }
 
     private async Task<UserProfile?> GetEnrichedLegacyUserProfile(Task<Result<UserProfile, bool>> legacyTask)

--- a/src/Altinn.Profile.Core/User/UserProfileService.cs
+++ b/src/Altinn.Profile.Core/User/UserProfileService.cs
@@ -151,7 +151,8 @@ public class UserProfileService : IUserProfileService
         }
         catch (Exception)
         {
-            // in shadow mode, exceptions from the register client should not affect the user experience.
+            // fallback to sbl bridge if register lookup fails for any reason, as we do not want a failure in the register to cause a complete failure in user profile retrieval.
+            // This is especially important if the register is used in shadow mode, where we want to ensure that we can still retrieve user profiles even if the register is down or experiencing issues.
             return null;
         }
 

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/UserProfileInternalControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/UserProfileInternalControllerTests.cs
@@ -605,41 +605,6 @@ public class UserProfileInternalControllerTests : IClassFixture<ProfileWebApplic
         Assert.EndsWith($"sblbridge/profile/api/users/?username={username}", sblRequest.RequestUri.ToString());
     }
 
-    [Fact]
-    public async Task GetUserBySsn_RegisterAsPrimaryEnabled_RegisterReturnsSelfIdentified_FallsBackToSbl()
-    {
-        // Arrange
-        const string ssn = "01017512345";
-
-        HttpRequestMessage sblRequest = null;
-        _factory.SblBridgeHttpMessageHandler.ChangeHandlerFunction(async (request, token) =>
-        {
-            sblRequest = request;
-            UserProfile userProfile = await TestDataLoader.Load<UserProfile>("2516356");
-            return new HttpResponseMessage() { Content = JsonContent.Create(userProfile) };
-        });
-
-        SelfIdentifiedUser selfIdentifiedFromRegister = await TestDataLoader.Load<SelfIdentifiedUser>("siuser-input");
-
-        _factory.RegisterClientMock
-            .Setup(m => m.GetUserPartyBySsn(ssn, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(selfIdentifiedFromRegister);
-
-        using WebApplicationFactory<Program> registerPrimaryFactory = CreateFactoryWithRegisterAsPrimaryEnabled();
-        HttpClient client = registerPrimaryFactory.CreateClient();
-
-        HttpRequestMessage httpRequestMessage = CreatePostRequest("/profile/api/v1/internal/user/", new UserProfileLookup { Ssn = ssn });
-
-        // Act
-        HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
-
-        // Assert
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        Assert.NotNull(sblRequest);
-        Assert.Equal(HttpMethod.Post, sblRequest.Method);
-        Assert.EndsWith("sblbridge/profile/api/users", sblRequest.RequestUri.ToString());
-    }
-
     private WebApplicationFactory<Program> CreateFactoryWithRegisterAsPrimaryEnabled()
     {
         return _factory.WithWebHostBuilder(builder =>

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/UsersControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/UsersControllerTests.cs
@@ -1032,7 +1032,12 @@ public class UsersControllerTests : IClassFixture<ProfileWebApplicationFactory<P
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        Assert.Null(sblRequest); 
+        Assert.Null(sblRequest); // register path should not call legacy
+
+        string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        UserProfile? actualUser = JsonSerializer.Deserialize<UserProfile>(responseContent, _serializerOptionsCamelCase);
+        Assert.NotNull(actualUser);
+        Assert.NotNull(actualUser.Party);
     }
 
     private static HttpRequestMessage CreateGetRequest(int userId, string requestUri)

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/UsersControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/UsersControllerTests.cs
@@ -994,7 +994,7 @@ public class UsersControllerTests : IClassFixture<ProfileWebApplicationFactory<P
     }
 
     [Fact]
-    public async Task GetUsersById_AsUser_RegisterAsPrimaryEnabled_RegisterReturnsSelfIdentified_FallsBackToSbl()
+    public async Task GetUsersById_AsUser_RegisterAsPrimaryEnabled_RegisterReturnsSelfIdentified()
     {
         // Arrange
         const int userId = 2516356;
@@ -1032,8 +1032,7 @@ public class UsersControllerTests : IClassFixture<ProfileWebApplicationFactory<P
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        Assert.NotNull(sblRequest); // no SSN => should fallback
-        Assert.EndsWith($"users/{userId}", sblRequest!.RequestUri?.ToString());
+        Assert.Null(sblRequest); 
     }
 
     private static HttpRequestMessage CreateGetRequest(int userId, string requestUri)


### PR DESCRIPTION
This respects the feature flag `RegisterAsPrimaryUserProfileSource`


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #824 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified user profile retrieval when register is the primary source by removing an unnecessary eligibility restriction and preventing unintended fallback to legacy bridge for self-identified register entries.
* **Tests**
  * Updated integration tests to reflect the new behavior: one test renamed/adjusted and one legacy fallback test removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->