### PR TITLE
Add feature to use stale contact information

### DIFF
--- a/src/Altinn.Profile.Core/User.ContactPoints/IUserContactPointsService.cs
+++ b/src/Altinn.Profile.Core/User.ContactPoints/IUserContactPointsService.cs
@@ -9,10 +9,10 @@ public interface IUserContactPointsService
     /// Method for retriveing contact points for a user 
     /// </summary>
     /// <param name="nationalIdentityNumbers">A list of national identity numbers to lookup contact points for</param>
-    /// <param name="skipAgeCheck">A boolean indicating whether to skip the age check for contact points.</param>
+    /// <param name="useStaleContactInfo">A boolean indicating whether to skip the age check for contact points.</param>
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
     /// <returns>The users' contact points and reservation status or a boolean if failure.</returns>
-    Task<UserContactPointsList> GetContactPoints(List<string> nationalIdentityNumbers, bool skipAgeCheck, CancellationToken cancellationToken);
+    Task<UserContactPointsList> GetContactPoints(List<string> nationalIdentityNumbers, bool useStaleContactInfo, CancellationToken cancellationToken);
 
     /// <summary>
     /// Retrieves the self-identified users' contact points associated with the specified external identities.

--- a/src/Altinn.Profile.Core/User.ContactPoints/IUserContactPointsService.cs
+++ b/src/Altinn.Profile.Core/User.ContactPoints/IUserContactPointsService.cs
@@ -9,9 +9,10 @@ public interface IUserContactPointsService
     /// Method for retriveing contact points for a user 
     /// </summary>
     /// <param name="nationalIdentityNumbers">A list of national identity numbers to lookup contact points for</param>
+    /// <param name="ignoreNotificationStatus">A boolean indicating whether to ignore the notification status.</param>
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
     /// <returns>The users' contact points and reservation status or a boolean if failure.</returns>
-    Task<UserContactPointsList> GetContactPoints(List<string> nationalIdentityNumbers, CancellationToken cancellationToken);
+    Task<UserContactPointsList> GetContactPoints(List<string> nationalIdentityNumbers, bool ignoreNotificationStatus, CancellationToken cancellationToken);
 
     /// <summary>
     /// Retrieves the self-identified users' contact points associated with the specified external identities.

--- a/src/Altinn.Profile.Core/User.ContactPoints/IUserContactPointsService.cs
+++ b/src/Altinn.Profile.Core/User.ContactPoints/IUserContactPointsService.cs
@@ -9,10 +9,10 @@ public interface IUserContactPointsService
     /// Method for retriveing contact points for a user 
     /// </summary>
     /// <param name="nationalIdentityNumbers">A list of national identity numbers to lookup contact points for</param>
-    /// <param name="ignoreNotificationStatus">A boolean indicating whether to ignore the notification status.</param>
+    /// <param name="skipAgeCheck">A boolean indicating whether to skip the age check for contact points.</param>
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
     /// <returns>The users' contact points and reservation status or a boolean if failure.</returns>
-    Task<UserContactPointsList> GetContactPoints(List<string> nationalIdentityNumbers, bool ignoreNotificationStatus, CancellationToken cancellationToken);
+    Task<UserContactPointsList> GetContactPoints(List<string> nationalIdentityNumbers, bool skipAgeCheck, CancellationToken cancellationToken);
 
     /// <summary>
     /// Retrieves the self-identified users' contact points associated with the specified external identities.

