### PR TITLE
Use default values for patch user settings when not found

### DIFF
--- a/src/Altinn.Profile.Core/User.ProfileSettings/ProfileSettings.cs
+++ b/src/Altinn.Profile.Core/User.ProfileSettings/ProfileSettings.cs
@@ -1,4 +1,6 @@
-﻿namespace Altinn.Profile.Core.User.ProfileSettings
+﻿using Altinn.Profile.Models;
+
+namespace Altinn.Profile.Core.User.ProfileSettings
 {
     /// <summary>
     /// Represents user-specific portal settings and preferences.
@@ -81,6 +83,22 @@
             {
                 PreselectedPartyUuid = other.PreselectedPartyUuid.Value;
             }
+        }
+
+        /// <summary>
+        /// Create a new instance of ProfileSettings with default values.
+        /// </summary>
+        public static ProfileSettings GetDefaultValues()
+        {
+            return new ProfileSettings
+            {
+                LanguageType = "nb",
+                DoNotPromptForParty = false,
+                PreselectedPartyUuid = null,
+                ShowClientUnits = false,
+                ShouldShowSubEntities = true,
+                ShouldShowDeletedEntities = false
+            };
         }
     }
 }

--- a/src/Altinn.Profile.Core/User.ProfileSettings/ProfileSettings.cs
+++ b/src/Altinn.Profile.Core/User.ProfileSettings/ProfileSettings.cs
@@ -88,6 +88,7 @@ namespace Altinn.Profile.Core.User.ProfileSettings
         /// <summary>
         /// Create a new instance of ProfileSettings with default values.
         /// </summary>
+        /// <returns>A new <see cref="ProfileSettings"/> instance initialized with default values.</returns>
         public static ProfileSettings GetDefaultValues()
         {
             return new ProfileSettings

--- a/src/Altinn.Profile.Core/User/UserProfileService.cs
+++ b/src/Altinn.Profile.Core/User/UserProfileService.cs
@@ -208,21 +208,17 @@ public class UserProfileService : IUserProfileService
     private async Task<UserProfile> EnrichWithProfileSettings(UserProfile userProfile, CancellationToken cancellationToken)
     {
         ProfileSettings.ProfileSettings? profileSettings = await _profileSettingsRepository.GetProfileSettings(userProfile.UserId, cancellationToken);
-        if (profileSettings != null)
-        {
-            userProfile.ProfileSettingPreference ??= new ProfileSettingPreference();
-            userProfile.ProfileSettingPreference.DoNotPromptForParty = profileSettings.DoNotPromptForParty;
-            userProfile.ProfileSettingPreference.Language = profileSettings.LanguageType;
-            userProfile.ProfileSettingPreference.PreselectedPartyUuid = profileSettings.PreselectedPartyUuid;
-            userProfile.ProfileSettingPreference.ShowClientUnits = profileSettings.ShowClientUnits;
-            userProfile.ProfileSettingPreference.ShouldShowSubEntities = profileSettings.ShouldShowSubEntities;
-            userProfile.ProfileSettingPreference.ShouldShowDeletedEntities = profileSettings.ShouldShowDeletedEntities;
-        }
-        else
-        {
-            // If there are no profile settings for the user, we initialize it with default values to ensure that the user profile always has valid profile settings.
-            userProfile.ProfileSettingPreference ??= ProfileSettingPreference.GetDefaultValues();
-        }
+
+        // If there are no profile settings for the user, we initialize it with default values to ensure that the user profile always has valid profile settings.
+        profileSettings ??= ProfileSettings.ProfileSettings.GetDefaultValues();
+
+        userProfile.ProfileSettingPreference ??= new ProfileSettingPreference();
+        userProfile.ProfileSettingPreference.DoNotPromptForParty = profileSettings.DoNotPromptForParty;
+        userProfile.ProfileSettingPreference.Language = profileSettings.LanguageType;
+        userProfile.ProfileSettingPreference.PreselectedPartyUuid = profileSettings.PreselectedPartyUuid;
+        userProfile.ProfileSettingPreference.ShowClientUnits = profileSettings.ShowClientUnits;
+        userProfile.ProfileSettingPreference.ShouldShowSubEntities = profileSettings.ShouldShowSubEntities;
+        userProfile.ProfileSettingPreference.ShouldShowDeletedEntities = profileSettings.ShouldShowDeletedEntities;
 
         if (userProfile.ProfileSettingPreference.PreselectedPartyUuid != null)
         {

--- a/src/Altinn.Profile.Integrations/Repositories/ProfileSettingsRepository.cs
+++ b/src/Altinn.Profile.Integrations/Repositories/ProfileSettingsRepository.cs
@@ -2,6 +2,7 @@
 using Altinn.Profile.Core.User.ProfileSettings;
 using Altinn.Profile.Integrations.Events;
 using Altinn.Profile.Integrations.Persistence;
+using Altinn.Profile.Models;
 
 using Microsoft.EntityFrameworkCore;
 
@@ -54,10 +55,16 @@ namespace Altinn.Profile.Integrations.Repositories
 
             if (existing == null)
             {
-                return null;
-            }
+                // If there are no profile settings for the user, we initialize it with default values to ensure that the user profile always has valid profile settings.
+                existing = ProfileSettings.GetDefaultValues();
+                existing.UpdateFrom(profileSettings);
 
-            existing.UpdateFrom(profileSettings);
+                databaseContext.ProfileSettings.Add(existing);
+            }
+            else
+            {
+                existing.UpdateFrom(profileSettings);
+            }
 
             ProfileSettingsUpdatedEvent NotifyProfileSettingsUpdated() => new(profileSettings.UserId, DateTime.UtcNow, existing.LanguageType, existing.DoNotPromptForParty, existing.PreselectedPartyUuid, existing.ShowClientUnits, existing.ShouldShowSubEntities, existing.ShouldShowDeletedEntities, existing.IgnoreUnitProfileDateTime);
             await NotifyAndSave(databaseContext, NotifyProfileSettingsUpdated, CancellationToken.None);

--- a/src/Altinn.Profile.Integrations/Repositories/ProfileSettingsRepository.cs
+++ b/src/Altinn.Profile.Integrations/Repositories/ProfileSettingsRepository.cs
@@ -58,6 +58,7 @@ namespace Altinn.Profile.Integrations.Repositories
                 // If there are no profile settings for the user, we initialize it with default values to ensure that the user profile always has valid profile settings.
                 existing = ProfileSettings.GetDefaultValues();
                 existing.UpdateFrom(profileSettings);
+                existing.UserId = profileSettings.UserId;
 
                 databaseContext.ProfileSettings.Add(existing);
             }

--- a/src/Altinn.Profile.Models/ProfileSettingPreference.cs
+++ b/src/Altinn.Profile.Models/ProfileSettingPreference.cs
@@ -58,22 +58,5 @@
         /// Indicates whether deleted entities should be shown.
         /// </summary>
         public bool ShouldShowDeletedEntities { get; set; }
-
-        /// <summary>
-        /// Create a new instance of ProfileSettingPreference with default values.
-        /// </summary>
-        public static ProfileSettingPreference GetDefaultValues()
-        {
-            return new ProfileSettingPreference
-            {
-                Language = "nb",
-                PreSelectedPartyId = 0,
-                DoNotPromptForParty = false,
-                PreselectedPartyUuid = null,
-                ShowClientUnits = false,
-                ShouldShowSubEntities = true,
-                ShouldShowDeletedEntities = false
-            };
-        }
     }
 }

