### PR TITLE
Propagate CancellationToken through legacy user profile enrichment

### DIFF
--- a/src/Altinn.Profile.Core/User/UserProfileService.cs
+++ b/src/Altinn.Profile.Core/User/UserProfileService.cs
@@ -227,14 +227,14 @@ public class UserProfileService : IUserProfileService
         if (userProfile.ProfileSettingPreference.PreselectedPartyUuid != null && _settings.LookupPreselectedPartyIdAtRegister)
         {
             // If a preselected party UUID is provided, we need to fetch the corresponding party ID from the register to ensure data consistency.
-            int? partyId = await _registerClient.GetPartyId(userProfile.ProfileSettingPreference.PreselectedPartyUuid.Value, default);
+            int? partyId = await _registerClient.GetPartyId(userProfile.ProfileSettingPreference.PreselectedPartyUuid.Value, cancellationToken);
             userProfile.ProfileSettingPreference.PreSelectedPartyId = partyId ?? 0;
         }
 
         return userProfile;
     }
 
-    private async Task<UserProfile> EnrichWithKrrData(UserProfile userProfile, CancellationToken cancellationToken = default)
+    private async Task<UserProfile> EnrichWithKrrData(UserProfile userProfile, CancellationToken cancellationToken)
     {
         if (userProfile.Party == null || string.IsNullOrEmpty(userProfile.Party.SSN))
         {
@@ -254,7 +254,7 @@ public class UserProfileService : IUserProfileService
         return userProfile;
     }
 
-    private async Task<UserProfile> EnrichWithSiUserContactSettings(UserProfile userProfile, CancellationToken cancellationToken = default)
+    private async Task<UserProfile> EnrichWithSiUserContactSettings(UserProfile userProfile, CancellationToken cancellationToken)
     {
         if (userProfile.UserType is not UserType.SelfIdentified)
         {

--- a/src/Altinn.Profile.Core/User/UserProfileService.cs
+++ b/src/Altinn.Profile.Core/User/UserProfileService.cs
@@ -93,7 +93,7 @@ public class UserProfileService : IUserProfileService
                 return registerProfile;
             }
 
-            UserProfile? fallbackLegacy = await GetEnrichedLegacyUserProfile(getLegacy());
+            UserProfile? fallbackLegacy = await GetEnrichedLegacyUserProfile(getLegacy(), cancellationToken);
             return CreateUserProfileResult(fallbackLegacy);
         }
 
@@ -105,14 +105,14 @@ public class UserProfileService : IUserProfileService
             await Task.WhenAll(legacyTask, registerTask);
 
             UserProfile? registerProfile = await registerTask;
-            UserProfile? legacyProfile = await GetEnrichedLegacyUserProfile(legacyTask);
+            UserProfile? legacyProfile = await GetEnrichedLegacyUserProfile(legacyTask, cancellationToken);
 
             _userProfileComparer.CompareAndLog(legacyProfile, registerProfile);
 
             return CreateUserProfileResult(legacyProfile);
         }
 
-        UserProfile? legacyOnly = await GetEnrichedLegacyUserProfile(getLegacy());
+        UserProfile? legacyOnly = await GetEnrichedLegacyUserProfile(getLegacy(), cancellationToken);
         return CreateUserProfileResult(legacyOnly);
     }
 
@@ -126,7 +126,7 @@ public class UserProfileService : IUserProfileService
         return userProfile;
     }
 
-    private async Task<UserProfile?> GetEnrichedLegacyUserProfile(Task<Result<UserProfile, bool>> legacyTask)
+    private async Task<UserProfile?> GetEnrichedLegacyUserProfile(Task<Result<UserProfile, bool>> legacyTask, CancellationToken cancellationToken)
     {
         Result<UserProfile, bool> legacyResult = await legacyTask;
         if (!legacyResult.IsSuccess)
@@ -135,9 +135,9 @@ public class UserProfileService : IUserProfileService
         }
 
         UserProfile legacyProfile = legacyResult.Match(userProfile => userProfile, _ => default!);