--- a/src/Altinn.Profile.Core/User.ContactPoints/UserContactPointService.cs
+++ b/src/Altinn.Profile.Core/User.ContactPoints/UserContactPointService.cs
@@ -59,7 +59,7 @@ public class UserContactPointService : IUserContactPointsService
 
     /// <inheritdoc/>
     public async Task<UserContactPointsList> GetContactPoints(
-        List<string> nationalIdentityNumbers, bool ignoreNotificationStatus, CancellationToken cancellationToken)
+        List<string> nationalIdentityNumbers, bool skipAgeCheck, CancellationToken cancellationToken)
     {
         UserContactPointsList resultList = new();
         DateTime cutoffDate = DateTime.UtcNow.AddMonths(-ActiveContactPointMonths);
@@ -68,10 +68,10 @@ public class UserContactPointService : IUserContactPointsService
 
         foreach (var contactPreference in contactPreferences)
         {
-            var emailTooOld = IsContactPointTooOld(contactPreference.EmailLastTouched, cutoffDate);
-            var mobileTooOld = IsContactPointTooOld(contactPreference.MobileNumberLastTouched, cutoffDate);
+            var emailTooOld = IsContactPointTooOld(contactPreference.EmailLastTouched, cutoffDate, skipAgeCheck);
+            var mobileTooOld = IsContactPointTooOld(contactPreference.MobileNumberLastTouched, cutoffDate, skipAgeCheck);
             
-            if (!ignoreNotificationStatus && mobileTooOld && emailTooOld)
+            if (mobileTooOld && emailTooOld)
             {
                 continue;
             }
@@ -80,8 +80,8 @@ public class UserContactPointService : IUserContactPointsService
                 new UserContactPoints()
                 {
                     NationalIdentityNumber = contactPreference.NationalIdentityNumber,
-                    Email = emailTooOld && !ignoreNotificationStatus ? null : contactPreference.Email,
-                    MobileNumber = mobileTooOld && !ignoreNotificationStatus ? null : contactPreference.MobileNumber,
+                    Email = emailTooOld ? null : contactPreference.Email,
+                    MobileNumber = mobileTooOld ? null : contactPreference.MobileNumber,
                     IsReserved = contactPreference.IsReserved
                 });
         }
@@ -117,9 +117,9 @@ public class UserContactPointService : IUserContactPointsService
         return contactPointsList;
     }
 
-    private static bool IsContactPointTooOld(DateTime? lastTouched, DateTime cutoffDate)
+    private static bool IsContactPointTooOld(DateTime? lastTouched, DateTime cutoffDate, bool skipAgeCheck)
     {
-        return !lastTouched.HasValue || lastTouched.Value < cutoffDate;
+        return !skipAgeCheck && (!lastTouched.HasValue || lastTouched.Value < cutoffDate);
     }
 
     private async Task<SiUserContactPoints?> ProcessIdPortenEmail(IDPortenEmail idportenEmail, string urnIdentifier, CancellationToken cancellationToken)

--- a/src/Altinn.Profile.Core/User.ContactPoints/UserContactPointService.cs
+++ b/src/Altinn.Profile.Core/User.ContactPoints/UserContactPointService.cs
@@ -13,6 +13,8 @@ namespace Altinn.Profile.Core.User.ContactPoints;
 /// </summary>
 public class UserContactPointService : IUserContactPointsService
 {
+    private const int ActiveContactPointMonths = 18;
+
     private readonly IUserProfileService _userProfileService;
     private readonly IPersonService _personService;
     private readonly IUserContactInfoRepository _userContactInfoRepository;
@@ -56,23 +58,31 @@ public class UserContactPointService : IUserContactPointsService
     }
 
     /// <inheritdoc/>