--- a/test/Altinn.Profile.Tests/Profile.Integrations/Repositories/ProfileSettingsRepositoryTests.cs
+++ b/test/Altinn.Profile.Tests/Profile.Integrations/Repositories/ProfileSettingsRepositoryTests.cs
@@ -298,7 +298,7 @@ public class ProfileSettingsRepositoryTests
     }
 
     [Fact]
-    public async Task PatchProfileSettings_ReturnsUpdatedDefaultValuesIfNotExists()
+    public async Task PatchProfileSettings_WhenNotExists_ReturnsUpdatedDefaultValues()
     {
         // Arrange
         var userId = 9999;
@@ -314,6 +314,7 @@ public class ProfileSettingsRepositoryTests
         // Assert
         Assert.NotNull(result);
         Assert.Equal("en", result.LanguageType);
+        Assert.Equal(userId, result.UserId);
     }
 
     private void MockDbContextOutbox<TEvent>(Action<TEvent, DeliveryOptions> callback)

--- a/test/Altinn.Profile.Tests/Profile.Integrations/Repositories/ProfileSettingsRepositoryTests.cs
+++ b/test/Altinn.Profile.Tests/Profile.Integrations/Repositories/ProfileSettingsRepositoryTests.cs
@@ -298,21 +298,22 @@ public class ProfileSettingsRepositoryTests
     }
 
     [Fact]
-    public async Task PatchProfileSettings_ReturnsNullIfNotExists()
+    public async Task PatchProfileSettings_ReturnsUpdatedDefaultValuesIfNotExists()
     {
         // Arrange
         var userId = 9999;
         var patch = new ProfileSettingsPatchModel
         {
             UserId = userId,
-            Language = "nb"
+            Language = "en"
         };
 
         // Act
         var result = await _repository.PatchProfileSettings(patch, TestContext.Current.CancellationToken);
 
         // Assert
-        Assert.Null(result);
+        Assert.NotNull(result);
+        Assert.Equal("en", result.LanguageType);
     }
 
     private void MockDbContextOutbox<TEvent>(Action<TEvent, DeliveryOptions> callback)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #903 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Profile settings are now auto-initialized with sensible defaults when missing, preventing incomplete profiles.
  * User profile preferences are consistently applied so all profiles have complete, predictable settings.

* **Tests**
  * Updated integration tests to verify missing profile settings are created and returned with the applied defaults.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-profile/pull/904?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->