### PR TITLE
Improve error handling for configuration failures and fix workflow/docs

### DIFF
--- a/.github/workflows/assign-issues-to-projects.yml
+++ b/.github/workflows/assign-issues-to-projects.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions: {}
     steps:
-      - uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2
+      - uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0
         with:
           project-url: https://github.com/orgs/Altinn/projects/20
           github-token: ${{ secrets.ASSIGN_PROJECT_TOKEN }}

--- a/.github/workflows/build-and-analyze.yml
+++ b/.github/workflows/build-and-analyze.yml
@@ -1,13 +1,13 @@
 name: Code test and analysis
 on:
   push:
-    branches: [ main ]
+    branches: [main]
     paths-ignore:
       - 'test/k6/**'
       - '.github/**'
   pull_request:
-    branches: [ main ]
-    types: [ opened, synchronize, reopened ]
+    branches: [main]
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
 jobs:
   build-test-analyze:
@@ -75,7 +75,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
-          dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
+          dotnet-sonarscanner end /d:sonar.token="$SONAR_TOKEN"
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/test/k6/.gitignore
+++ b/test/k6/.gitignore
@@ -1,4 +1,2 @@
-#Junit reports
-**/reports/*.xml
-.env
+# Secret-source
 .secrets

--- a/test/k6/readme.md
+++ b/test/k6/readme.md
@@ -28,6 +28,7 @@ Alternatively, it is possible to run the tests directly on your machine as well.
 
 
 | Variable | Description | Required |
+|----------|-------------|----------|
 | `tokenGeneratorUserName` | Username for token generator | Yes |
 | `tokenGeneratorUserPwd` | Password for token generator | Yes |
 

--- a/test/k6/src/api/token-generator.js
+++ b/test/k6/src/api/token-generator.js
@@ -66,7 +66,7 @@ async function getFromSecretSource(secretName, raiseError) {
     }
     catch (error) {
         if (error == "no secret sources are configured") {
-            raiseError("The secret sources is not configured", false);
+            raiseError("No secret source is configured for the k6 command - specify the file path with the --secret-source flag");
         }
         else if (error == "no value") {
             raiseError(`Secret ${secretName} does not exist in the secret source`);

--- a/test/k6/src/api/token-generator.js
+++ b/test/k6/src/api/token-generator.js
@@ -2,7 +2,7 @@ import http from "k6/http";
 import encoding from "k6/encoding";
 import secrets from "k6/secrets";
 import * as apiHelpers from "../apiHelpers.js";
-import { stopIterationOnFail } from "../errorhandler.js";
+import { stopIterationOnFail, throwConfigurationError } from "../errorhandler.js";
 
 
 const userID = __ENV.userID;
@@ -22,11 +22,8 @@ const environment = __ENV.altinn_env.toLowerCase();
  * @returns {Promise<string>} The generated token.
  */
 export async function generateToken(endpoint, useTestdata, testData = null) {
-
-    const failIterationWithMsg = (errorMsg) => stopIterationOnFail(errorMsg, false);
-
-    const tokenGeneratorUserName = await getFromSecretSource('tokenGeneratorUserName', failIterationWithMsg);
-    const tokenGeneratorUserPwd = await getFromSecretSource('tokenGeneratorUserPwd', failIterationWithMsg);
+    const tokenGeneratorUserName = await getFromSecretSource('tokenGeneratorUserName', throwConfigurationError);
+    const tokenGeneratorUserPwd = await getFromSecretSource('tokenGeneratorUserPwd', throwConfigurationError);
 
 
     const queryParams = {
@@ -54,7 +51,7 @@ export async function generateToken(endpoint, useTestdata, testData = null) {
     const response = http.get(endpointWithParams, params);
 
     if (response.status != 200) {
-        failIterationWithMsg("Token generation failed");
+        stopIterationOnFail("Token generation failed", false);
     }
 
     const token = response.body;
@@ -74,7 +71,6 @@ async function getFromSecretSource(secretName, raiseError) {
         else if (error == "no value") {
             raiseError(`Secret ${secretName} does not exist in the secret source`);
         }
-        console.log(error);
         raiseError("Unknown error occurred in the attempt to get secret from source");
     }
     if (!secretValue) {

--- a/test/k6/src/config.js
+++ b/test/k6/src/config.js
@@ -1,4 +1,4 @@
-import { stopIterationOnFail } from "./errorhandler.js";
+import { throwConfigurationError } from "./errorhandler.js";
 
 // Base URLs for the Altinn platform across different environments.
 const baseUrls = {
@@ -11,12 +11,12 @@ const baseUrls = {
 
 const environment = __ENV.altinn_env ? __ENV.altinn_env.toLowerCase() : null;
 if (!environment) {
-    stopIterationOnFail("Environment variable 'altinn_env' is not set", false);
+    throwConfigurationError("Environment variable 'altinn_env' is not set");
 }
 
 const baseUrl = baseUrls[environment];
 if (!baseUrl) {
-    stopIterationOnFail(`Invalid value for environment variable 'altinn_env': '${environment}'.`, false);
+    throwConfigurationError(`Invalid value for environment variable 'altinn_env': '${environment}'.`);
 }
 
 // Altinn TestTools token generator URL.

--- a/test/k6/src/errorhandler.js
+++ b/test/k6/src/errorhandler.js
@@ -10,3 +10,11 @@ export function stopIterationOnFail(failReason, success) {
         fail(failReason);
     }
 }
+
+/**
+ * Interrupts the test run(s) by flagging an invalid k6 configuration that is fundamental.
+ * @param {String} message A description of the faulty configuration parameter
+ */
+export function throwConfigurationError(message) {
+    throw new Error(`Invalid k6 configuration: ${message}`)
+}


### PR DESCRIPTION
Cleaning up some things:
- Use full semver `actions/add-to-project` in Renovate tag comment (was changed to `v2` by Renovate in previous patch)
- Pass SONAR_TOKEN to dotnet-sonarscanner via existing env var
  - Not a practical security difference for secret references, but it's preferrable for reinforcing the best practice of using env var instead of inline `${{ }}` _for values that could be user-controlled_ (ref GitHub docs "[Use an intermediate environment variable](https://docs.github.com/en/actions/reference/security/secure-use#use-an-intermediate-environment-variable)")
- Throw errors in k6 for incorrect test setup.
  - Missing configuration parameters is a setup/programming error - a failure mode that is different from test execution failures. It can be helpful to better differentiate these kinds of failures
- Remove a console.log leftover from development

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified load-testing secret-source instructions by adding a table header for secret variables.

* **Chores**
  * Standardized CI workflow formatting and moved to environment-based token usage for analysis steps.
  * Adjusted test artifact and secret-file handling in project ignores.

* **Tests**
  * Improved test helpers and error handling for configuration and token-generation flows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-profile/pull/895)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->