-    public async Task<UserContactPointsList> GetContactPoints(List<string> nationalIdentityNumbers, CancellationToken cancellationToken)
+    public async Task<UserContactPointsList> GetContactPoints(
+        List<string> nationalIdentityNumbers, bool ignoreNotificationStatus, CancellationToken cancellationToken)
     {
         UserContactPointsList resultList = new();
+        DateTime cutoffDate = DateTime.UtcNow.AddMonths(-ActiveContactPointMonths);
 
         var contactPreferences = await _personService.GetContactPreferencesAsync(nationalIdentityNumbers, cancellationToken);
 
         foreach (var contactPreference in contactPreferences)
         {
+            var emailTooOld = IsContactPointTooOld(contactPreference.EmailLastTouched, cutoffDate);
+            var mobileTooOld = IsContactPointTooOld(contactPreference.MobileNumberLastTouched, cutoffDate);
+            
+            if (!ignoreNotificationStatus && mobileTooOld && emailTooOld)
+            {
+                continue;
+            }
+
             resultList.ContactPointsList.Add(
                 new UserContactPoints()
                 {
                     NationalIdentityNumber = contactPreference.NationalIdentityNumber,
-                    Email = contactPreference.Email,
-                    MobileNumber = contactPreference.MobileNumber,
-                    IsReserved = contactPreference.IsReserved,
-                    MobileNumberLastTouched = contactPreference.MobileNumberLastTouched,
-                    EmailLastTouched = contactPreference.EmailLastTouched
+                    Email = emailTooOld && !ignoreNotificationStatus ? null : contactPreference.Email,
+                    MobileNumber = mobileTooOld && !ignoreNotificationStatus ? null : contactPreference.MobileNumber,
+                    IsReserved = contactPreference.IsReserved
                 });
         }
 
@@ -105,6 +115,11 @@ public class UserContactPointService : IUserContactPointsService
         }
 
         return contactPointsList;
+    }
+
+    private static bool IsContactPointTooOld(DateTime? lastTouched, DateTime cutoffDate)
+    {
+        return !lastTouched.HasValue || lastTouched.Value < cutoffDate;
     }
 
     private async Task<SiUserContactPoints?> ProcessIdPortenEmail(IDPortenEmail idportenEmail, string urnIdentifier, CancellationToken cancellationToken)

--- a/src/Altinn.Profile.Core/User.ContactPoints/UserContactPointService.cs
+++ b/src/Altinn.Profile.Core/User.ContactPoints/UserContactPointService.cs
@@ -59,7 +59,7 @@ public class UserContactPointService : IUserContactPointsService
 
     /// <inheritdoc/>
     public async Task<UserContactPointsList> GetContactPoints(
-        List<string> nationalIdentityNumbers, bool skipAgeCheck, CancellationToken cancellationToken)
+        List<string> nationalIdentityNumbers, bool useStaleContactInfo, CancellationToken cancellationToken)
     {
         UserContactPointsList resultList = new();
         DateTime cutoffDate = DateTime.UtcNow.AddMonths(-ActiveContactPointMonths);
@@ -68,8 +68,8 @@ public class UserContactPointService : IUserContactPointsService
 
         foreach (var contactPreference in contactPreferences)
         {
-            var emailTooOld = IsContactPointTooOld(contactPreference.EmailLastTouched, cutoffDate, skipAgeCheck);
-            var mobileTooOld = IsContactPointTooOld(contactPreference.MobileNumberLastTouched, cutoffDate, skipAgeCheck);
+            var emailTooOld = IsContactPointTooOld(contactPreference.EmailLastTouched, cutoffDate, useStaleContactInfo);
+            var mobileTooOld = IsContactPointTooOld(contactPreference.MobileNumberLastTouched, cutoffDate, useStaleContactInfo);
             
             if (mobileTooOld && emailTooOld)
             {
@@ -117,9 +117,9 @@ public class UserContactPointService : IUserContactPointsService
         return contactPointsList;
     }
 
-    private static bool IsContactPointTooOld(DateTime? lastTouched, DateTime cutoffDate, bool skipAgeCheck)
+    private static bool IsContactPointTooOld(DateTime? lastTouched, DateTime cutoffDate, bool useStaleContactInfo)
     {
-        return !skipAgeCheck && (!lastTouched.HasValue || lastTouched.Value < cutoffDate);
+        return !useStaleContactInfo && (!lastTouched.HasValue || lastTouched.Value < cutoffDate);
     }
 
     private async Task<SiUserContactPoints?> ProcessIdPortenEmail(IDPortenEmail idportenEmail, string urnIdentifier, CancellationToken cancellationToken)

--- a/src/Altinn.Profile.Core/User.ContactPoints/UserContactPoints.cs
+++ b/src/Altinn.Profile.Core/User.ContactPoints/UserContactPoints.cs
@@ -29,16 +29,6 @@ public class UserContactPoints
     /// Gets or sets the email address
     /// </summary>
     public string? Email { get; set; }
-
-    /// <summary>
-    /// Gets or sets the timestamp for when the mobile number was last updated by the user.
-    /// </summary>
-    public DateTime? MobileNumberLastTouched { get; set; }
-
-    /// <summary>
-    /// Gets or sets the timestamp for when the email address was last updated by the user.
-    /// </summary>
-    public DateTime? EmailLastTouched { get; set; }
 }
 
 /// <summary>

--- a/src/Altinn.Profile/Controllers/UserContactPointController.cs
+++ b/src/Altinn.Profile/Controllers/UserContactPointController.cs
@@ -61,7 +61,7 @@ public class UserContactPointController : ControllerBase
         }
 
         UserContactPointsList userContactPointsList = await _contactPointService.GetContactPoints(
-            userContactPointLookup.NationalIdentityNumbers, userContactPointLookup.SkipAgeCheck, cancellationToken);
+            userContactPointLookup.NationalIdentityNumbers, userContactPointLookup.UseStaleContactInfo, cancellationToken);
 
         return Ok(userContactPointsList);
     }

