### PR TITLE
Feature/private issue 502 return contact information status

### DIFF
--- a/src/Altinn.Profile.Core/User.ContactPoints/IUserContactPointsService.cs
+++ b/src/Altinn.Profile.Core/User.ContactPoints/IUserContactPointsService.cs
@@ -9,10 +9,10 @@ public interface IUserContactPointsService
     /// Method for retriveing contact points for a user 
     /// </summary>
     /// <param name="nationalIdentityNumbers">A list of national identity numbers to lookup contact points for</param>
-    /// <param name="useStaleContactInfo">A boolean indicating whether to skip the age check for contact points.</param>
+    /// <param name="includeOutdatedContactInfo">A boolean indicating whether to include outdated contact information.</param>
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
     /// <returns>The users' contact points and reservation status or a boolean if failure.</returns>
-    Task<UserContactPointsList> GetContactPoints(List<string> nationalIdentityNumbers, bool useStaleContactInfo, CancellationToken cancellationToken);
+    Task<UserContactPointsList> GetContactPoints(List<string> nationalIdentityNumbers, bool includeOutdatedContactInfo, CancellationToken cancellationToken);
 
     /// <summary>
     /// Retrieves the self-identified users' contact points associated with the specified external identities.

--- a/src/Altinn.Profile.Core/User.ContactPoints/UserContactPointService.cs
+++ b/src/Altinn.Profile.Core/User.ContactPoints/UserContactPointService.cs
@@ -68,10 +68,11 @@ public class UserContactPointService : IUserContactPointsService
 
         foreach (var contactPreference in contactPreferences)
         {
-            var emailTooOld = IsContactPointTooOld(contactPreference.EmailLastTouched, cutoffDate);
-            var mobileTooOld = IsContactPointTooOld(contactPreference.MobileNumberLastTouched, cutoffDate);
-            
-            if (!includeOutdatedContactInfo && mobileTooOld && emailTooOld)
+            bool emailIsOutdated = IsContactPointTooOld(contactPreference.EmailLastTouched, cutoffDate);
+            bool mobileIsOutdated = IsContactPointTooOld(contactPreference.MobileNumberLastTouched, cutoffDate);
+
+            bool bothContactPointsOutdated = emailIsOutdated && mobileIsOutdated;
+            if (!includeOutdatedContactInfo && bothContactPointsOutdated)
             {
                 continue;
             }
@@ -79,12 +80,13 @@ public class UserContactPointService : IUserContactPointsService
             UserContactPoints contactPoint = new()
             {
                 NationalIdentityNumber = contactPreference.NationalIdentityNumber,
-                Email = includeOutdatedContactInfo || !emailTooOld ? contactPreference.Email : null,
-                EmailIsOutdated = emailTooOld,
-                MobileNumber = includeOutdatedContactInfo || !mobileTooOld ? contactPreference.MobileNumber : null,
-                MobileNumberIsOutdated = mobileTooOld,
+                Email = emailIsOutdated && !includeOutdatedContactInfo ? null : contactPreference.Email,
+                EmailIsOutdated = emailIsOutdated,
+                MobileNumber = mobileIsOutdated && !includeOutdatedContactInfo ? null : contactPreference.MobileNumber,
+                MobileNumberIsOutdated = mobileIsOutdated,
                 IsReserved = contactPreference.IsReserved
             };
+
             resultList.ContactPointsList.Add(contactPoint);
         }
 

