### PR TITLE
Use secrets file for secret management in k6

### DIFF
--- a/.github/workflows/build-and-analyze.yml
+++ b/.github/workflows/build-and-analyze.yml
@@ -58,7 +58,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
-          dotnet-sonarscanner begin /k:"Altinn_altinn-profile" /o:"altinn" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vstest.reportsPaths="**/*.trx" /d:sonar.cs.opencover.reportsPaths="**/coverage.opencover.xml" /d:sonar.exclusions="**/ServiceDefaults.**" /d:sonar.coverage.exclusions="test/k6/**/*"
+          dotnet-sonarscanner begin /k:"Altinn_altinn-profile" /o:"altinn" /d:sonar.login="$SONAR_TOKEN" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vstest.reportsPaths="**/*.trx" /d:sonar.cs.opencover.reportsPaths="**/coverage.opencover.xml" /d:sonar.exclusions="**/ServiceDefaults.**" /d:sonar.coverage.exclusions="test/k6/**/*"
 
           dotnet build Altinn.Profile.sln -v q
 

--- a/.github/workflows/build-and-analyze.yml
+++ b/.github/workflows/build-and-analyze.yml
@@ -1,18 +1,19 @@
 name: Code test and analysis
 on:
   push:
-    branches: [main]
+    branches: [ main ]
     paths-ignore:
       - 'test/k6/**'
       - '.github/**'
   pull_request:
-    branches: [main]
-    types: [opened, synchronize, reopened]
+    branches: [ main ]
+    types: [ opened, synchronize, reopened ]
   workflow_dispatch:
 jobs:
   build-test-analyze:
     name: Build, test & analyze
-    if: ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false) || github.event_name == 'push') && github.repository_owner == 'Altinn'
+    if: ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false) ||
+      github.event_name == 'push') && github.repository_owner == 'Altinn'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -25,10 +26,7 @@ jobs:
           POSTGRES_PASSWORD: Password
           POSTGRES_DB: profiledb
         options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+          --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
         ports:
           - 5432:5432
     steps:
@@ -60,7 +58,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
-          dotnet-sonarscanner begin /k:"Altinn_altinn-profile" /o:"altinn" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vstest.reportsPaths="**/*.trx" /d:sonar.cs.opencover.reportsPaths="**/coverage.opencover.xml" /d:sonar.exclusions="**/ServiceDefaults.**"
+          dotnet-sonarscanner begin /k:"Altinn_altinn-profile" /o:"altinn" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vstest.reportsPaths="**/*.trx" /d:sonar.cs.opencover.reportsPaths="**/coverage.opencover.xml" /d:sonar.exclusions="**/ServiceDefaults.**" /d:sonar.coverage.exclusions="test/k6/**/*"
 
           dotnet build Altinn.Profile.sln -v q
 

--- a/.github/workflows/use-case-ATX.yaml
+++ b/.github/workflows/use-case-ATX.yaml
@@ -4,13 +4,16 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '*/15 * * * *'
+  pull_request:
+    branches: [ main ]
+    types: [ opened, synchronize, reopened ]
 
 jobs:
   test:
     strategy:
       fail-fast: false
       matrix:
-        environment: [AT22, AT23]
+        environment: [ AT22, AT23 ]
     environment: ${{ matrix.environment }}
     runs-on: ubuntu-latest
     permissions:
@@ -18,41 +21,49 @@ jobs:
     outputs:
       failed-AT22: ${{ steps.set-failure.outputs.AT22 }}
       failed-AT23: ${{ steps.set-failure.outputs.AT23 }}
-    env: # Shared environment vars for all k6 test scripts
+    env:
+      # Shared environment vars for all k6 test scripts
       altinn_env: ${{ matrix.environment }}
       partyId: ${{ secrets.PARTYID }}
       pid: ${{ secrets.PID }}
