### PR TITLE
Making outdated contact information available for Notifications

### DIFF
--- a/src/Altinn.Profile.Core/User.ContactPoints/UserContactPointService.cs
+++ b/src/Altinn.Profile.Core/User.ContactPoints/UserContactPointService.cs
@@ -13,8 +13,6 @@ namespace Altinn.Profile.Core.User.ContactPoints;
 /// </summary>
 public class UserContactPointService : IUserContactPointsService
 {
-    private const int ActiveContactPointMonths = 18;
-
     private readonly IUserProfileService _userProfileService;
     private readonly IPersonService _personService;
     private readonly IUserContactInfoRepository _userContactInfoRepository;
@@ -61,26 +59,20 @@ public class UserContactPointService : IUserContactPointsService
     public async Task<UserContactPointsList> GetContactPoints(List<string> nationalIdentityNumbers, CancellationToken cancellationToken)
     {
         UserContactPointsList resultList = new();
-        var cutoffDate = DateTime.UtcNow.AddMonths(-ActiveContactPointMonths);
 
         var contactPreferences = await _personService.GetContactPreferencesAsync(nationalIdentityNumbers, cancellationToken);
 
         foreach (var contactPreference in contactPreferences)
         {
-            var emailTooOld = IsContactPointTooOld(contactPreference.EmailLastTouched, cutoffDate);
-            var mobileTooOld = IsContactPointTooOld(contactPreference.MobileNumberLastTouched, cutoffDate);
-            if (mobileTooOld && emailTooOld)
-            {
-                continue;
-            }
-
             resultList.ContactPointsList.Add(
                 new UserContactPoints()
                 {
                     NationalIdentityNumber = contactPreference.NationalIdentityNumber,
-                    Email = emailTooOld ? null : contactPreference.Email,
-                    MobileNumber = mobileTooOld ? null : contactPreference.MobileNumber,
+                    Email = contactPreference.Email,
+                    MobileNumber = contactPreference.MobileNumber,
                     IsReserved = contactPreference.IsReserved,
+                    MobileNumberLastTouched = contactPreference.MobileNumberLastTouched,
+                    EmailLastTouched = contactPreference.EmailLastTouched
                 });
         }
 
@@ -181,10 +173,5 @@ public class UserContactPointService : IUserContactPointsService
         }
 
         return null;
-    }
-
-    private static bool IsContactPointTooOld(DateTime? lastTouched, DateTime cutoffDate)
-    {
-        return !lastTouched.HasValue || lastTouched.Value < cutoffDate;
     }
 }

--- a/src/Altinn.Profile.Core/User.ContactPoints/UserContactPoints.cs
+++ b/src/Altinn.Profile.Core/User.ContactPoints/UserContactPoints.cs
@@ -29,6 +29,16 @@ public class UserContactPoints
     /// Gets or sets the email address
     /// </summary>
     public string? Email { get; set; }
+
+    /// <summary>
+    /// Gets or sets the timestamp for when the mobile number was last updated by the user.
+    /// </summary>
+    public DateTime? MobileNumberLastTouched { get; set; }
+
+    /// <summary>
+    /// Gets or sets the timestamp for when the email address was last updated by the user.
+    /// </summary>
+    public DateTime? EmailLastTouched { get; set; }
 }
 
 /// <summary>

--- a/test/Altinn.Profile.Tests/Profile.Core/User/UserContactPointServiceTest.cs
+++ b/test/Altinn.Profile.Tests/Profile.Core/User/UserContactPointServiceTest.cs
@@ -64,39 +64,21 @@ public class UserContactPointServiceTest
         };
         var expectedUserContactPointB = new UserContactPoints()
         {
-            Email = null,
+            Email = userProfileB.Email,
             NationalIdentityNumber = userProfileB.Party.SSN,
             IsReserved = userProfileB.IsReserved,
             MobileNumber = userProfileB.PhoneNumber,
         };
 
-        var userProfileC = await TestDataLoader.Load<UserProfile>(_userIdCStr);
-        var contactPreferencesC = new PersonContactPreferences()
-        {
-            NationalIdentityNumber = _userIdCStr,
-            Email = userProfileC.Email,
-            IsReserved = userProfileC.IsReserved,
-            MobileNumber = userProfileC.PhoneNumber,
-            MobileNumberLastTouched = DateTime.UtcNow.AddMonths(-26),
-            EmailLastTouched = DateTime.UtcNow.AddMonths(-26),
-        };
-        var expectedUserContactPointC = new UserContactPoints()
-        {
-            Email = null,
-            NationalIdentityNumber = _userIdCStr,
-            IsReserved = userProfileC.IsReserved,
-            MobileNumber = null,
-        };
-
         _userProfileServiceMock.Setup(m => m.GetUser(userProfileA.Party.SSN, It.IsAny<CancellationToken>())).ReturnsAsync(userProfileA);
         _userProfileServiceMock.Setup(m => m.GetUser(userProfileB.Party.SSN, It.IsAny<CancellationToken>())).ReturnsAsync(userProfileB);