--- a/src/Altinn.Profile.Core/User.ContactPoints/UserContactPointService.cs
+++ b/src/Altinn.Profile.Core/User.ContactPoints/UserContactPointService.cs
@@ -59,7 +59,7 @@ public class UserContactPointService : IUserContactPointsService
 
     /// <inheritdoc/>
     public async Task<UserContactPointsList> GetContactPoints(
-        List<string> nationalIdentityNumbers, bool useStaleContactInfo, CancellationToken cancellationToken)
+        List<string> nationalIdentityNumbers, bool includeOutdatedContactInfo, CancellationToken cancellationToken)
     {
         UserContactPointsList resultList = new();
         DateTime cutoffDate = DateTime.UtcNow.AddMonths(-ActiveContactPointMonths);
@@ -68,22 +68,24 @@ public class UserContactPointService : IUserContactPointsService
 
         foreach (var contactPreference in contactPreferences)
         {
-            var emailTooOld = IsContactPointTooOld(contactPreference.EmailLastTouched, cutoffDate, useStaleContactInfo);
-            var mobileTooOld = IsContactPointTooOld(contactPreference.MobileNumberLastTouched, cutoffDate, useStaleContactInfo);
+            var emailTooOld = IsContactPointTooOld(contactPreference.EmailLastTouched, cutoffDate);
+            var mobileTooOld = IsContactPointTooOld(contactPreference.MobileNumberLastTouched, cutoffDate);
             
-            if (mobileTooOld && emailTooOld)
+            if (!includeOutdatedContactInfo && mobileTooOld && emailTooOld)
             {
                 continue;
             }
 
-            resultList.ContactPointsList.Add(
-                new UserContactPoints()
-                {
-                    NationalIdentityNumber = contactPreference.NationalIdentityNumber,
-                    Email = emailTooOld ? null : contactPreference.Email,
-                    MobileNumber = mobileTooOld ? null : contactPreference.MobileNumber,
-                    IsReserved = contactPreference.IsReserved
-                });
+            UserContactPoints contactPoint = new()
+            {
+                NationalIdentityNumber = contactPreference.NationalIdentityNumber,
+                Email = includeOutdatedContactInfo || !emailTooOld ? contactPreference.Email : null,
+                EmailIsOutdated = emailTooOld,
+                MobileNumber = includeOutdatedContactInfo || !mobileTooOld ? contactPreference.MobileNumber : null,
+                MobileNumberIsOutdated = mobileTooOld,
+                IsReserved = contactPreference.IsReserved
+            };
+            resultList.ContactPointsList.Add(contactPoint);
         }
 
         return resultList;
@@ -117,9 +119,9 @@ public class UserContactPointService : IUserContactPointsService
         return contactPointsList;
     }
 
-    private static bool IsContactPointTooOld(DateTime? lastTouched, DateTime cutoffDate, bool useStaleContactInfo)
+    private static bool IsContactPointTooOld(DateTime? lastTouched, DateTime cutoffDate)
     {
-        return !useStaleContactInfo && (!lastTouched.HasValue || lastTouched.Value < cutoffDate);
+        return !lastTouched.HasValue || lastTouched.Value < cutoffDate;
     }
 
     private async Task<SiUserContactPoints?> ProcessIdPortenEmail(IDPortenEmail idportenEmail, string urnIdentifier, CancellationToken cancellationToken)

--- a/src/Altinn.Profile.Core/User.ContactPoints/UserContactPoints.cs
+++ b/src/Altinn.Profile.Core/User.ContactPoints/UserContactPoints.cs
@@ -26,9 +26,19 @@ public class UserContactPoints
     public string? MobileNumber { get; set; }
 
     /// <summary>
+    /// Gets or sets a boolean indicating whether the mobile number is outdated
+    /// </summary>
+    public bool MobileNumberIsOutdated { get; set; }
+
+    /// <summary>
     /// Gets or sets the email address
     /// </summary>
     public string? Email { get; set; }