--- a/src/Altinn.Profile/Controllers/UserContactPointController.cs
+++ b/src/Altinn.Profile/Controllers/UserContactPointController.cs
@@ -60,7 +60,9 @@ public class UserContactPointController : ControllerBase
             return Ok(new UserContactPointsList());
         }
 
-        UserContactPointsList userContactPointsList = await _contactPointService.GetContactPoints(userContactPointLookup.NationalIdentityNumbers, cancellationToken);
+        UserContactPointsList userContactPointsList = await _contactPointService.GetContactPoints(
+            userContactPointLookup.NationalIdentityNumbers, userContactPointLookup.IgnoreNotificationStatus, cancellationToken);
+
         return Ok(userContactPointsList);
     }
 

--- a/src/Altinn.Profile/Controllers/UserContactPointController.cs
+++ b/src/Altinn.Profile/Controllers/UserContactPointController.cs
@@ -61,7 +61,7 @@ public class UserContactPointController : ControllerBase
         }
 
         UserContactPointsList userContactPointsList = await _contactPointService.GetContactPoints(
-            userContactPointLookup.NationalIdentityNumbers, userContactPointLookup.IgnoreNotificationStatus, cancellationToken);
+            userContactPointLookup.NationalIdentityNumbers, userContactPointLookup.SkipAgeCheck, cancellationToken);
 
         return Ok(userContactPointsList);
     }

--- a/src/Altinn.Profile/Models/UserContactDetailsLookupCriteria.cs
+++ b/src/Altinn.Profile/Models/UserContactDetailsLookupCriteria.cs
@@ -13,9 +13,8 @@ public class UserContactDetailsLookupCriteria
     public List<string> NationalIdentityNumbers { get; set; } = [];
 
     /// <summary>
-    /// Indicates whether the lookup should ignore the notification status of the contact points. If set to true, 
-    /// contact points will be returned regardless of their notification status.
-    /// Notification status is determined by the age of the contact point or time since last verification.
+    /// Indicates whether the lookup should skip the age check for contact points. If set to true, 
+    /// contact points will be returned regardless of their age.
     /// </summary>
-    public bool IgnoreNotificationStatus { get; set; } = false;
+    public bool SkipAgeCheck { get; set; } = false;
 }

--- a/src/Altinn.Profile/Models/UserContactDetailsLookupCriteria.cs
+++ b/src/Altinn.Profile/Models/UserContactDetailsLookupCriteria.cs
@@ -16,5 +16,5 @@ public class UserContactDetailsLookupCriteria
     /// Indicates whether the lookup should skip the age check for contact points. If set to true, 
     /// contact points will be returned regardless of their age.
     /// </summary>
