### PR TITLE
Remove access check on delete for professional notificationSettings

### DIFF
--- a/src/Altinn.Profile/Controllers/ProfessionalNotificationSettingsController.cs
+++ b/src/Altinn.Profile/Controllers/ProfessionalNotificationSettingsController.cs
@@ -235,7 +235,6 @@ namespace Altinn.Profile.Controllers
         /// </summary>
         /// <param name="partyUuid">The UUID of the party for which the notification address is being deleted</param>
         /// <param name="cancellationToken"> Cancellation token for the operation</param>
-        [Authorize(Policy = AuthConstants.UserPartyAccess)]
         [HttpDelete("{partyUuid:guid}")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Users shouldn't need current access to a party to be able to delet their notification settings for the given party. 

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated authorization requirements for professional notification settings deletion to ensure proper access control policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->