-        legacyProfile = await EnrichWithProfileSettings(legacyProfile, default);
-        legacyProfile = await EnrichWithKrrData(legacyProfile);
-        legacyProfile = await EnrichWithSiUserContactSettings(legacyProfile);
+        legacyProfile = await EnrichWithProfileSettings(legacyProfile, cancellationToken);
+        legacyProfile = await EnrichWithKrrData(legacyProfile, cancellationToken);
+        legacyProfile = await EnrichWithSiUserContactSettings(legacyProfile, cancellationToken);
 
         return legacyProfile;
     }

--- a/test/Altinn.Profile.Tests/Profile.Core/User/UserProfileServiceTests.cs
+++ b/test/Altinn.Profile.Tests/Profile.Core/User/UserProfileServiceTests.cs
@@ -1,0 +1,166 @@
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Altinn.Profile.Core;
+using Altinn.Profile.Core.Integrations;
+using Altinn.Profile.Core.Person.ContactPreferences;
+using Altinn.Profile.Core.User;
+using Altinn.Profile.Core.User.ProfileSettings;
+using Altinn.Profile.Models;
+
+using Microsoft.Extensions.Options;
+
+using Moq;
+
+using Xunit;
+
+namespace Altinn.Profile.Tests.Profile.Core.User;
+
+public class UserProfileServiceTests
+{
+    private readonly Mock<IUserProfileClient> _userProfileClientMock = new();
+    private readonly Mock<IUserProfileComparer> _userProfileComparerMock = new();
+    private readonly Mock<IProfileSettingsRepository> _profileSettingsRepositoryMock = new();
+    private readonly Mock<IPersonService> _personServiceMock = new();
+    private readonly Mock<IRegisterClient> _registerClientMock = new();
+    private readonly Mock<IUserContactInfoRepository> _userContactInfoRepositoryMock = new();
+    private readonly Mock<IOptionsMonitor<CoreSettings>> _settingsMock = new();
+
+    public UserProfileServiceTests()
+    {
+        _settingsMock.Setup(s => s.CurrentValue).Returns(new CoreSettings
+        {
+            RegisterAsPrimaryUserProfileSource = false,
+            RegisterLookupInShadowMode = false,
+        });
+
+        _personServiceMock
+            .Setup(p => p.GetContactPreferencesAsync(It.IsAny<System.Collections.Generic.IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ImmutableList<PersonContactPreferences>.Empty);
+    }
+
+    private UserProfileService CreateSut() => new(
+        _userProfileClientMock.Object,
+        _userProfileComparerMock.Object,
+        _profileSettingsRepositoryMock.Object,
+        _personServiceMock.Object,
+        _registerClientMock.Object,
+        _userContactInfoRepositoryMock.Object,
+        _settingsMock.Object);
+
+    [Fact]
+    public async Task GetUser_ById_LegacyPath_PropagatesCancellationTokenToProfileSettingsRepository()
+    {
+        // Arrange
+        const int UserId = 2001607;
+        using var cts = new CancellationTokenSource();
+        var expectedToken = cts.Token;
+
+        _userProfileClientMock.Setup(c => c.GetUser(UserId)).ReturnsAsync(new UserProfile { UserId = UserId });
+
+        var sut = CreateSut();
+
+        // Act
+        await sut.GetUser(UserId, expectedToken);
+
+        // Assert
+        _profileSettingsRepositoryMock.Verify(
+            r => r.GetProfileSettings(UserId, expectedToken),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GetUser_BySsn_LegacyPath_PropagatesCancellationTokenToProfileSettingsRepository()
+    {
+        // Arrange
+        const int UserId = 2001607;
+        const string Ssn = "01025101038";
+        using var cts = new CancellationTokenSource();
+        var expectedToken = cts.Token;
+
+        _userProfileClientMock.Setup(c => c.GetUser(Ssn)).ReturnsAsync(new UserProfile { UserId = UserId });
+
+        var sut = CreateSut();
+
+        // Act
+        await sut.GetUser(Ssn, expectedToken);
+
+        // Assert
+        _profileSettingsRepositoryMock.Verify(
+            r => r.GetProfileSettings(UserId, expectedToken),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GetUserByUsername_LegacyPath_PropagatesCancellationTokenToProfileSettingsRepository()
+    {
+        // Arrange
+        const int UserId = 2001072;
+        const string Username = "OrstaECUser";
+        using var cts = new CancellationTokenSource();
+        var expectedToken = cts.Token;
+
+        _userProfileClientMock.Setup(c => c.GetUserByUsername(Username)).ReturnsAsync(new UserProfile { UserId = UserId });
+
+        var sut = CreateSut();
+
+        // Act
+        await sut.GetUserByUsername(Username, expectedToken);
+
+        // Assert
+        _profileSettingsRepositoryMock.Verify(
+            r => r.GetProfileSettings(UserId, expectedToken),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GetUserByUuid_LegacyPath_PropagatesCancellationTokenToProfileSettingsRepository()
+    {
+        // Arrange
+        const int UserId = 2001607;
+        var userUuid = new System.Guid("cc86d2c7-1695-44b0-8e82-e633243fdf31");
+        using var cts = new CancellationTokenSource();
+        var expectedToken = cts.Token;
+
+        _userProfileClientMock.Setup(c => c.GetUserByUuid(userUuid)).ReturnsAsync(new UserProfile { UserId = UserId, UserUuid = userUuid });
+
+        var sut = CreateSut();
+
+        // Act
+        await sut.GetUserByUuid(userUuid, expectedToken);
+
+        // Assert
+        _profileSettingsRepositoryMock.Verify(
+            r => r.GetProfileSettings(UserId, expectedToken),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GetUser_ById_ShadowMode_PropagatesCancellationTokenToProfileSettingsRepositoryOnLegacyEnrichment()
+    {
+        // Arrange
+        const int UserId = 2001607;
+        using var cts = new CancellationTokenSource();
+        var expectedToken = cts.Token;
+
+        _settingsMock.Setup(s => s.CurrentValue).Returns(new CoreSettings
+        {
+            RegisterAsPrimaryUserProfileSource = false,
+            RegisterLookupInShadowMode = true,
+        });
+
+        _userProfileClientMock.Setup(c => c.GetUser(UserId)).ReturnsAsync(new UserProfile { UserId = UserId });
+        _registerClientMock.Setup(c => c.GetUserParty(UserId, It.IsAny<CancellationToken>())).ReturnsAsync(default(Altinn.Register.Contracts.Party));
+
+        var sut = CreateSut();
+
+        // Act
+        await sut.GetUser(UserId, expectedToken);
+
+        // Assert
+        _profileSettingsRepositoryMock.Verify(
+            r => r.GetProfileSettings(UserId, expectedToken),
+            Times.Once);
+    }
+}


### PR DESCRIPTION
## Summary
- Closes #873.
- `GetEnrichedLegacyUserProfile` now takes a `CancellationToken` and threads the request token through `EnrichWithProfileSettings`, `EnrichWithKrrData` and `EnrichWithSiUserContactSettings` (previously hard-coded to `default`).
- Adds focused unit tests in `UserProfileServiceTests` that lock in token propagation through the legacy and shadow-mode paths.

## Why
Production has been throwing `System.ObjectDisposedException` from `Npgsql.NpgsqlConnector.ResetCancellation` inside `ProfileSettingsRepository.GetProfileSettings` via the legacy enrichment path. The trigger is graceful shutdown of the host (deploy / pod restart): the `NpgsqlDataSource` is being disposed while these DB calls are still running, and because the request token never reached EF Core they couldn't be cancelled cleanly. With the token propagated, the queries terminate with `OperationCanceledException` as expected.

## Test plan
- [x] `dotnet build`
- [x] `dotnet test --filter "FullyQualifiedName~UserProfileServiceTests"` — 5 new tests pass
- [x] `dotnet test --filter "FullyQualifiedName!~IntegrationTests"` — 654 tests pass (was 649)
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved backend reliability by ensuring request cancellation is consistently respected across legacy and fallback profile enrichment paths.

* **Tests**
  * Added comprehensive tests verifying user profile retrieval scenarios and correct cancellation propagation during enrichment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->