-    public bool SkipAgeCheck { get; set; } = false;
+    public bool UseStaleContactInfo { get; set; } = false;
 }

--- a/src/Altinn.Profile/Models/UserContactDetailsLookupCriteria.cs
+++ b/src/Altinn.Profile/Models/UserContactDetailsLookupCriteria.cs
@@ -11,4 +11,11 @@ public class UserContactDetailsLookupCriteria
     /// A collection of national identity numbers used to retrieve contact points, obtain contact details, or check the availability of contact points.
     /// </summary>
     public List<string> NationalIdentityNumbers { get; set; } = [];
+
+    /// <summary>
+    /// Indicates whether the lookup should ignore the notification status of the contact points. If set to true, 
+    /// contact points will be returned regardless of their notification status.
+    /// Notification status is determined by the age of the contact point or time since last verification.
+    /// </summary>
+    public bool IgnoreNotificationStatus { get; set; } = false;
 }

--- a/test/Altinn.Profile.Tests/Profile.Core/User/UserContactPointServiceTest.cs
+++ b/test/Altinn.Profile.Tests/Profile.Core/User/UserContactPointServiceTest.cs
@@ -98,7 +98,7 @@ public class UserContactPointServiceTest
     }
 
     [Fact]
-    public async Task GetContactPoints_WhenSkipAgeCheckIsFalse_IsSuccessAndFiltersOutOldAddresses()
+    public async Task GetContactPoints_WhenUseStaleContactInfoIsFalse_IsSuccessAndFiltersOutOldAddresses()
     {
         // Arrange
         List<UserContactPoints> expectedUsers = await MockTestUsers();
@@ -123,7 +123,7 @@ public class UserContactPointServiceTest
     }
 
     [Fact]
-    public async Task GetContactPoints_WhenSkipAgeCheckIsTrue_IsSuccessAndKeepsOldAddresses()
+    public async Task GetContactPoints_WhenUseStaleContactInfoIsTrue_IsSuccessAndKeepsOldAddresses()
     {
         // Arrange
         List<UserContactPoints> expectedUsers = await MockTestUsers();

--- a/test/Altinn.Profile.Tests/Profile.Core/User/UserContactPointServiceTest.cs
+++ b/test/Altinn.Profile.Tests/Profile.Core/User/UserContactPointServiceTest.cs
@@ -98,7 +98,7 @@ public class UserContactPointServiceTest
     }
 
     [Fact]
-    public async Task GetContactPoints_WhenPersonServiceIsCalled_IsSuccessAndFiltersOutOldAddresses()
+    public async Task GetContactPoints_WhenSkipAgeCheckIsFalse_IsSuccessAndFiltersOutOldAddresses()
     {
         // Arrange
         List<UserContactPoints> expectedUsers = await MockTestUsers();
@@ -123,7 +123,7 @@ public class UserContactPointServiceTest
     }
 
     [Fact]
-    public async Task GetContactPoints_WhenPersonServiceIsCalled_IsSuccessAndKeepsOldAddresses()
+    public async Task GetContactPoints_WhenSkipAgeCheckIsTrue_IsSuccessAndKeepsOldAddresses()
     {
         // Arrange
         List<UserContactPoints> expectedUsers = await MockTestUsers();

--- a/test/Altinn.Profile.Tests/Profile.Core/User/UserContactPointServiceTest.cs
+++ b/test/Altinn.Profile.Tests/Profile.Core/User/UserContactPointServiceTest.cs
@@ -142,7 +142,11 @@ public class UserContactPointServiceTest
         // Assert
         Assert.Equal(3, result.ContactPointsList.Count);
         Assert.Contains(result.ContactPointsList, ob => AreEqualUserContactPoints(ob, expectedUsers[0]));
-        /* The second user has an old email address, but a valid mobile number, so should be included in the results with the email address filtered out, but the mobile number intact */
+        Assert.Contains(result.ContactPointsList, ob =>
+            ob.NationalIdentityNumber == expectedUsers[1].NationalIdentityNumber &&
+            ob.Email == "tuva@business.com" &&
+            ob.MobileNumber == expectedUsers[1].MobileNumber &&
+            ob.IsReserved == expectedUsers[1].IsReserved);
         Assert.Contains(result.ContactPointsList, ob => AreEqualUserContactPoints(ob, expectedUsers[2]));
 
         _personServiceMock.Verify(service => service.GetContactPreferencesAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()), Times.Exactly(1));