+    
+    /// <summary>
+    /// Gets or sets a boolean indicating whether the email address is outdated
+    /// </summary>
+    public bool EmailIsOutdated { get; set; }
 }
 
 /// <summary>

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/UserContactPointControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/UserContactPointControllerTests.cs
@@ -96,7 +96,7 @@ public class UserContactPointControllerTests : IClassFixture<ProfileWebApplicati
     [Fact]
     public async Task PostAvailabilityLookup_SingleUser_DetailsReturned()
     {
-        // Arrange       
+        // Arrange
         UserContactDetailsLookupCriteria input = new()
         {
             NationalIdentityNumbers = new List<string>() { "01025101037" }
@@ -121,7 +121,7 @@ public class UserContactPointControllerTests : IClassFixture<ProfileWebApplicati
     [Fact]
     public async Task PostAvailabilityLookup_SingleProfileNotFoundInBridge_RemainingUsersReturned()
     {
-        // Arrange       
+        // Arrange
         UserContactDetailsLookupCriteria input = new()
         {
             NationalIdentityNumbers = new List<string>() { "01025101037", "99999999999" }
@@ -146,7 +146,7 @@ public class UserContactPointControllerTests : IClassFixture<ProfileWebApplicati
     [Fact]
     public async Task PostLookup_NoNationalIdentityNumbers_EmptyListReturned()
     {
-        // Arrange       
+        // Arrange
         UserContactDetailsLookupCriteria input = new()
         {
             NationalIdentityNumbers = new List<string>() { }
@@ -170,7 +170,7 @@ public class UserContactPointControllerTests : IClassFixture<ProfileWebApplicati
     [Fact]
     public async Task PostLookup_SingleProfileNotFoundInBridge_RemainingUsersReturned()
     {
-        // Arrange       
+        // Arrange
         UserContactDetailsLookupCriteria input = new()
         {
             NationalIdentityNumbers = new List<string>() { "01025101037", "01025101038", "99999999999" }
@@ -196,7 +196,7 @@ public class UserContactPointControllerTests : IClassFixture<ProfileWebApplicati
     [Fact]
     public async Task PostLookup_SingleUser_DetailsReturned()
     {
-        // Arrange       
+        // Arrange
         UserContactDetailsLookupCriteria input = new()
         {
             NationalIdentityNumbers = new List<string>() { "01025101037" }

--- a/test/Altinn.Profile.Tests/Profile.Core/User/UserContactPointServiceTest.cs
+++ b/test/Altinn.Profile.Tests/Profile.Core/User/UserContactPointServiceTest.cs
@@ -68,6 +68,7 @@ public class UserContactPointServiceTest
             NationalIdentityNumber = userProfileB.Party.SSN,
             IsReserved = userProfileB.IsReserved,
             MobileNumber = userProfileB.PhoneNumber,
+            EmailIsOutdated = true
         };
 
         var userProfileC = await TestDataLoader.Load<UserProfile>(_userIdCStr);
@@ -82,10 +83,12 @@ public class UserContactPointServiceTest
         };
         var expectedUserContactPointC = new UserContactPoints()
         {
-            Email = userProfileC.Email,
             NationalIdentityNumber = _userIdCStr,
             IsReserved = userProfileC.IsReserved,
+            Email = userProfileC.Email,
+            EmailIsOutdated = true,
             MobileNumber = userProfileC.PhoneNumber,
+            MobileNumberIsOutdated = true
         };
 
         _userProfileServiceMock.Setup(m => m.GetUser(userProfileA.Party.SSN, It.IsAny<CancellationToken>())).ReturnsAsync(userProfileA);
@@ -176,8 +179,10 @@ public class UserContactPointServiceTest
     {
         return a.NationalIdentityNumber == b.NationalIdentityNumber &&
             a.Email == b.Email &&
-            a.IsReserved == b.IsReserved &&
-            a.MobileNumber == b.MobileNumber;
+            a.EmailIsOutdated == b.EmailIsOutdated &&
+            a.MobileNumber == b.MobileNumber &&
+            a.MobileNumberIsOutdated == b.MobileNumberIsOutdated &&
+            a.IsReserved == b.IsReserved;
     }
 
     [Fact]


### PR DESCRIPTION
## Description
Adding EmailIsOutdated and MobileNumberIsOutdated and setting the values based on the last touched value and an 18 month cut off date. This mirrors a little bit better what we're doing with the IsReservable value. 

Profile determines if the data is out dated, while Notifications can choose to use the data despite the out dated status.

## Related Issue(s)
- Private issue 502 follow up.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit indicators to show whether email and mobile contact information is outdated.
  * Enhanced control over including or excluding outdated contact information in lookups.

* **Improvements**
  * Refined logic for determining when contact information is considered outdated based on last-modified date.

* **Tests**
  * Updated test coverage to validate outdated contact information handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->