### PR TITLE
Remove feature flag for preselectedPartyID lookup at register

### DIFF
--- a/src/Altinn.Profile.Core/CoreSettings.cs
+++ b/src/Altinn.Profile.Core/CoreSettings.cs
@@ -11,11 +11,6 @@ public class CoreSettings
     public int ProfileCacheLifetimeSeconds { get; set; } = 600;
 
     /// <summary>
-    /// A flag indicating whether to perform a lookup for a preselected party ID at the register when fetching the user profile. If not, the value from SBLBridge must be provided.
-    /// </summary>
-    public bool LookupPreselectedPartyIdAtRegister { get; set; }
-
-    /// <summary>
     /// A flag indicating whether to perform a lookup for users from the register and compare this.
     /// </summary>
     public bool RegisterLookupInShadowMode { get; set; }

--- a/src/Altinn.Profile.Core/User/UserProfileService.cs
+++ b/src/Altinn.Profile.Core/User/UserProfileService.cs
@@ -254,7 +254,7 @@ public class UserProfileService : IUserProfileService
         if (userProfile.ProfileSettingPreference.PreselectedPartyUuid != null)
         {
             // If a preselected party UUID is provided, we need to fetch the corresponding party ID from the register to ensure data consistency.
-            int? partyId = await _registerClient.GetPartyId(userProfile.ProfileSettingPreference.PreselectedPartyUuid.Value, default);
+            int? partyId = await _registerClient.GetPartyId(userProfile.ProfileSettingPreference.PreselectedPartyUuid.Value, cancellationToken);
             userProfile.ProfileSettingPreference.PreSelectedPartyId = partyId ?? 0;
         }
 

--- a/src/Altinn.Profile.Core/User/UserProfileService.cs
+++ b/src/Altinn.Profile.Core/User/UserProfileService.cs
@@ -251,7 +251,7 @@ public class UserProfileService : IUserProfileService
             userProfile.ProfileSettingPreference ??= ProfileSettingPreference.GetDefaultValues();
         }
 
-        if (userProfile.ProfileSettingPreference.PreselectedPartyUuid != null && _settings.LookupPreselectedPartyIdAtRegister)
+        if (userProfile.ProfileSettingPreference.PreselectedPartyUuid != null)
         {
             // If a preselected party UUID is provided, we need to fetch the corresponding party ID from the register to ensure data consistency.
             int? partyId = await _registerClient.GetPartyId(userProfile.ProfileSettingPreference.PreselectedPartyUuid.Value, default);

--- a/src/Altinn.Profile/appsettings.json
+++ b/src/Altinn.Profile/appsettings.json
@@ -13,7 +13,6 @@
   },
   "CoreSettings": {
     "ProfileCacheLifetimeSeconds": 600,
-    "LookupPreselectedPartyIdAtRegister": true,
     "RegisterLookupInShadowMode": true,
     "RegisterAsPrimaryUserProfileSource": false
   },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This feature has been running in production for some time now without any issues. As we are moving away from sblBridge dependencies we should now allways rely on register lookup for this value. Thus the feature flag can be removed

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified preselected party lookup behavior—the system now always retrieves preselected party information from the register when available, removing unnecessary configuration complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->