--- a/test/Altinn.Profile.Tests/Profile.Core/User/UserContactPointServiceTest.cs
+++ b/test/Altinn.Profile.Tests/Profile.Core/User/UserContactPointServiceTest.cs
@@ -30,6 +30,8 @@ public class UserContactPointServiceTest
 
     private static readonly string _userIdBStr = "2001607";
 
+    private static readonly string _userIdCStr = "2001608";
+
     private async Task<List<UserContactPoints>> MockTestUsers() // Take a look at IAsyncLifetime / InitializeAsync from XUnit, as something for next time
     {
         var userProfileA = await TestDataLoader.Load<UserProfile>(_userIdAStr);
@@ -48,8 +50,6 @@ public class UserContactPointServiceTest
             NationalIdentityNumber = userProfileA.Party.SSN,
             IsReserved = userProfileA.IsReserved,
             MobileNumber = userProfileA.PhoneNumber,
-            MobileNumberLastTouched = contactPreferencesA.MobileNumberLastTouched,
-            EmailLastTouched = contactPreferencesA.EmailLastTouched,
         };
 
         var userProfileB = await TestDataLoader.Load<UserProfile>(_userIdBStr);
@@ -64,23 +64,41 @@ public class UserContactPointServiceTest
         };
         var expectedUserContactPointB = new UserContactPoints()
         {
-            Email = userProfileB.Email,
+            Email = null,
             NationalIdentityNumber = userProfileB.Party.SSN,
             IsReserved = userProfileB.IsReserved,
             MobileNumber = userProfileB.PhoneNumber,
-            MobileNumberLastTouched = contactPreferencesB.MobileNumberLastTouched,
-            EmailLastTouched = contactPreferencesB.EmailLastTouched,
+        };
+
+        var userProfileC = await TestDataLoader.Load<UserProfile>(_userIdCStr);
+        var contactPreferencesC = new PersonContactPreferences()
+        {
+            NationalIdentityNumber = _userIdCStr,
+            Email = userProfileC.Email,
+            IsReserved = userProfileC.IsReserved,
+            MobileNumber = userProfileC.PhoneNumber,
+            MobileNumberLastTouched = DateTime.UtcNow.AddMonths(-26),
+            EmailLastTouched = DateTime.UtcNow.AddMonths(-26),
+        };
+        var expectedUserContactPointC = new UserContactPoints()
+        {
+            Email = userProfileC.Email,
+            NationalIdentityNumber = _userIdCStr,
+            IsReserved = userProfileC.IsReserved,
+            MobileNumber = userProfileC.PhoneNumber,
         };
 
         _userProfileServiceMock.Setup(m => m.GetUser(userProfileA.Party.SSN, It.IsAny<CancellationToken>())).ReturnsAsync(userProfileA);
         _userProfileServiceMock.Setup(m => m.GetUser(userProfileB.Party.SSN, It.IsAny<CancellationToken>())).ReturnsAsync(userProfileB);