-        _personServiceMock.Setup(m => m.GetContactPreferencesAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>())).ReturnsAsync([contactPreferencesA, contactPreferencesB, contactPreferencesC]);
+        _personServiceMock.Setup(m => m.GetContactPreferencesAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>())).ReturnsAsync([contactPreferencesA, contactPreferencesB]);
 
-        return [expectedUserContactPointA, expectedUserContactPointB, expectedUserContactPointC];
+        return [expectedUserContactPointA, expectedUserContactPointB];
     }
 
     [Fact]
-    public async Task GetContactPoints_WhenPersonServiceIsCalled_IsSuccessAndFiltersOutOldAddresses()
+    public async Task GetContactPoints_WhenPersonServiceIsCalled_IsSuccess()
     {
         // Arrange
         List<UserContactPoints> expectedUsers = await MockTestUsers();
@@ -107,7 +89,6 @@ public class UserContactPointServiceTest
             [
                 expectedUsers[0].NationalIdentityNumber,
                 expectedUsers[1].NationalIdentityNumber,
-                expectedUsers[2].NationalIdentityNumber,
             ],
             TestContext.Current.CancellationToken);
 

--- a/test/Altinn.Profile.Tests/Profile.Core/User/UserContactPointServiceTest.cs
+++ b/test/Altinn.Profile.Tests/Profile.Core/User/UserContactPointServiceTest.cs
@@ -48,6 +48,8 @@ public class UserContactPointServiceTest
             NationalIdentityNumber = userProfileA.Party.SSN,
             IsReserved = userProfileA.IsReserved,
             MobileNumber = userProfileA.PhoneNumber,
+            MobileNumberLastTouched = contactPreferencesA.MobileNumberLastTouched,
+            EmailLastTouched = contactPreferencesA.EmailLastTouched,
         };
 
         var userProfileB = await TestDataLoader.Load<UserProfile>(_userIdBStr);
@@ -66,6 +68,8 @@ public class UserContactPointServiceTest
             NationalIdentityNumber = userProfileB.Party.SSN,
             IsReserved = userProfileB.IsReserved,
             MobileNumber = userProfileB.PhoneNumber,
+            MobileNumberLastTouched = contactPreferencesB.MobileNumberLastTouched,
+            EmailLastTouched = contactPreferencesB.EmailLastTouched,
         };
 
         _userProfileServiceMock.Setup(m => m.GetUser(userProfileA.Party.SSN, It.IsAny<CancellationToken>())).ReturnsAsync(userProfileA);
@@ -122,7 +126,9 @@ public class UserContactPointServiceTest
         return a.NationalIdentityNumber == b.NationalIdentityNumber &&
             a.Email == b.Email &&
             a.IsReserved == b.IsReserved &&
-            a.MobileNumber == b.MobileNumber;
+            a.MobileNumber == b.MobileNumber &&
+            a.MobileNumberLastTouched == b.MobileNumberLastTouched &&
+            a.EmailLastTouched == b.EmailLastTouched;
     }
 
     [Fact]

--- a/test/Altinn.Profile.Tests/Profile.Core/User/UserContactPointServiceTest.cs
+++ b/test/Altinn.Profile.Tests/Profile.Core/User/UserContactPointServiceTest.cs
@@ -30,8 +30,6 @@ public class UserContactPointServiceTest
 
     private static readonly string _userIdBStr = "2001607";
 
-    private static readonly string _userIdCStr = "2001608";
-
     private async Task<List<UserContactPoints>> MockTestUsers() // Take a look at IAsyncLifetime / InitializeAsync from XUnit, as something for next time
     {
         var userProfileA = await TestDataLoader.Load<UserProfile>(_userIdAStr);


### PR DESCRIPTION
## Description
Expose the last touched date for email address and phone number to Notifications.

## Related Issue(s)
- Issue 502 in private issue tracker

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Contact point management now tracks timestamps for when mobile numbers and email addresses were last updated.

* **Behavior Changes**
  * Contact point validation no longer filters out older contact information based on age thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->