-      tokenGeneratorUserName: ${{ secrets.TOKENGENERATOR_USERNAME }}
-      tokenGeneratorUserPwd: ${{ secrets.TOKENGENERATOR_USERPASSWORD }}
       userID: ${{ secrets.USERID }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up K6
         uses: grafana/setup-k6-action@ffe7d7290dfa715e48c2ccc924d068444c94bde2 # v1.1.0
+      - name: Create k6 secrets file
+        id: k6-secrets
+        run: |
+          SECRETS_FILE="${{ runner.temp }}/k6.secrets"
+          cat <<EOF > "$SECRETS_FILE"
+          tokenGeneratorUserName=${{ secrets.TOKENGENERATOR_USERNAME }}
+          tokenGeneratorUserPwd=${{ secrets.TOKENGENERATOR_USERPASSWORD }}
+          EOF
+          echo "file=$SECRETS_FILE" >> "$GITHUB_OUTPUT"
       - name: Run favorites use case tests
         uses: grafana/run-k6-action@a15e2072ede004e8d46141e33d7f7dad8ad08d9d # v1.3.1
         with:
           path: test/k6/src/tests/favorites.js
-          flags: -e partyUuid=${{ secrets.PARTYUUID }}
+          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e partyUuid=${{ secrets.PARTYUUID }}
           inspect-flags: -e altinn_env=${{ env.altinn_env }} # Supplies the value for pre-run validation, when env vars / flags are not yet defined
       - name: Run groups use case tests
         uses: grafana/run-k6-action@a15e2072ede004e8d46141e33d7f7dad8ad08d9d # v1.3.1
         with:
           path: test/k6/src/tests/groups.js
-          flags: -e partyUuid=${{ secrets.PARTYUUID }}
+          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e partyUuid=${{ secrets.PARTYUUID }}
           inspect-flags: -e altinn_env=${{ env.altinn_env }} # Supplies the value for pre-run validation, when env vars / flags are not yet defined
       - name: Run notification settings use case tests
         uses: grafana/run-k6-action@a15e2072ede004e8d46141e33d7f7dad8ad08d9d # v1.3.1
         with:
           path: test/k6/src/tests/notification-settings.js
-          flags: -e partyUuid=${{ secrets.PARTYUUID }}
+          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e partyUuid=${{ secrets.PARTYUUID }}
           inspect-flags: -e altinn_env=${{ env.altinn_env }} # Supplies the value for pre-run validation, when env vars / flags are not yet defined
       - name: Run org notification addresses use case tests
         uses: grafana/run-k6-action@a15e2072ede004e8d46141e33d7f7dad8ad08d9d # v1.3.1
         with:
           path: test/k6/src/tests/org-notification-addresses.js
-          flags: -e orgNo=${{ secrets.ORGNO }}
+          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e orgNo=${{ secrets.ORGNO }}
           inspect-flags: -e altinn_env=${{ env.altinn_env }} # Supplies the value for pre-run validation, when env vars / flags are not yet defined
       - name: Set failure output
         id: set-failure
@@ -65,7 +76,7 @@ jobs:
     permissions: {}
     strategy:
       matrix:
-        environment: [AT22, AT23]
+        environment: [ AT22, AT23 ]
         include:
           - environment: AT22
             output: failed-AT22

--- a/.github/workflows/use-case-ATX.yaml
+++ b/.github/workflows/use-case-ATX.yaml
@@ -34,12 +34,13 @@ jobs:
         uses: grafana/setup-k6-action@ffe7d7290dfa715e48c2ccc924d068444c94bde2 # v1.1.0
       - name: Create k6 secrets file
         id: k6-secrets
+        env:
+          TOKEN_GENERATOR_USERNAME: ${{ secrets.TOKENGENERATOR_USERNAME }}
+          TOKEN_GENERATOR_USERPASSWORD: ${{ secrets.TOKENGENERATOR_USERPASSWORD }}
         run: |
           SECRETS_FILE="${{ runner.temp }}/k6.secrets"
-          cat <<EOF > "$SECRETS_FILE"
-          tokenGeneratorUserName=${{ secrets.TOKENGENERATOR_USERNAME }}
-          tokenGeneratorUserPwd=${{ secrets.TOKENGENERATOR_USERPASSWORD }}
-          EOF
+          printf 'tokenGeneratorUserName=%s\n' "$TOKEN_GENERATOR_USERNAME" > "$SECRETS_FILE"
+          printf 'tokenGeneratorUserPwd=%s\n' "$TOKEN_GENERATOR_USERPASSWORD" >> "$SECRETS_FILE"
           echo "file=$SECRETS_FILE" >> "$GITHUB_OUTPUT"
       - name: Run favorites use case tests
         uses: grafana/run-k6-action@a15e2072ede004e8d46141e33d7f7dad8ad08d9d # v1.3.1

--- a/.github/workflows/use-case-ATX.yaml
+++ b/.github/workflows/use-case-ATX.yaml
@@ -35,6 +35,7 @@ jobs:
           TOKEN_GENERATOR_USERNAME: ${{ secrets.TOKENGENERATOR_USERNAME }}
           TOKEN_GENERATOR_USERPASSWORD: ${{ secrets.TOKENGENERATOR_USERPASSWORD }}
         run: |
+          umask 077
           SECRETS_FILE="${{ runner.temp }}/k6.secrets"
           printf 'tokenGeneratorUserName=%s\n' "$TOKEN_GENERATOR_USERNAME" > "$SECRETS_FILE"
           printf 'tokenGeneratorUserPwd=%s\n' "$TOKEN_GENERATOR_USERPASSWORD" >> "$SECRETS_FILE"

--- a/.github/workflows/use-case-ATX.yaml
+++ b/.github/workflows/use-case-ATX.yaml
@@ -4,9 +4,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '*/15 * * * *'
-  pull_request:
-    branches: [ main ]
-    types: [ opened, synchronize, reopened ]
 
 jobs:
   test:

--- a/.github/workflows/use-case-TT02.yaml
+++ b/.github/workflows/use-case-TT02.yaml
@@ -25,12 +25,13 @@ jobs:
         uses: grafana/setup-k6-action@ffe7d7290dfa715e48c2ccc924d068444c94bde2 # v1.1.0
       - name: Create k6 secrets file
         id: k6-secrets
+        env:
+          TOKEN_GENERATOR_USERNAME: ${{ secrets.TOKENGENERATOR_USERNAME }}
+          TOKEN_GENERATOR_USERPASSWORD: ${{ secrets.TOKENGENERATOR_USERPASSWORD }}
         run: |
           SECRETS_FILE="${{ runner.temp }}/k6.secrets"
-          cat <<EOF > "$SECRETS_FILE"
-          tokenGeneratorUserName=${{ secrets.TOKENGENERATOR_USERNAME }}
-          tokenGeneratorUserPwd=${{ secrets.TOKENGENERATOR_USERPASSWORD }}
-          EOF
+          printf 'tokenGeneratorUserName=%s\n' "$TOKEN_GENERATOR_USERNAME" > "$SECRETS_FILE"
+          printf 'tokenGeneratorUserPwd=%s\n' "$TOKEN_GENERATOR_USERPASSWORD" >> "$SECRETS_FILE"
           echo "file=$SECRETS_FILE" >> "$GITHUB_OUTPUT"
       - name: Run favorites use case tests
         uses: grafana/run-k6-action@a15e2072ede004e8d46141e33d7f7dad8ad08d9d # v1.3.1

--- a/.github/workflows/use-case-TT02.yaml
+++ b/.github/workflows/use-case-TT02.yaml
@@ -4,6 +4,9 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '*/15 * * * *'
+  pull_request:
+    branches: [ main ]
+    types: [ opened, synchronize, reopened ]
 
 jobs:
   test:

--- a/.github/workflows/use-case-TT02.yaml
+++ b/.github/workflows/use-case-TT02.yaml
@@ -4,9 +4,7 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '*/15 * * * *'
-  pull_request:
-    branches: [ main ]
-    types: [ opened, synchronize, reopened ]
+
 jobs:
   test:
     environment: TT02

--- a/.github/workflows/use-case-TT02.yaml
+++ b/.github/workflows/use-case-TT02.yaml
@@ -27,6 +27,7 @@ jobs:
           TOKEN_GENERATOR_USERNAME: ${{ secrets.TOKENGENERATOR_USERNAME }}
           TOKEN_GENERATOR_USERPASSWORD: ${{ secrets.TOKENGENERATOR_USERPASSWORD }}
         run: |
+          umask 077
           SECRETS_FILE="${{ runner.temp }}/k6.secrets"
           printf 'tokenGeneratorUserName=%s\n' "$TOKEN_GENERATOR_USERNAME" > "$SECRETS_FILE"
           printf 'tokenGeneratorUserPwd=%s\n' "$TOKEN_GENERATOR_USERPASSWORD" >> "$SECRETS_FILE"

--- a/.github/workflows/use-case-TT02.yaml
+++ b/.github/workflows/use-case-TT02.yaml
@@ -4,9 +4,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '*/15 * * * *'
-  pull_request:
-    branches: [ main ]
-    types: [ opened, synchronize, reopened ]
 
 jobs:
   test:

--- a/.github/workflows/use-case-TT02.yaml
+++ b/.github/workflows/use-case-TT02.yaml
@@ -4,46 +4,58 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '*/15 * * * *'
+  pull_request:
+    branches: [ main ]
+    types: [ opened, synchronize, reopened ]
 jobs:
   test:
     environment: TT02
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    env: # Shared environment vars for all k6 test scripts
+    env:
+      # Shared environment vars for all k6 test scripts
       altinn_env: TT02
       partyId: ${{ secrets.PARTYID }}
       pid: ${{ secrets.PID }}
-      tokenGeneratorUserName: ${{ secrets.TOKENGENERATOR_USERNAME }}
-      tokenGeneratorUserPwd: ${{ secrets.TOKENGENERATOR_USERPASSWORD }}
       userID: ${{ secrets.USERID }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up K6
         uses: grafana/setup-k6-action@ffe7d7290dfa715e48c2ccc924d068444c94bde2 # v1.1.0
+      - name: Create k6 secrets file
+        id: k6-secrets
+        run: |
+          SECRETS_FILE="${{ runner.temp }}/k6.secrets"
+          cat <<EOF > "$SECRETS_FILE"
+          tokenGeneratorUserName=${{ secrets.TOKENGENERATOR_USERNAME }}
+          tokenGeneratorUserPwd=${{ secrets.TOKENGENERATOR_USERPASSWORD }}
+          EOF
+          echo "file=$SECRETS_FILE" >> "$GITHUB_OUTPUT"
       - name: Run favorites use case tests
         uses: grafana/run-k6-action@a15e2072ede004e8d46141e33d7f7dad8ad08d9d # v1.3.1
         with:
           path: test/k6/src/tests/favorites.js
-          flags: -e partyUuid=${{ secrets.PARTYUUID }}
+          flags: >-
+            --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e partyUuid=${{ secrets.PARTYUUID }}
           inspect-flags: -e altinn_env=TT02 # Supplies a valid value for the pre-run validation, when env vars / flags are not yet defined
       - name: Run groups use case tests
         uses: grafana/run-k6-action@a15e2072ede004e8d46141e33d7f7dad8ad08d9d # v1.3.1
         with:
           path: test/k6/src/tests/groups.js
-          flags: -e partyUuid=${{ secrets.PARTYUUID }}
+          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e partyUuid=${{ secrets.PARTYUUID }}
           inspect-flags: -e altinn_env=TT02 # Supplies a valid value for the pre-run validation, when env vars / flags are not yet defined
       - name: Run notification settings use case tests
         uses: grafana/run-k6-action@a15e2072ede004e8d46141e33d7f7dad8ad08d9d # v1.3.1
         with:
           path: test/k6/src/tests/notification-settings.js
-          flags: -e partyUuid=${{ secrets.PARTYUUID }}
+          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e partyUuid=${{ secrets.PARTYUUID }}
           inspect-flags: -e altinn_env=TT02 # Supplies a valid value for the pre-run validation, when env vars / flags are not yet defined
       - name: Run org notification addresses use case tests
         uses: grafana/run-k6-action@a15e2072ede004e8d46141e33d7f7dad8ad08d9d # v1.3.1
         with:
           path: test/k6/src/tests/org-notification-addresses.js
-          flags: -e orgNo=${{ secrets.ORGNO }}
+          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e orgNo=${{ secrets.ORGNO }}
           inspect-flags: -e altinn_env=TT02 # Supplies a valid value for the pre-run validation, when env vars / flags are not yet defined
 
   slack-notify:

--- a/test/k6/.gitignore
+++ b/test/k6/.gitignore
@@ -1,3 +1,4 @@
 #Junit reports
 **/reports/*.xml
-.env 
+.env
+.secrets

--- a/test/k6/.secrets.sample
+++ b/test/k6/.secrets.sample
@@ -1,0 +1,2 @@
+tokenGeneratorUserName=
+tokenGeneratorUserPwd=

--- a/test/k6/docker-compose.yml
+++ b/test/k6/docker-compose.yml
@@ -12,3 +12,4 @@ services:
       - "6565:6565"
     volumes:
       - ./src:/src
+      - ./.secrets:/.secrets

--- a/test/k6/readme.md
+++ b/test/k6/readme.md
@@ -186,7 +186,7 @@ $> podman compose run k6 run /src/tests/favorites.js \
 Common issues and solutions:
 
 1. **Authentication Failures**
-   - Verify that tokenGeneratorUserName and tokenGeneratorUserPwd are correct
+   - Verify the entries for `tokenGeneratorUserName` and `tokenGeneratorUserPwd` in the file `.secrets`, and confirm the file is mounted and passed via `--secret-source=file=/.secrets`
    - Check that the token generator service is accessible
    - Verify that the user has necessary permissions in the target environment
 

--- a/test/k6/readme.md
+++ b/test/k6/readme.md
@@ -18,6 +18,20 @@ Alternatively, it is possible to run the tests directly on your machine as well.
 
 ---
 
+## Configuring the secret source
+
+**Never put secrets on the command line** - sensitive values should be passed to the k6 script via a secret source, as this provides full k6 redaction. In other words, secrets loaded via k6/secrets are automatically redacted from all k6 log output as `***SECRET_REDACTED***`, effectively preventing the values to leak into logs.
+
+1. Create a `.secrets` file in the k6 folder
+2. Copy contents from `.secrets.sample`
+3. Assign valid values to the variables
+
+
+| Variable | Description | Required |
+| `tokenGeneratorUserName` | Username for token generator | Yes |
+| `tokenGeneratorUserPwd` | Password for token generator | Yes |
+
+
 ## Environment Variables
 
 The following environment variables are required to run the tests:
@@ -25,8 +39,6 @@ The following environment variables are required to run the tests:
 | Variable | Description | Required | Default |
 |----------|-------------|----------|---------|
 | `altinn_env` | Environment to run tests against (prod/tt02/yt01/at22/at23) | Yes | - |
-| `tokenGeneratorUserName` | Username for token generator | Yes | - |
-| `tokenGeneratorUserPwd` | Password for token generator | Yes | - |
 | `partyUuid` | Party UUID for testing (for favorites and notification-settings tests) | No* | - |
 | `orgNo` | Organization number for testing (for org-notification-addresses test) | No* | - |
 
@@ -90,9 +102,8 @@ $> cd /altinn-profile/test/k6
 
 ```bash
 $> podman compose run k6 run /src/tests/favorites.js \
+    --secret-source=file=/.secrets \
     -e altinn_env=yt01 \
-    -e tokenGeneratorUserName=*** \
-    -e tokenGeneratorUserPwd=*** \
     -e partyUuid=***
     -e userID=*** \
     -e pid=*** \
@@ -105,9 +116,8 @@ This uses the provided `partyUuid` directly for all iterations.
 
 ```bash
 $> podman compose run k6 run /src/tests/favorites.js \
+    --secret-source=file=/.secrets \
     -e altinn_env=yt01 \
-    -e tokenGeneratorUserName=*** \
-    -e tokenGeneratorUserPwd=***
 ```
 
 Each test iteration will randomly select a row from the static CSV file (`/src/data/orgs-in-yt01-with-party-uuid.csv`), ensuring diverse test data across iterations. This happens automatically when environment variables are not provided.
@@ -118,9 +128,8 @@ Run with custom timeout and retry settings (using static CSV file):
 
 ```bash
 $> podman compose run k6 run /src/tests/favorites.js \
+    --secret-source=file=/.secrets \
     -e altinn_env=tt02 \
-    -e tokenGeneratorUserName=*** \
-    -e tokenGeneratorUserPwd=*** \
     -e REQUEST_TIMEOUT=60s \
     -e RETRY_COUNT=5 \
     -e RETRY_INTERVAL=2000
@@ -130,9 +139,8 @@ Or with environment variables (overrides CSV):
 
 ```bash
 $> podman compose run k6 run /src/tests/favorites.js \
+    --secret-source=file=/.secrets \
     -e altinn_env=tt02 \
-    -e tokenGeneratorUserName=*** \
-    -e tokenGeneratorUserPwd=*** \
     -e partyUuid=*** \
     -e REQUEST_TIMEOUT=60s \
     -e RETRY_COUNT=5 \
@@ -153,9 +161,8 @@ Run load tests with additional parameters like `--vus` (virtual users) and `--du
 
 ```bash
 $> podman compose run k6 run /src/tests/favorites.js \
+    --secret-source=file=/.secrets \
     -e altinn_env=yt01 \
-    -e tokenGeneratorUserName=*** \
-    -e tokenGeneratorUserPwd=*** \
     --vus=10 \
     --duration=5m
 ```
@@ -164,9 +171,8 @@ $> podman compose run k6 run /src/tests/favorites.js \
 
 ```bash
 $> podman compose run k6 run /src/tests/favorites.js \
+    --secret-source=file=/.secrets \
     -e altinn_env=yt01 \
-    -e tokenGeneratorUserName=*** \
-    -e tokenGeneratorUserPwd=*** \
     --vus=5 \
     --iterations=50
 ```

--- a/test/k6/src/api/token-generator.js
+++ b/test/k6/src/api/token-generator.js
@@ -19,7 +19,7 @@ const environment = __ENV.altinn_env.toLowerCase();
  * @param {boolean} useTestData - Flag indicating whether to use test data from CSV.
  * @param {Object} testData - Optional test data object from CSV row. Should contain userId, ssn, and userPartyId.
  *                            Only used if environment variables (userID, pid, partyId) are not provided.
- * @returns {string} The generated token.
+ * @returns {Promise<string>} The generated token.
  */
 export async function generateToken(endpoint, useTestdata, testData = null) {
 

--- a/test/k6/src/api/token-generator.js
+++ b/test/k6/src/api/token-generator.js
@@ -65,7 +65,7 @@ export async function generateToken(endpoint, useTestdata, testData = null) {
 async function getFromSecretSource(secretName, raiseError) {
     let secretValue;
     try {
-        secretValue = await secrets.get(secretName);
+        secretValue = await Promise.resolve(secrets.get(secretName));
     }
     catch (error) {
         if (error == "no secret sources are configured") {

--- a/test/k6/src/api/token-generator.js
+++ b/test/k6/src/api/token-generator.js
@@ -65,7 +65,7 @@ export async function generateToken(endpoint, useTestdata, testData = null) {
 async function getFromSecretSource(secretName, raiseError) {
     let secretValue;
     try {
-        secretValue = await Promise.resolve(secrets.get(secretName));
+        secretValue = await secrets.get(secretName);
     }
     catch (error) {
         if (error == "no secret sources are configured") {

--- a/test/k6/src/api/token-generator.js
+++ b/test/k6/src/api/token-generator.js
@@ -1,10 +1,10 @@
 import http from "k6/http";
 import encoding from "k6/encoding";
+import secrets from "k6/secrets";
 import * as apiHelpers from "../apiHelpers.js";
 import { stopIterationOnFail } from "../errorhandler.js";
 
-const tokenGeneratorUserPwd = __ENV.tokenGeneratorUserPwd;
-const tokenGeneratorUserName = __ENV.tokenGeneratorUserName;
+
 const userID = __ENV.userID;
 const pid = __ENV.pid;
 const partyId = __ENV.partyId;
@@ -21,14 +21,13 @@ const environment = __ENV.altinn_env.toLowerCase();
  *                            Only used if environment variables (userID, pid, partyId) are not provided.
  * @returns {string} The generated token.
  */
-export function generateToken(endpoint, useTestdata, testData = null) {
-    if (!tokenGeneratorUserName) {
-        stopIterationOnFail(`Invalid value for environment variable 'tokenGeneratorUserName': '${tokenGeneratorUserName}'.`, false);
-    }
+export async function generateToken(endpoint, useTestdata, testData = null) {
 
-    if (!tokenGeneratorUserPwd) {
-        stopIterationOnFail(`Invalid value for environment variable 'tokenGeneratorUserPwd': '${tokenGeneratorUserPwd}'.`, false);
-    }
+    const failIterationWithMsg = (errorMsg) => stopIterationOnFail(errorMsg, false);
+
+    const tokenGeneratorUserName = await getFromSecretSource('tokenGeneratorUserName', failIterationWithMsg);
+    const tokenGeneratorUserPwd = await getFromSecretSource('tokenGeneratorUserPwd', failIterationWithMsg);
+
 
     const queryParams = {
         env: environment,
@@ -37,7 +36,7 @@ export function generateToken(endpoint, useTestdata, testData = null) {
         partyId: partyId,
     };
 
-    if (useTestdata){
+    if (useTestdata) {
         queryParams.userID = testData.userId;
         queryParams.pid = testData.ssn;
         queryParams.partyId = testData.userPartyId;
@@ -55,10 +54,31 @@ export function generateToken(endpoint, useTestdata, testData = null) {
     const response = http.get(endpointWithParams, params);
 
     if (response.status != 200) {
-        stopIterationOnFail("Token generation failed", false);
+        failIterationWithMsg("Token generation failed");
     }
 
     const token = response.body;
 
     return token;
+}
+
+async function getFromSecretSource(secretName, raiseError) {
+    let secretValue;
+    try {
+        secretValue = await secrets.get(secretName);
+    }
+    catch (error) {
+        if (error == "no secret sources are configured") {
+            raiseError("The secret sources is not configured", false);
+        }
+        else if (error == "no value") {
+            raiseError(`Secret ${secretName} does not exist in the secret source`);
+        }
+        console.log(error);
+        raiseError("Unknown error occurred in the attempt to get secret from source");
+    }
+    if (!secretValue) {
+        raiseError(`Secret ${secretName} is not properly assigned in the secret source`);
+    }
+    return secretValue;
 }

--- a/test/k6/src/tests/favorites.js
+++ b/test/k6/src/tests/favorites.js
@@ -98,7 +98,7 @@ function removeFavorites(token, partyUuid) {
  * Priority: Environment variables take precedence over CSV data.
  * @param {Object} data - The data object containing csvData array (if using CSV) or partyUuid (if using env vars), and token.
  */
-export default function runTests(data) {
+export default async function runTests(data) {
     let partyUuid;
     let testRow = null;
     let useTestData = false;
@@ -115,10 +115,10 @@ export default function runTests(data) {
         stopIterationOnFail("No test data available: neither partyUuid environment variable nor CSV data", false);
         return;
     }
-    
+
     // Generate token for this iteration: environment variables take priority, CSV data used as fallback
-    const token = generateToken(config.tokenGenerator.getPersonalToken, useTestData, testRow);
-    
+    const token = await generateToken(config.tokenGenerator.getPersonalToken, useTestData, testRow);
+
     addFavorites(token, partyUuid);
     getFavorites(token);
     removeFavorites(token, partyUuid);

--- a/test/k6/src/tests/favorites.js
+++ b/test/k6/src/tests/favorites.js
@@ -9,8 +9,7 @@ import { createCSVSharedArray, getRandomRow } from '../data/csv-loader.js';
 // With environment variable (takes priority):
 // podman compose run k6 run /src/tests/favorites.js \
 //   -e altinn_env=*** \
-//   -e tokenGeneratorUserName=*** \
-//   -e tokenGeneratorUserPwd=*** \
+//   --secret-source=file=/.secrets \
 //   -e userID=*** \
 //   -e partyId=*** \
 //   -e pid=*** \
@@ -19,8 +18,7 @@ import { createCSVSharedArray, getRandomRow } from '../data/csv-loader.js';
 // Without environment variable (uses CSV file with random row selection):
 // podman compose run k6 run /src/tests/favorites.js \
 //   -e altinn_env=*** \
-//   -e tokenGeneratorUserName=*** \
-//   -e tokenGeneratorUserPwd=***
+//   --secret-source=file=/.secrets
 
 export const options = {
     vus: 1,

--- a/test/k6/src/tests/groups.js
+++ b/test/k6/src/tests/groups.js
@@ -9,8 +9,7 @@ import { createCSVSharedArray, getRandomRow } from '../data/csv-loader.js';
 // With environment variable (takes priority):
 // podman compose run k6 run /src/tests/groups.js \
 //   -e altinn_env=*** \
-//   -e tokenGeneratorUserName=*** \
-//   -e tokenGeneratorUserPwd=*** \
+//   --secret-source=file=/.secrets \
 //   -e userID=*** \
 //   -e partyId=*** \
 //   -e pid=*** \
@@ -19,8 +18,7 @@ import { createCSVSharedArray, getRandomRow } from '../data/csv-loader.js';
 // Without environment variable (uses CSV file with random row selection):
 // podman compose run k6 run /src/tests/groups.js \
 //   -e altinn_env=*** \
-//   -e tokenGeneratorUserName=*** \
-//   -e tokenGeneratorUserPwd=***
+//   --secret-source=file=/.secrets
 
 export const options = {
     vus: 1,

--- a/test/k6/src/tests/groups.js
+++ b/test/k6/src/tests/groups.js
@@ -152,7 +152,7 @@ function deleteGroup(token, id) {
  * Priority: Environment variables take precedence over CSV data.
  * @param {Object} data - The data object containing csvData array (if using CSV) or partyUuid (if using env vars), and token.
  */
-export default function runTests(data) {
+export default async function runTests(data) {
     let partyUuid;
     let testRow = null;
     let useTestData = false;

--- a/test/k6/src/tests/groups.js
+++ b/test/k6/src/tests/groups.js
@@ -169,9 +169,9 @@ export default function runTests(data) {
         stopIterationOnFail("No test data available: neither partyUuid environment variable nor CSV data", false);
         return;
     }
-    
+
     // Generate token for this iteration: environment variables take priority, CSV data used as fallback
-    const token = generateToken(config.tokenGenerator.getPersonalToken, useTestData, testRow);
+    const token = await generateToken(config.tokenGenerator.getPersonalToken, useTestData, testRow);
 
     const timestamp = new Date().toISOString();
     const baseName = `k6-test-group`;
@@ -181,7 +181,7 @@ export default function runTests(data) {
     const groupId = createGroup(token, groupName);
 
     if (groupId) {
-            // 2. Rename group
+        // 2. Rename group
 
         renameGroup(token, groupId, `${groupName}-renamed`);
 

--- a/test/k6/src/tests/notification-settings.js
+++ b/test/k6/src/tests/notification-settings.js
@@ -10,8 +10,7 @@ import { createCSVSharedArray, getRandomRow } from '../data/csv-loader.js';
 // With environment variable (takes priority):
 // podman compose run k6 run /src/tests/notification-settings.js \
 //   -e altinn_env=*** \
-//   -e tokenGeneratorUserName=*** \
-//   -e tokenGeneratorUserPwd=*** \
+//   --secret-source=file=/.secrets \
 //   -e userID=*** \
 //   -e partyId=*** \
 //   -e pid=*** \
@@ -20,8 +19,7 @@ import { createCSVSharedArray, getRandomRow } from '../data/csv-loader.js';
 // Without environment variable (uses CSV file with random row selection):
 // podman compose run k6 run /src/tests/notification-settings.js \
 //   -e altinn_env=*** \
-//   -e tokenGeneratorUserName=*** \
-//   -e tokenGeneratorUserPwd=***
+//   --secret-source=file=/.secrets
 
 export const options = {
     vus: 1,

--- a/test/k6/src/tests/notification-settings.js
+++ b/test/k6/src/tests/notification-settings.js
@@ -161,7 +161,7 @@ function removePersonalNotificationAddresses(token, partyUuid) {
  * Priority: Environment variables take precedence over CSV data.
  * @param {Object} data - The data object containing partyUuid (if using env vars), and notificationSettings.
  */
-export default function runTests(data) {
+export default async function runTests(data) {
     let partyUuid;
     let testRow = null;
     let useTestData = false;

--- a/test/k6/src/tests/notification-settings.js
+++ b/test/k6/src/tests/notification-settings.js
@@ -178,10 +178,10 @@ export default function runTests(data) {
         stopIterationOnFail("No test data available: neither partyUuid environment variable nor CSV data", false);
         return;
     }
-    
+
     // Generate token for this iteration: environment variables take priority, CSV data used as fallback
-    const token = generateToken(config.tokenGenerator.getPersonalToken, useTestData, testRow);
-    
+    const token = await generateToken(config.tokenGenerator.getPersonalToken, useTestData, testRow);
+
     addPersonalNotificationAddresses(token, partyUuid, data.notificationSettings);
     getPersonalNotificationAddresses(token, partyUuid);
     getVerifiedAddresses(token);

--- a/test/k6/src/tests/org-notification-addresses.js
+++ b/test/k6/src/tests/org-notification-addresses.js
@@ -174,7 +174,7 @@ function removeOrgNotificationAddresses(token, orgNo, addressId) {
  * Priority: Environment variables take precedence over CSV data.
  * @param {Object} data - The data object containing csvData array (if using CSV) or orgNo (if using env vars), token, address, and updateAddress.
  */
-export default function runTests(data) {
+export default async function runTests(data) {
     let orgNo;
     let testRow = null;
     let useTestData = false;

--- a/test/k6/src/tests/org-notification-addresses.js
+++ b/test/k6/src/tests/org-notification-addresses.js
@@ -43,8 +43,8 @@ const csvData = createCSVSharedArray('orgNotificationAddressesTestData');
  */
 export function setup() {
     const orgNo = __ENV.orgNo;
-    
-   
+
+
     const envSuffix = __ENV.altinn_env.slice(-1);
     const numericSuffix = Number.parseInt(envSuffix);
     const suffix = Number.isInteger(numericSuffix) ? envSuffix : 0;
@@ -191,9 +191,9 @@ export default function runTests(data) {
         stopIterationOnFail("No test data available: neither orgNo environment variable nor CSV data", false);
         return;
     }
-    
+
     // Generate token for this iteration: environment variables take priority, CSV data used as fallback
-    const token = generateToken(config.tokenGenerator.getPersonalToken, useTestData, testRow);
+    const token = await generateToken(config.tokenGenerator.getPersonalToken, useTestData, testRow);
 
     let addressId = addOrgNotificationAddresses(token, orgNo, data.address);
     getOrgNotificationAddresses(token, orgNo);

--- a/test/k6/src/tests/org-notification-addresses.js
+++ b/test/k6/src/tests/org-notification-addresses.js
@@ -9,8 +9,7 @@ import { createCSVSharedArray, getRandomRow } from '../data/csv-loader.js';
 // With environment variable (takes priority):
 // podman compose run k6 run /src/tests/org-notification-addresses.js \
 //   -e altinn_env=*** \
-//   -e tokenGeneratorUserName=*** \
-//   -e tokenGeneratorUserPwd=*** \
+//   --secret-source=file=/.secrets \
 //   -e userID=*** \
 //   -e partyId=*** \
 //   -e pid=*** \
@@ -19,8 +18,7 @@ import { createCSVSharedArray, getRandomRow } from '../data/csv-loader.js';
 // Without environment variable (uses CSV file with random row selection):
 // podman compose run k6 run /src/tests/org-notification-addresses.js \
 //   -e altinn_env=*** \
-//   -e tokenGeneratorUserName=*** \
-//   -e tokenGeneratorUserPwd=***
+//   --secret-source=file=/.secrets
 
 export const options = {
     vus: 1,

--- a/test/k6/src/tests/users.js
+++ b/test/k6/src/tests/users.js
@@ -62,7 +62,7 @@ function getUser(token) {
  * Priority: Environment variables take precedence over CSV data.
  * @param {Object} data - The data object containing csvData array (if using CSV) or userId (if using env vars), and token.
  */
-export default function runTests(data) {
+export default async function runTests(data) {
     let testRow = null;
     let useTestData = false;
 

--- a/test/k6/src/tests/users.js
+++ b/test/k6/src/tests/users.js
@@ -9,8 +9,7 @@ import { createCSVSharedArray, getRandomRow } from '../data/csv-loader.js';
 // With environment variable (takes priority):
 // podman compose run k6 run /src/tests/users.js \
 //   -e altinn_env=*** \
-//   -e tokenGeneratorUserName=*** \
-//   -e tokenGeneratorUserPwd=*** \
+//   --secret-source=file=/.secrets \
 //   -e userID=*** \
 //   -e partyId=*** \
 //   -e pid=*** \
@@ -18,8 +17,7 @@ import { createCSVSharedArray, getRandomRow } from '../data/csv-loader.js';
 // Without environment variable (uses CSV file with random row selection):
 // podman compose run k6 run /src/tests/users.js \
 //   -e altinn_env=*** \
-//   -e tokenGeneratorUserName=*** \
-//   -e tokenGeneratorUserPwd=***
+//   --secret-source=file=/.secrets
 
 export const options = {
     vus: 1,

--- a/test/k6/src/tests/users.js
+++ b/test/k6/src/tests/users.js
@@ -75,9 +75,9 @@ export default function runTests(data) {
         stopIterationOnFail("No test data available: neither userId environment variable nor CSV data", false);
         return;
     }
-    
+
     // Generate token for this iteration: environment variables take priority, CSV data used as fallback
-    const token = generateToken(config.tokenGenerator.getPersonalToken, useTestData, testRow);
-    
+    const token = await generateToken(config.tokenGenerator.getPersonalToken, useTestData, testRow);
+
     getUser(token);
 }


### PR DESCRIPTION
Secret values such as credentials are not automatically redacted in log outputs when they are passed to k6 as env vars. Passing secrets to k6 via [secret-source](https://grafana.com/docs/k6/latest/using-k6/secret-source/#secret-source) **does** provide auto-redaction of the sensitive values.

This makes secret-source the preferred mechanism..
(i) for workflows, where the full k6 redaction becomes a defense-in-depth layer on top of GitHub Actions' own secret masking, and 
(ii) for developers when running k6 tests on their machine. The [file secret-source](https://grafana.com/docs/k6/latest/using-k6/secret-source/file/#file-secret-source) allows a way of providing secrets to k6 while avoiding the bad security practice of putting secrets on the command line, in addition to the primary goal of keeping the logs "secret free". Keeping logs free of sensitive values is vital e.g. when sharing logs with other developers or AI. 

The k6-readme now instructs developers to create a git-ignored `.secrets` file, as a "setup once and forget" store of the secret values (similar to how we use the `.env` file in Bruno).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now creates and supplies a temporary k6 secrets file to test runs; job-level secret env vars removed and workflow formatting adjusted. Local test setup mounts and ignores the secrets file and includes a secrets sample.

* **Tests**
  * k6 test suites converted to async flows and now await token acquisition before making API calls.

* **Documentation**
  * k6 docs updated with secret-source configuration and troubleshooting guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->