-        _personServiceMock.Setup(m => m.GetContactPreferencesAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>())).ReturnsAsync([contactPreferencesA, contactPreferencesB]);
+        _userProfileServiceMock.Setup(m => m.GetUser(userProfileC.Party.SSN, It.IsAny<CancellationToken>())).ReturnsAsync(userProfileC);
+        _personServiceMock.Setup(m => m.GetContactPreferencesAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([contactPreferencesA, contactPreferencesB, contactPreferencesC]);
 
-        return [expectedUserContactPointA, expectedUserContactPointB];
+        return [expectedUserContactPointA, expectedUserContactPointB, expectedUserContactPointC];
     }
 
     [Fact]
-    public async Task GetContactPoints_WhenPersonServiceIsCalled_IsSuccess()
+    public async Task GetContactPoints_WhenPersonServiceIsCalled_IsSuccessAndFiltersOutOldAddresses()
     {
         // Arrange
         List<UserContactPoints> expectedUsers = await MockTestUsers();
@@ -91,13 +109,41 @@ public class UserContactPointServiceTest
             [
                 expectedUsers[0].NationalIdentityNumber,
                 expectedUsers[1].NationalIdentityNumber,
+                expectedUsers[2].NationalIdentityNumber,
             ],
+            false,
             TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(2, result.ContactPointsList.Count);
         Assert.Contains(result.ContactPointsList, ob => AreEqualUserContactPoints(ob, expectedUsers[0]));
         Assert.Contains(result.ContactPointsList, ob => AreEqualUserContactPoints(ob, expectedUsers[1]));
+
+        _personServiceMock.Verify(service => service.GetContactPreferencesAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
+    }
+
+    [Fact]
+    public async Task GetContactPoints_WhenPersonServiceIsCalled_IsSuccessAndKeepsOldAddresses()
+    {
+        // Arrange
+        List<UserContactPoints> expectedUsers = await MockTestUsers();
+        var target = new UserContactPointService(_userProfileServiceMock.Object, _personServiceMock.Object, _userContactInfoRepositoryMock.Object, _loggerMock.Object);
+
+        // Act
+        UserContactPointsList result = await target.GetContactPoints(
+            [
+                expectedUsers[0].NationalIdentityNumber,
+                expectedUsers[1].NationalIdentityNumber,
+                expectedUsers[2].NationalIdentityNumber,
+            ],
+            true,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(3, result.ContactPointsList.Count);
+        Assert.Contains(result.ContactPointsList, ob => AreEqualUserContactPoints(ob, expectedUsers[0]));
+        /* The second user has an old email address, but a valid mobile number, so should be included in the results with the email address filtered out, but the mobile number intact */
+        Assert.Contains(result.ContactPointsList, ob => AreEqualUserContactPoints(ob, expectedUsers[2]));
 
         _personServiceMock.Verify(service => service.GetContactPreferencesAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
     }
@@ -115,6 +161,7 @@ public class UserContactPointServiceTest
                 expectedUsers[0].NationalIdentityNumber,
                 expectedUsers[1].NationalIdentityNumber
             ],
+            false,
             CancellationToken.None);
 
         // Assert
@@ -126,9 +173,7 @@ public class UserContactPointServiceTest
         return a.NationalIdentityNumber == b.NationalIdentityNumber &&
             a.Email == b.Email &&
             a.IsReserved == b.IsReserved &&
-            a.MobileNumber == b.MobileNumber &&
-            a.MobileNumberLastTouched == b.MobileNumberLastTouched &&
-            a.EmailLastTouched == b.EmailLastTouched;
+            a.MobileNumber == b.MobileNumber;
     }
 
     [Fact]


### PR DESCRIPTION
## Description
Profile should by default prevent the usage of outdated notification addresses, but there are exceptions where we still need to expose the addresses for Notifications.

## Related Issue(s)
- Private issue 502.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Contact point lookup now supports a "skip age check" option to return contact points regardless of age.

* **Refactor**
  * Activity-based filtering added to contact point retrieval.
  * Contact point responses simplified by removing historical timestamp fields.

* **Tests**
  * Unit tests updated to cover the new age-check behavior and revised response shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->