### PR TITLE
Rewrite from registerClientMock to use delegating handler stub

### DIFF
--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/DashboardContactInformationControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/DashboardContactInformationControllerTests.cs
@@ -18,8 +18,6 @@ using Moq;
 
 using Xunit;
 
-using RegisterParty = Altinn.Profile.Core.Unit.ContactPoints.Party;
-
 namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
 {
     public class DashboardContactInformationControllerTests : IClassFixture<ProfileWebApplicationFactory<Program>>
@@ -70,14 +68,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
             string orgNumber = "123456789";
             Guid partyUuid = Guid.NewGuid();
 
-            // Mock Register Client - translate org number to party UUID
-            var parties = new List<RegisterParty>
-            {
-                new() { PartyId = 12345, PartyUuid = partyUuid, OrganizationIdentifier = orgNumber }
-            };
-            _factory.RegisterClientMock
-                .Setup(r => r.GetPartyUuids(It.Is<string[]>(arr => arr.Length == 1 && arr[0] == orgNumber), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(parties);
+            SetupRegisterPartyUuidsLookup(orgNumber, partyUuid);
 
             // Mock ProfessionalNotificationsRepository - return contact info for multiple users
             var contactInfos = new List<UserPartyContactInfo>
@@ -140,13 +131,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
             string orgNumber = "987654321";
             Guid partyUuid = Guid.NewGuid();
 
-            var parties = new List<RegisterParty>
-            {
-                new() { PartyId = 12345, PartyUuid = partyUuid, OrganizationIdentifier = orgNumber }
-            };
-            _factory.RegisterClientMock
-                .Setup(r => r.GetPartyUuids(It.Is<string[]>(arr => arr.Length == 1 && arr[0] == orgNumber), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(parties);
+            SetupRegisterPartyUuidsLookup(orgNumber, partyUuid);
 
             _factory.ProfessionalNotificationsRepositoryMock
                 .Setup(r => r.GetAllNotificationAddressesForPartyAsync(partyUuid, It.IsAny<CancellationToken>()))
@@ -174,9 +159,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
             // Arrange
             string orgNumber = "888888888";
 
-            _factory.RegisterClientMock
-                .Setup(r => r.GetPartyUuids(It.Is<string[]>(arr => arr.Length == 1 && arr[0] == orgNumber), It.IsAny<CancellationToken>()))
-                .ReturnsAsync([]);
+            SetupRegisterPartyUuidsLookup(orgNumber);
 
             HttpClient client = _factory.CreateClient();
             HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, $"/profile/api/v1/dashboard/organizations/{orgNumber}/contactinformation");
@@ -238,13 +221,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
             string orgNumber = "111222333";
             Guid partyUuid = Guid.NewGuid();
 
-            var parties = new List<RegisterParty>
-            {
-                new() { PartyId = 12345, PartyUuid = partyUuid, OrganizationIdentifier = orgNumber }
-            };
-            _factory.RegisterClientMock
-                .Setup(r => r.GetPartyUuids(It.Is<string[]>(arr => arr.Length == 1 && arr[0] == orgNumber), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(parties);
+            SetupRegisterPartyUuidsLookup(orgNumber, partyUuid);
 
             var contactInfos = new List<UserPartyContactInfo>
             {
@@ -300,14 +277,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
             Guid partyUuid1 = Guid.NewGuid();
             Guid partyUuid2 = Guid.NewGuid();
 
-            var parties = new List<RegisterParty>
-            {
-                new() { PartyId = 12345, PartyUuid = partyUuid1, OrganizationIdentifier = orgNumber },
-                new() { PartyId = 67890, PartyUuid = partyUuid2, OrganizationIdentifier = orgNumber }
-            };
-            _factory.RegisterClientMock
-                .Setup(r => r.GetPartyUuids(It.Is<string[]>(arr => arr.Length == 1 && arr[0] == orgNumber), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(parties);
+            SetupRegisterPartyUuidsLookup(orgNumber, partyUuid1, partyUuid2);
 
             HttpClient client = _factory.CreateClient();
             HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, $"/profile/api/v1/dashboard/organizations/{orgNumber}/contactinformation");
@@ -341,13 +311,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
             string orgNumber = "555666777";
             Guid partyUuid = Guid.NewGuid();
 
-            var parties = new List<RegisterParty>
-            {
-                new() { PartyId = 12345, PartyUuid = partyUuid, OrganizationIdentifier = orgNumber }
-            };
-            _factory.RegisterClientMock
-                .Setup(r => r.GetPartyUuids(It.Is<string[]>(arr => arr.Length == 1 && arr[0] == orgNumber), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(parties);
+            SetupRegisterPartyUuidsLookup(orgNumber, partyUuid);
 
             var contactInfos = new List<UserPartyContactInfo>
             {
@@ -404,13 +368,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
             string orgNumber = "444555666";
             Guid partyUuid = Guid.NewGuid();
 
-            var parties = new List<RegisterParty>
-            {
-                new() { PartyId = 12345, PartyUuid = partyUuid, OrganizationIdentifier = orgNumber }
-            };
-            _factory.RegisterClientMock
-                .Setup(r => r.GetPartyUuids(It.Is<string[]>(arr => arr.Length == 1 && arr[0] == orgNumber), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(parties);
+            SetupRegisterPartyUuidsLookup(orgNumber, partyUuid);
 
             var contactInfos = new List<UserPartyContactInfo>
             {
@@ -465,13 +423,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
             string orgNumber = "333444555";
             Guid partyUuid = Guid.NewGuid();
 
-            var parties = new List<RegisterParty>
-            {
-                new() { PartyId = 12345, PartyUuid = partyUuid, OrganizationIdentifier = orgNumber }
-            };
-            _factory.RegisterClientMock
-                .Setup(r => r.GetPartyUuids(It.Is<string[]>(arr => arr.Length == 1 && arr[0] == orgNumber), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(parties);
+            SetupRegisterPartyUuidsLookup(orgNumber, partyUuid);
 
             var contactInfos = new List<UserPartyContactInfo>
             {
@@ -531,13 +483,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
             string orgNumber = "222333444";
             Guid partyUuid = Guid.NewGuid();
 
-            var parties = new List<RegisterParty>
-            {
-                new() { PartyId = 12345, PartyUuid = partyUuid, OrganizationIdentifier = orgNumber }
-            };
-            _factory.RegisterClientMock
-                .Setup(r => r.GetPartyUuids(It.Is<string[]>(arr => arr.Length == 1 && arr[0] == orgNumber), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(parties);
+            SetupRegisterPartyUuidsLookup(orgNumber, partyUuid);
 
             var contactInfos = new List<UserPartyContactInfo>
             {
@@ -630,12 +576,11 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
                 .ReturnsAsync(contactInfosFromRepo);
 
             // Mock register client used by service/controller to map partyUuid -> org number
-            _factory.RegisterClientMock
-                .Setup(r => r.GetOrganizationNumberByPartyUuid(partyUuid1, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(orgNumber1);
-            _factory.RegisterClientMock
-                .Setup(r => r.GetOrganizationNumberByPartyUuid(partyUuid2, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(orgNumber2);
+            SetupRegisterOrganizationNumberLookup(new Dictionary<Guid, string>
+            {
+                [partyUuid1] = orgNumber1,
+                [partyUuid2] = orgNumber2
+            });
 
             HttpClient client = _factory.CreateClient();
             string encodedEmail = Uri.EscapeDataString(email);
@@ -768,12 +713,11 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
                 .Setup(r => r.GetAllContactInfoByEmailAddressAsync(email, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(contactInfosFromRepo);
 
-            _factory.RegisterClientMock
-                .Setup(r => r.GetOrganizationNumberByPartyUuid(partyUuid1, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(orgNumber);
-            _factory.RegisterClientMock
-                .Setup(r => r.GetOrganizationNumberByPartyUuid(partyUuid2, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(orgNumber);
+            SetupRegisterOrganizationNumberLookup(new Dictionary<Guid, string>
+            {
+                [partyUuid1] = orgNumber,
+                [partyUuid2] = orgNumber
+            });
 
             HttpClient client = _factory.CreateClient();
             string encodedEmail = Uri.EscapeDataString(email);
@@ -864,12 +808,11 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
                 .ReturnsAsync(contactInfosFromRepo);
 
             // Mock register client used by service/controller to map partyUuid -> org number
-            _factory.RegisterClientMock
-                .Setup(r => r.GetOrganizationNumberByPartyUuid(partyUuid1, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(orgNumber1);
-            _factory.RegisterClientMock
-                .Setup(r => r.GetOrganizationNumberByPartyUuid(partyUuid2, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(orgNumber2);
+            SetupRegisterOrganizationNumberLookup(new Dictionary<Guid, string>
+            {
+                [partyUuid1] = orgNumber1,
+                [partyUuid2] = orgNumber2
+            });
 
             HttpClient client = _factory.CreateClient();
             string encodedPhoneNumber = Uri.EscapeDataString(phoneNumber);
@@ -1009,12 +952,11 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
                 .Setup(r => r.GetAllContactInfoByPhoneNumberAsync(fullPhoneNumber, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(contactInfosFromRepo);
 
-            _factory.RegisterClientMock
-                .Setup(r => r.GetOrganizationNumberByPartyUuid(partyUuid1, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(orgNumber);
-            _factory.RegisterClientMock
-                .Setup(r => r.GetOrganizationNumberByPartyUuid(partyUuid2, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(orgNumber);
+            SetupRegisterOrganizationNumberLookup(new Dictionary<Guid, string>
+            {
+                [partyUuid1] = orgNumber,
+                [partyUuid2] = orgNumber
+            });
 
             HttpClient client = _factory.CreateClient();
             HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, $"/profile/api/v1/dashboard/organizations/contactinformation/phoneNumber/{phoneNumber}?countrycode={encodedCountryCode}");
@@ -1098,12 +1040,11 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
                 .Setup(r => r.GetAllContactInfoByPhoneNumberAsync(phoneNumber, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(contactInfosFromRepo);
 
-            _factory.RegisterClientMock
-                .Setup(r => r.GetOrganizationNumberByPartyUuid(partyUuid1, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(orgNumber1);
-            _factory.RegisterClientMock
-                .Setup(r => r.GetOrganizationNumberByPartyUuid(partyUuid2, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(orgNumber2);
+            SetupRegisterOrganizationNumberLookup(new Dictionary<Guid, string>
+            {
+                [partyUuid1] = orgNumber1,
+                [partyUuid2] = orgNumber2
+            });
 
             HttpClient client = _factory.CreateClient();
             HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, $"/profile/api/v1/dashboard/organizations/contactinformation/phoneNumber/{phoneNumber}");
@@ -1216,9 +1157,10 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
                 .Setup(r => r.GetAllContactInfoByPhoneNumberAsync(searchPhoneNumber, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(contactInfosFromRepo);
 
-            _factory.RegisterClientMock
-                .Setup(r => r.GetOrganizationNumberByPartyUuid(partyUuid, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(orgNumber);
+            SetupRegisterOrganizationNumberLookup(new Dictionary<Guid, string>
+            {
+                [partyUuid] = orgNumber
+            });
 
             HttpClient client = _factory.CreateClient();
 
@@ -1271,6 +1213,117 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        }
+
+        private void SetupRegisterPartyUuidsLookup(string orgNumber, params Guid[] partyUuids)
+        {
+            var lookup = partyUuids.ToDictionary(partyUuid => partyUuid, _ => orgNumber);
+
+            _factory.RegisterHttpMessageHandler.ChangeHandlerFunction(async (request, token) =>
+            {
+                if (request.RequestUri?.AbsolutePath.EndsWith("v2/internal/parties/query", StringComparison.Ordinal) == true)
+                {
+                    string[] requestedOrgNumbers = [];
+                    if (request.Content != null)
+                    {
+                        await using var stream = await request.Content.ReadAsStreamAsync(token);
+                        using JsonDocument jsonDocument = await JsonDocument.ParseAsync(stream, cancellationToken: token);
+                        if (jsonDocument.RootElement.TryGetProperty("data", out JsonElement dataElement) && dataElement.ValueKind == JsonValueKind.Array)
+                        {
+                            requestedOrgNumbers = dataElement
+                                .EnumerateArray()
+                                .Where(element => element.ValueKind == JsonValueKind.String)
+                                .Select(element => element.GetString())
+                                .Where(value => !string.IsNullOrEmpty(value))
+                                .Select(value => value[(value.LastIndexOf(':') + 1)..])
+                                .ToArray();
+                        }
+                    }
+
+                    var responseData = lookup
+                        .Where(entry => requestedOrgNumbers.Length == 0 || requestedOrgNumbers.Contains(entry.Value, StringComparer.Ordinal))
+                        .Select((entry, index) => new
+                        {
+                            partyId = index + 1,
+                            partyUuid = entry.Key,
+                            organizationIdentifier = entry.Value
+                        })
+                        .ToArray();
+
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = JsonContent.Create(new { data = responseData })
+                    };
+                }
+
+                if (request.RequestUri?.AbsolutePath.EndsWith("v1/parties/identifiers", StringComparison.Ordinal) == true)
+                {
+                    string uuidQuery = request.RequestUri.Query.TrimStart('?')
+                        .Split('&', StringSplitOptions.RemoveEmptyEntries)
+                        .FirstOrDefault(part => part.StartsWith("uuids=", StringComparison.OrdinalIgnoreCase))?
+                        ["uuids=".Length..] ?? string.Empty;
+
+                    var uuids = Uri.UnescapeDataString(uuidQuery)
+                        .Split(',', StringSplitOptions.RemoveEmptyEntries)
+                        .Select(value => Guid.TryParse(value, out Guid parsed) ? parsed : Guid.Empty)
+                        .Where(value => value != Guid.Empty)
+                        .ToArray();
+
+                    var responseData = uuids
+                        .Where(partyUuid => lookup.ContainsKey(partyUuid))
+                        .Select((partyUuid, index) => new
+                        {
+                            partyId = index + 1,
+                            partyUuid,
+                            orgNumber = lookup[partyUuid]
+                        })
+                        .ToArray();
+
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = JsonContent.Create(responseData)
+                    };
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+            });
+        }
+
+        private void SetupRegisterOrganizationNumberLookup(IReadOnlyDictionary<Guid, string> organizationNumbersByPartyUuid)
+        {
+            _factory.RegisterHttpMessageHandler.ChangeHandlerFunction((request, token) =>
+            {
+                if (request.RequestUri?.AbsolutePath.EndsWith("v1/parties/identifiers", StringComparison.Ordinal) == true)
+                {
+                    string uuidQuery = request.RequestUri.Query.TrimStart('?')
+                        .Split('&', StringSplitOptions.RemoveEmptyEntries)
+                        .FirstOrDefault(part => part.StartsWith("uuids=", StringComparison.OrdinalIgnoreCase))?
+                        ["uuids=".Length..] ?? string.Empty;
+
+                    var uuids = Uri.UnescapeDataString(uuidQuery)
+                        .Split(',', StringSplitOptions.RemoveEmptyEntries)
+                        .Select(value => Guid.TryParse(value, out Guid parsed) ? parsed : Guid.Empty)
+                        .Where(value => value != Guid.Empty)
+                        .ToArray();
+
+                    var responseData = uuids
+                        .Where(partyUuid => organizationNumbersByPartyUuid.ContainsKey(partyUuid))
+                        .Select((partyUuid, index) => new
+                        {
+                            partyId = index + 1,
+                            partyUuid,
+                            orgNumber = organizationNumbersByPartyUuid[partyUuid]
+                        })
+                        .ToArray();
+
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = JsonContent.Create(responseData)
+                    });
+                }
+
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+            });
         }
 
         private static HttpRequestMessage CreateAuthorizedRequestWithoutScope(HttpRequestMessage httpRequestMessage, string org = "ttd")

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/DashboardContactInformationControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/DashboardContactInformationControllerTests.cs
@@ -1221,7 +1221,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
 
             _factory.RegisterHttpMessageHandler.ChangeHandlerFunction(async (request, token) =>
             {
-                if (request.RequestUri?.AbsolutePath.EndsWith("v2/internal/parties/query", StringComparison.Ordinal) == true)
+                if (request.Method == HttpMethod.Post && request.RequestUri?.AbsolutePath.EndsWith("v2/internal/parties/query", StringComparison.Ordinal) == true)
                 {
                     string[] requestedOrgNumbers = [];
                     if (request.Content != null)
@@ -1256,7 +1256,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
                     };
                 }
 
-                if (request.RequestUri?.AbsolutePath.EndsWith("v1/parties/identifiers", StringComparison.Ordinal) == true)
+                if (request.Method == HttpMethod.Get && request.RequestUri?.AbsolutePath.EndsWith("v1/parties/identifiers", StringComparison.Ordinal) == true)
                 {
                     string uuidQuery = request.RequestUri.Query.TrimStart('?')
                         .Split('&', StringSplitOptions.RemoveEmptyEntries)

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/DashboardContactInformationControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/DashboardContactInformationControllerTests.cs
@@ -1218,112 +1218,13 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
         private void SetupRegisterPartyUuidsLookup(string orgNumber, params Guid[] partyUuids)
         {
             var lookup = partyUuids.ToDictionary(partyUuid => partyUuid, _ => orgNumber);
-
-            _factory.RegisterHttpMessageHandler.ChangeHandlerFunction(async (request, token) =>
-            {
-                if (request.Method == HttpMethod.Post && request.RequestUri?.AbsolutePath.EndsWith("v2/internal/parties/query", StringComparison.Ordinal) == true)
-                {
-                    string[] requestedOrgNumbers = [];
-                    if (request.Content != null)
-                    {
-                        await using var stream = await request.Content.ReadAsStreamAsync(token);
-                        using JsonDocument jsonDocument = await JsonDocument.ParseAsync(stream, cancellationToken: token);
-                        if (jsonDocument.RootElement.TryGetProperty("data", out JsonElement dataElement) && dataElement.ValueKind == JsonValueKind.Array)
-                        {
-                            requestedOrgNumbers = dataElement
-                                .EnumerateArray()
-                                .Where(element => element.ValueKind == JsonValueKind.String)
-                                .Select(element => element.GetString())
-                                .Where(value => !string.IsNullOrEmpty(value))
-                                .Select(value => value[(value.LastIndexOf(':') + 1)..])
-                                .ToArray();
-                        }
-                    }
-
-                    var responseData = lookup
-                        .Where(entry => requestedOrgNumbers.Length == 0 || requestedOrgNumbers.Contains(entry.Value, StringComparer.Ordinal))
-                        .Select((entry, index) => new
-                        {
-                            partyId = index + 1,
-                            partyUuid = entry.Key,
-                            organizationIdentifier = entry.Value
-                        })
-                        .ToArray();
-
-                    return new HttpResponseMessage(HttpStatusCode.OK)
-                    {
-                        Content = JsonContent.Create(new { data = responseData })
-                    };
-                }
-
-                if (request.Method == HttpMethod.Get && request.RequestUri?.AbsolutePath.EndsWith("v1/parties/identifiers", StringComparison.Ordinal) == true)
-                {
-                    string uuidQuery = request.RequestUri.Query.TrimStart('?')
-                        .Split('&', StringSplitOptions.RemoveEmptyEntries)
-                        .FirstOrDefault(part => part.StartsWith("uuids=", StringComparison.OrdinalIgnoreCase))?
-                        ["uuids=".Length..] ?? string.Empty;
-
-                    var uuids = Uri.UnescapeDataString(uuidQuery)
-                        .Split(',', StringSplitOptions.RemoveEmptyEntries)
-                        .Select(value => Guid.TryParse(value, out Guid parsed) ? parsed : Guid.Empty)
-                        .Where(value => value != Guid.Empty)
-                        .ToArray();
-
-                    var responseData = uuids
-                        .Where(partyUuid => lookup.ContainsKey(partyUuid))
-                        .Select((partyUuid, index) => new
-                        {
-                            partyId = index + 1,
-                            partyUuid,
-                            orgNumber = lookup[partyUuid]
-                        })
-                        .ToArray();
-
-                    return new HttpResponseMessage(HttpStatusCode.OK)
-                    {
-                        Content = JsonContent.Create(responseData)
-                    };
-                }
-
-                return new HttpResponseMessage(HttpStatusCode.NotFound);
-            });
+            _factory.RegisterHttpMessageHandler.ChangeHandlerFunction(
+                RegisterHttpMessageHandlerHelpers.CreateCombinedRegisterPartyQueryAndIdentifiersHandler(lookup));
         }
 
         private void SetupRegisterOrganizationNumberLookup(Dictionary<Guid, string> organizationNumbersByPartyUuid)
         {
-            _factory.RegisterHttpMessageHandler.ChangeHandlerFunction((request, token) =>
-            {
-                if (request.RequestUri?.AbsolutePath.EndsWith("v1/parties/identifiers", StringComparison.Ordinal) == true)
-                {
-                    string uuidQuery = request.RequestUri.Query.TrimStart('?')
-                        .Split('&', StringSplitOptions.RemoveEmptyEntries)
-                        .FirstOrDefault(part => part.StartsWith("uuids=", StringComparison.OrdinalIgnoreCase))?
-                        ["uuids=".Length..] ?? string.Empty;
-
-                    var uuids = Uri.UnescapeDataString(uuidQuery)
-                        .Split(',', StringSplitOptions.RemoveEmptyEntries)
-                        .Select(value => Guid.TryParse(value, out Guid parsed) ? parsed : Guid.Empty)
-                        .Where(value => value != Guid.Empty)
-                        .ToArray();
-
-                    var responseData = uuids
-                        .Where(partyUuid => organizationNumbersByPartyUuid.ContainsKey(partyUuid))
-                        .Select((partyUuid, index) => new
-                        {
-                            partyId = index + 1,
-                            partyUuid,
-                            orgNumber = organizationNumbersByPartyUuid[partyUuid]
-                        })
-                        .ToArray();
-
-                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
-                    {
-                        Content = JsonContent.Create(responseData)
-                    });
-                }
-
-                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
-            });
+            RegisterHttpMessageHandlerHelpers.SetupRegisterOrganizationNumberLookup(_factory, organizationNumbersByPartyUuid);
         }
 
         private static HttpRequestMessage CreateAuthorizedRequestWithoutScope(HttpRequestMessage httpRequestMessage, string org = "ttd")

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/DashboardContactInformationControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/DashboardContactInformationControllerTests.cs
@@ -1289,7 +1289,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
             });
         }
 
-        private void SetupRegisterOrganizationNumberLookup(IReadOnlyDictionary<Guid, string> organizationNumbersByPartyUuid)
+        private void SetupRegisterOrganizationNumberLookup(Dictionary<Guid, string> organizationNumbersByPartyUuid)
         {
             _factory.RegisterHttpMessageHandler.ChangeHandlerFunction((request, token) =>
             {

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/DashboardNotificationAddressesControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/DashboardNotificationAddressesControllerTests.cs
@@ -475,16 +475,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
                 {
                     return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                     {
-                        Content = JsonContent.Create(new
-                        {
-                            data = new[]
-                            {
-                                new
-                                {
-                                    organizationIdentifier = parentOrgNumber
-                                }
-                            }
-                        })
+                        Content = JsonContent.Create(new { data = new[] { new { organizationIdentifier = parentOrgNumber } } })
                     });
                 }
 

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/DashboardNotificationAddressesControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/DashboardNotificationAddressesControllerTests.cs
@@ -202,7 +202,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
                 .Setup(r => r.GetOrganizationsAsync(It.Is<List<string>>(a => a.Contains(requestedOrg)), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Enumerable.Empty<Organization>());
 
-            SetupRegisterMainUnitLookup(parentOrg);
+            RegisterHttpMessageHandlerHelpers.SetupRegisterMainUnitLookup(_factory, parentOrg);
 
             _factory.OrganizationNotificationAddressRepositoryMock
                 .Setup(r => r.GetOrganizationAsync(parentOrg, It.IsAny<CancellationToken>()))
@@ -239,7 +239,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
         {
             // Arrange
             string orgNumber = "error-org";
-            SetupRegisterMainUnitLookup(null);
+            RegisterHttpMessageHandlerHelpers.SetupRegisterMainUnitLookup(_factory, null);
 
             _factory.OrganizationNotificationAddressRepositoryMock
                 .Setup(r => r.GetOrganizationsAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
@@ -464,23 +464,6 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
             Assert.NotNull(phoneItem);
             Assert.Equal(phoneNumber, phoneItem.Phone);
             Assert.Equal(countryCode, phoneItem.CountryCode);
-        }
-
-        private void SetupRegisterMainUnitLookup(string parentOrgNumber)
-        {
-            _factory.RegisterHttpMessageHandler.ChangeHandlerFunction((request, token) =>
-            {
-                if (request.Method == HttpMethod.Post
-                    && request.RequestUri?.AbsolutePath.EndsWith("v2/internal/parties/main-units", StringComparison.Ordinal) == true)
-                {
-                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
-                    {
-                        Content = JsonContent.Create(new { data = new[] { new { organizationIdentifier = parentOrgNumber } } })
-                    });
-                }
-
-                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
-            });
         }
 
         private static HttpRequestMessage GenerateTokenWithoutScope(string orgNumber, HttpRequestMessage httpRequestMessage)

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/DashboardNotificationAddressesControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/DashboardNotificationAddressesControllerTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Net.Http.Json;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -120,7 +121,6 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
             _factory.PdpMock
               .Setup(pdp => pdp.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>()))
               .ReturnsAsync(new XacmlJsonResponse { Response = [new XacmlJsonResult { Decision = "Permit" }] });
-            _factory.RegisterClientMock.Reset();
             _factory.OrganizationNotificationAddressRepositoryMock.Reset();
         }
 
@@ -202,9 +202,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
                 .Setup(r => r.GetOrganizationsAsync(It.Is<List<string>>(a => a.Contains(requestedOrg)), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Enumerable.Empty<Organization>());
 
-            _factory.RegisterClientMock
-                .Setup(r => r.GetMainUnit(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(parentOrg);
+            SetupRegisterMainUnitLookup(parentOrg);
 
             _factory.OrganizationNotificationAddressRepositoryMock
                 .Setup(r => r.GetOrganizationAsync(parentOrg, It.IsAny<CancellationToken>()))
@@ -241,6 +239,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
         {
             // Arrange
             string orgNumber = "error-org";
+            SetupRegisterMainUnitLookup(null);
 
             _factory.OrganizationNotificationAddressRepositoryMock
                 .Setup(r => r.GetOrganizationsAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
@@ -465,6 +464,32 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
             Assert.NotNull(phoneItem);
             Assert.Equal(phoneNumber, phoneItem.Phone);
             Assert.Equal(countryCode, phoneItem.CountryCode);
+        }
+
+        private void SetupRegisterMainUnitLookup(string parentOrgNumber)
+        {
+            _factory.RegisterHttpMessageHandler.ChangeHandlerFunction((request, token) =>
+            {
+                if (request.Method == HttpMethod.Post
+                    && request.RequestUri?.AbsolutePath.EndsWith("v2/internal/parties/main-units", StringComparison.Ordinal) == true)
+                {
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = JsonContent.Create(new
+                        {
+                            data = new[]
+                            {
+                                new
+                                {
+                                    organizationIdentifier = parentOrgNumber
+                                }
+                            }
+                        })
+                    });
+                }
+
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+            });
         }
 
         private static HttpRequestMessage GenerateTokenWithoutScope(string orgNumber, HttpRequestMessage httpRequestMessage)

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/FavoritesControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/FavoritesControllerTests.cs
@@ -2,6 +2,7 @@
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Net.Http.Json;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -289,15 +290,38 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
 
         private static void SetupAuthHandler(ProfileWebApplicationFactory<Program> factory, Guid partyGuid, int UserId, bool access = true)
         {
-            factory.RegisterClientMock.Reset();
-            factory.RegisterClientMock
-                .Setup(x => x.GetPartyId(partyGuid, It.IsAny<CancellationToken>()))
-                .ReturnsAsync((int)partyGuid.GetHashCode()); // Simulate party ID retrieval
+            SetupRegisterPartyIdLookup(factory, partyGuid, partyGuid.GetHashCode());
 
             factory.AuthorizationClientMock.Reset();
             factory.AuthorizationClientMock
                 .Setup(x => x.ValidateSelectedParty(UserId, It.IsAny<int>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(access);
+        }
+
+        private static void SetupRegisterPartyIdLookup(ProfileWebApplicationFactory<Program> factory, Guid partyGuid, int partyId)
+        {
+            factory.RegisterHttpMessageHandler.ChangeHandlerFunction((request, token) =>
+            {
+                if (request.Method == HttpMethod.Get
+                    && request.RequestUri?.AbsolutePath.EndsWith("v1/parties/identifiers", StringComparison.Ordinal) == true
+                    && request.RequestUri.Query.Contains(partyGuid.ToString(), StringComparison.OrdinalIgnoreCase))
+                {
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = JsonContent.Create(new[]
+                        {
+                            new
+                            {
+                                partyId,
+                                partyUuid = partyGuid,
+                                orgNumber = string.Empty
+                            }
+                        })
+                    });
+                }
+
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+            });
         }
     }
 }

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/FavoritesControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/FavoritesControllerTests.cs
@@ -290,38 +290,12 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
 
         private static void SetupAuthHandler(ProfileWebApplicationFactory<Program> factory, Guid partyGuid, int UserId, bool access = true)
         {
-            SetupRegisterPartyIdLookup(factory, partyGuid, partyGuid.GetHashCode());
+            RegisterHttpMessageHandlerHelpers.SetupRegisterPartyIdLookup(factory, partyGuid, partyGuid.GetHashCode());
 
             factory.AuthorizationClientMock.Reset();
             factory.AuthorizationClientMock
                 .Setup(x => x.ValidateSelectedParty(UserId, It.IsAny<int>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(access);
-        }
-
-        private static void SetupRegisterPartyIdLookup(ProfileWebApplicationFactory<Program> factory, Guid partyGuid, int partyId)
-        {
-            factory.RegisterHttpMessageHandler.ChangeHandlerFunction((request, token) =>
-            {
-                if (request.Method == HttpMethod.Get
-                    && request.RequestUri?.AbsolutePath.EndsWith("v1/parties/identifiers", StringComparison.Ordinal) == true
-                    && request.RequestUri.Query.Contains(partyGuid.ToString(), StringComparison.OrdinalIgnoreCase))
-                {
-                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
-                    {
-                        Content = JsonContent.Create(new[]
-                        {
-                            new
-                            {
-                                partyId,
-                                partyUuid = partyGuid,
-                                orgNumber = string.Empty
-                            }
-                        })
-                    });
-                }
-
-                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
-            });
         }
     }
 }

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/OrgNotificationAddressesControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/OrgNotificationAddressesControllerTests.cs
@@ -341,16 +341,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
                 {
                     return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                     {
-                        Content = JsonContent.Create(new
-                        {
-                            data = new[]
-                            {
-                                new
-                                {
-                                    organizationIdentifier = parentOrgNumber
-                                }
-                            }
-                        })
+                        Content = JsonContent.Create(new { data = new[] { new { organizationIdentifier = parentOrgNumber } } })
                     });
                 }
 

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/OrgNotificationAddressesControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/OrgNotificationAddressesControllerTests.cs
@@ -1,7 +1,9 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Json;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -89,7 +91,6 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
             ];
 
             _factory = factory;
-            _factory.RegisterClientMock.Reset();
             _factory.OrganizationNotificationAddressRepositoryMock.Reset();
         }
 
@@ -135,9 +136,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
                 OrganizationNumbers = ["333333333"],
             };
 
-            _factory.RegisterClientMock
-                .Setup(r => r.GetMainUnit(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync("123456789");
+            SetupRegisterMainUnitLookup("123456789");
 
             var childUnit = _testdata.Where(o => input.OrganizationNumbers.Contains(o.OrganizationNumber));
             var parentUnit = _testdata.First(o => o.OrganizationNumber == "123456789");
@@ -331,6 +330,32 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        }
+
+        private void SetupRegisterMainUnitLookup(string parentOrgNumber)
+        {
+            _factory.RegisterHttpMessageHandler.ChangeHandlerFunction((request, token) =>
+            {
+                if (request.Method == HttpMethod.Post
+                    && request.RequestUri?.AbsolutePath.EndsWith("v2/internal/parties/main-units", StringComparison.Ordinal) == true)
+                {
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = JsonContent.Create(new
+                        {
+                            data = new[]
+                            {
+                                new
+                                {
+                                    organizationIdentifier = parentOrgNumber
+                                }
+                            }
+                        })
+                    });
+                }
+
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+            });
         }
     }
 }

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/OrgNotificationAddressesControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/OrgNotificationAddressesControllerTests.cs
@@ -112,7 +112,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
             {
                 Content = new StringContent(JsonSerializer.Serialize(input, _serializerOptions), System.Text.Encoding.UTF8, "application/json")
             };
-            SetupRegisterMainUnitLookup(null);
+            RegisterHttpMessageHandlerHelpers.SetupRegisterMainUnitLookup(_factory, null);
 
             // Act
             HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
@@ -137,7 +137,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
                 OrganizationNumbers = ["333333333"],
             };
 
-            SetupRegisterMainUnitLookup("123456789");
+            RegisterHttpMessageHandlerHelpers.SetupRegisterMainUnitLookup(_factory, "123456789");
 
             var childUnit = _testdata.Where(o => input.OrganizationNumbers.Contains(o.OrganizationNumber));
             var parentUnit = _testdata.First(o => o.OrganizationNumber == "123456789");
@@ -253,7 +253,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
             {
                 Content = new StringContent(JsonSerializer.Serialize(input, _serializerOptions), System.Text.Encoding.UTF8, "application/json")
             };
-            SetupRegisterMainUnitLookup(null);
+            RegisterHttpMessageHandlerHelpers.SetupRegisterMainUnitLookup(_factory, null);
 
             // Act
             HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
@@ -332,23 +332,6 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        }
-
-        private void SetupRegisterMainUnitLookup(string parentOrgNumber)
-        {
-            _factory.RegisterHttpMessageHandler.ChangeHandlerFunction((request, token) =>
-            {
-                if (request.Method == HttpMethod.Post
-                    && request.RequestUri?.AbsolutePath.EndsWith("v2/internal/parties/main-units", StringComparison.Ordinal) == true)
-                {
-                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
-                    {
-                        Content = JsonContent.Create(new { data = new[] { new { organizationIdentifier = parentOrgNumber } } })
-                    });
-                }
-
-                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
-            });
         }
     }
 }

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/OrgNotificationAddressesControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/OrgNotificationAddressesControllerTests.cs
@@ -112,6 +112,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
             {
                 Content = new StringContent(JsonSerializer.Serialize(input, _serializerOptions), System.Text.Encoding.UTF8, "application/json")
             };
+            SetupRegisterMainUnitLookup(null);
 
             // Act
             HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
@@ -252,6 +253,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
             {
                 Content = new StringContent(JsonSerializer.Serialize(input, _serializerOptions), System.Text.Encoding.UTF8, "application/json")
             };
+            SetupRegisterMainUnitLookup(null);
 
             // Act
             HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/PrivateNotificationSettingsControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/PrivateNotificationSettingsControllerTests.cs
@@ -18,7 +18,6 @@ using Altinn.Profile.Tests.IntegrationTests.Utils;
 using Altinn.Register.Contracts;
 using Altinn.Register.Contracts.Testing;
 
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 
 using Moq;
@@ -448,7 +447,7 @@ public class PrivateNotificationSettingsControllerTests : IClassFixture<ProfileW
         _factory.UserContactInfoRepositoryMock.Verify(x => x.CreateUserContactInfo(It.IsAny<UserContactInfoCreateModel>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
-    private void SetupRegisterUserPartyLookup(int userId, Party? userParty)
+    private void SetupRegisterUserPartyLookup(int userId, Party userParty)
     {
         _factory.RegisterHttpMessageHandler.ChangeHandlerFunction(async (request, token) =>
         {

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/PrivateNotificationSettingsControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/PrivateNotificationSettingsControllerTests.cs
@@ -114,7 +114,7 @@ public class PrivateNotificationSettingsControllerTests : IClassFixture<ProfileW
             .Setup(x => x.Get(UserId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((UserContactInfo)null);
         var party = SelfIdentifiedUser.MinimalEmail("test@example.com", System.Guid.NewGuid()) with { User = new PartyUser(1, "epost:test@example.com", ImmutableValueArray<uint>.Empty.Add(1u)) };
-        SetupRegisterUserPartyLookup(UserId, party);
+        RegisterHttpMessageHandlerHelpers.SetupRegisterUserPartyByUserIdLookup(_factory, UserId, party);
 
         _factory.UserContactInfoRepositoryMock
             .Setup(x => x.CreateUserContactInfo(It.Is<UserContactInfoCreateModel>(m => m.EmailAddress == "test@example.com"), It.IsAny<CancellationToken>()))
@@ -245,7 +245,7 @@ public class PrivateNotificationSettingsControllerTests : IClassFixture<ProfileW
             .ReturnsAsync((UserContactInfo)null);
 
         // Register returns a non-self-identified party so the service returns null
-        SetupRegisterUserPartyLookup(UserId, null);
+        RegisterHttpMessageHandlerHelpers.SetupRegisterUserPartyByUserIdLookup(_factory, UserId, null);
 
         HttpClient client = _factory.WithWebHostBuilder(builder =>
         {
@@ -281,7 +281,7 @@ public class PrivateNotificationSettingsControllerTests : IClassFixture<ProfileW
             .ReturnsAsync((UserContactInfo)null);
 
         // Register returns null (not a self-identified party)
-        SetupRegisterUserPartyLookup(UserId, null);
+        RegisterHttpMessageHandlerHelpers.SetupRegisterUserPartyByUserIdLookup(_factory, UserId, null);
 
         // UserProfileClient (SblBridge) returns a valid profile
         _factory.SblBridgeHttpMessageHandler.ChangeHandlerFunction(async (request, token) =>
@@ -358,7 +358,7 @@ public class PrivateNotificationSettingsControllerTests : IClassFixture<ProfileW
 
         // SelfIdentifiedUser without a User value set
         var party = SelfIdentifiedUser.MinimalEmail("nouser@example.com", Guid.NewGuid());
-        SetupRegisterUserPartyLookup(UserId, party);
+        RegisterHttpMessageHandlerHelpers.SetupRegisterUserPartyByUserIdLookup(_factory, UserId, party);
 
         HttpClient client = _factory.WithWebHostBuilder(builder =>
         {
@@ -395,7 +395,7 @@ public class PrivateNotificationSettingsControllerTests : IClassFixture<ProfileW
 
         // SelfIdentifiedUser without a User value set
         var party = SelfIdentifiedUser.MinimalEmail("nouser@example.com", Guid.NewGuid());
-        SetupRegisterUserPartyLookup(UserId, party);
+        RegisterHttpMessageHandlerHelpers.SetupRegisterUserPartyByUserIdLookup(_factory, UserId, party);
 
         _factory.SblBridgeHttpMessageHandler.ChangeHandlerFunction(async (request, token) =>
         {
@@ -445,43 +445,6 @@ public class PrivateNotificationSettingsControllerTests : IClassFixture<ProfileW
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         _factory.UserContactInfoRepositoryMock.Verify(x => x.CreateUserContactInfo(It.IsAny<UserContactInfoCreateModel>(), It.IsAny<CancellationToken>()), Times.Once);
-    }
-
-    private void SetupRegisterUserPartyLookup(int userId, Party userParty)
-    {
-        _factory.RegisterHttpMessageHandler.ChangeHandlerFunction(async (request, token) =>
-        {
-            if (request.Method == HttpMethod.Post
-                && request.RequestUri?.AbsolutePath.EndsWith("v2/internal/parties/query", StringComparison.Ordinal) == true)
-            {
-                if (request.Content == null)
-                {
-                    return new HttpResponseMessage(HttpStatusCode.BadRequest);
-                }
-
-                await using var stream = await request.Content.ReadAsStreamAsync(token);
-                using JsonDocument jsonDocument = await JsonDocument.ParseAsync(stream, cancellationToken: token);
-
-                bool containsRequestedUserId = jsonDocument.RootElement.TryGetProperty("data", out JsonElement dataElement)
-                    && dataElement.ValueKind == JsonValueKind.Array
-                    && dataElement.EnumerateArray().Any(element =>
-                        element.ValueKind == JsonValueKind.String
-                        && string.Equals(element.GetString(), $"urn:altinn:user:id:{userId}", StringComparison.Ordinal));
-
-                if (containsRequestedUserId)
-                {
-                    return new HttpResponseMessage(HttpStatusCode.OK)
-                    {
-                        Content = JsonContent.Create(new
-                        {
-                            data = userParty is null ? [] : new[] { userParty }
-                        })
-                    };
-                }
-            }
-
-            return new HttpResponseMessage(HttpStatusCode.NotFound);
-        });
     }
 
     private static HttpRequestMessage CreateRequestWithUserIdAndAuthMethod(HttpMethod method, int userId, string authMethod, string requestUri, PrivateNotificationSettingsUpdateRequest body)

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/PrivateNotificationSettingsControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/PrivateNotificationSettingsControllerTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -114,8 +115,7 @@ public class PrivateNotificationSettingsControllerTests : IClassFixture<ProfileW
             .Setup(x => x.Get(UserId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((UserContactInfo)null);
         var party = SelfIdentifiedUser.MinimalEmail("test@example.com", System.Guid.NewGuid()) with { User = new PartyUser(1, "epost:test@example.com", ImmutableValueArray<uint>.Empty.Add(1u)) };
-        _factory.RegisterClientMock.Setup(x => x.GetUserParty(UserId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(party);
+        SetupRegisterUserPartyLookup(UserId, party);
 
         _factory.UserContactInfoRepositoryMock
             .Setup(x => x.CreateUserContactInfo(It.Is<UserContactInfoCreateModel>(m => m.EmailAddress == "test@example.com"), It.IsAny<CancellationToken>()))
@@ -246,9 +246,7 @@ public class PrivateNotificationSettingsControllerTests : IClassFixture<ProfileW
             .ReturnsAsync((UserContactInfo)null);
 
         // Register returns a non-self-identified party so the service returns null
-        _factory.RegisterClientMock
-            .Setup(x => x.GetUserParty(UserId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync((Register.Contracts.Party)null);
+        SetupRegisterUserPartyLookup(UserId, null);
 
         HttpClient client = _factory.WithWebHostBuilder(builder =>
         {
@@ -284,9 +282,7 @@ public class PrivateNotificationSettingsControllerTests : IClassFixture<ProfileW
             .ReturnsAsync((UserContactInfo)null);
 
         // Register returns null (not a self-identified party)
-        _factory.RegisterClientMock
-            .Setup(x => x.GetUserParty(UserId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync((Register.Contracts.Party)null);
+        SetupRegisterUserPartyLookup(UserId, null);
 
         // UserProfileClient (SblBridge) returns a valid profile
         _factory.SblBridgeHttpMessageHandler.ChangeHandlerFunction(async (request, token) =>
@@ -363,9 +359,7 @@ public class PrivateNotificationSettingsControllerTests : IClassFixture<ProfileW
 
         // SelfIdentifiedUser without a User value set
         var party = SelfIdentifiedUser.MinimalEmail("nouser@example.com", Guid.NewGuid());
-        _factory.RegisterClientMock
-            .Setup(x => x.GetUserParty(UserId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(party);
+        SetupRegisterUserPartyLookup(UserId, party);
 
         HttpClient client = _factory.WithWebHostBuilder(builder =>
         {
@@ -402,9 +396,7 @@ public class PrivateNotificationSettingsControllerTests : IClassFixture<ProfileW
 
         // SelfIdentifiedUser without a User value set
         var party = SelfIdentifiedUser.MinimalEmail("nouser@example.com", Guid.NewGuid());
-        _factory.RegisterClientMock
-            .Setup(x => x.GetUserParty(UserId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(party);
+        SetupRegisterUserPartyLookup(UserId, party);
 
         _factory.SblBridgeHttpMessageHandler.ChangeHandlerFunction(async (request, token) =>
         {
@@ -454,6 +446,43 @@ public class PrivateNotificationSettingsControllerTests : IClassFixture<ProfileW
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         _factory.UserContactInfoRepositoryMock.Verify(x => x.CreateUserContactInfo(It.IsAny<UserContactInfoCreateModel>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    private void SetupRegisterUserPartyLookup(int userId, Party? userParty)
+    {
+        _factory.RegisterHttpMessageHandler.ChangeHandlerFunction(async (request, token) =>
+        {
+            if (request.Method == HttpMethod.Post
+                && request.RequestUri?.AbsolutePath.EndsWith("v2/internal/parties/query", StringComparison.Ordinal) == true)
+            {
+                if (request.Content == null)
+                {
+                    return new HttpResponseMessage(HttpStatusCode.BadRequest);
+                }
+
+                await using var stream = await request.Content.ReadAsStreamAsync(token);
+                using JsonDocument jsonDocument = await JsonDocument.ParseAsync(stream, cancellationToken: token);
+
+                bool containsRequestedUserId = jsonDocument.RootElement.TryGetProperty("data", out JsonElement dataElement)
+                    && dataElement.ValueKind == JsonValueKind.Array
+                    && dataElement.EnumerateArray().Any(element =>
+                        element.ValueKind == JsonValueKind.String
+                        && string.Equals(element.GetString(), $"urn:altinn:user:id:{userId}", StringComparison.Ordinal));
+
+                if (containsRequestedUserId)
+                {
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = JsonContent.Create(new
+                        {
+                            data = userParty is null ? [] : new[] { userParty }
+                        })
+                    };
+                }
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        });
     }
 
     private static HttpRequestMessage CreateRequestWithUserIdAndAuthMethod(HttpMethod method, int userId, string authMethod, string requestUri, PrivateNotificationSettingsUpdateRequest body)

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/ProfessionalNotificationSettingsControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/ProfessionalNotificationSettingsControllerTests.cs
@@ -1325,45 +1325,11 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
 
         private void SetupAuthHandler(Guid partyGuid, int UserId, bool access = true, int orgNo = 0)
         {
-            _factory.RegisterHttpMessageHandler.ChangeHandlerFunction((request, cancellationToken) =>
-            {
-                if (request.Method == HttpMethod.Get && request.RequestUri?.AbsolutePath.EndsWith("v1/parties/identifiers", StringComparison.Ordinal) == true)
-                {
-                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
-                    {
-                        Content = JsonContent.Create(new[]
-                        {
-                            new
-                            {
-                                partyId = partyGuid.GetHashCode(),
-                                partyUuid = partyGuid,
-                                orgNumber = orgNo.ToString()
-                            }
-                        })
-                    });
-                }
-
-                if (request.Method == HttpMethod.Post && request.RequestUri?.AbsolutePath.EndsWith("v2/internal/parties/query", StringComparison.Ordinal) == true)
-                {
-                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
-                    {
-                        Content = JsonContent.Create(new
-                        {
-                            data = new[]
-                            {
-                                new
-                                {
-                                    partyId = 12345,
-                                    partyUuid = partyGuid,
-                                    organizationIdentifier = orgNo.ToString()
-                                }
-                            }
-                        })
-                    });
-                }
-
-                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
-            });
+            RegisterHttpMessageHandlerHelpers.SetupRegisterPartyLookupForAuthorization(
+                _factory,
+                partyGuid,
+                partyGuid.GetHashCode(),
+                orgNo.ToString());
 
             _factory.AuthorizationClientMock
                 .Setup(x => x.ValidateSelectedParty(UserId, It.IsAny<int>(), It.IsAny<CancellationToken>()))

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/ProfessionalNotificationSettingsControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/ProfessionalNotificationSettingsControllerTests.cs
@@ -1327,7 +1327,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
         {
             _factory.RegisterHttpMessageHandler.ChangeHandlerFunction((request, cancellationToken) =>
             {
-                if (request.RequestUri?.AbsolutePath.EndsWith("v1/parties/identifiers", StringComparison.Ordinal) == true)
+                if (request.Method == HttpMethod.Get && request.RequestUri?.AbsolutePath.EndsWith("v1/parties/identifiers", StringComparison.Ordinal) == true)
                 {
                     return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                     {
@@ -1343,7 +1343,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
                     });
                 }
 
-                if (request.RequestUri?.AbsolutePath.EndsWith("v2/internal/parties/query", StringComparison.Ordinal) == true)
+                if (request.Method == HttpMethod.Post && request.RequestUri?.AbsolutePath.EndsWith("v2/internal/parties/query", StringComparison.Ordinal) == true)
                 {
                     return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                     {

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/ProfessionalNotificationSettingsControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/ProfessionalNotificationSettingsControllerTests.cs
@@ -46,7 +46,6 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
         {
             _factory = factory;
             _factory.ProfessionalNotificationsRepositoryMock.Reset();
-            _factory.RegisterClientMock.Reset();
             _factory.AuthorizationClientMock.Reset();
             _factory.AddressVerificationRepositoryMock.Reset();
             _factory.NotificationsClientMock.Reset();
@@ -163,15 +162,6 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
                 }
             };
 
-            var parties = new List<RegisterParty>
-            {
-                new() { PartyId = 12345, PartyUuid = partyGuid, OrganizationIdentifier = OrgNumber.ToString() }
-            };
-
-            _factory.RegisterClientMock
-                .Setup(r => r.GetPartyUuids(It.Is<string[]>(arr => arr.Length == 1 && arr[0] == OrgNumber.ToString()), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(parties);
-
             _factory
                 .ProfessionalNotificationsRepositoryMock
                 .Setup(x => x.GetNotificationAddressAsync(UserId, partyGuid, It.IsAny<CancellationToken>()))
@@ -233,15 +223,6 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
             const int UserId = 2516356;
             const int OrgNumber = 910459880;
             Guid partyUuid = Guid.NewGuid();
-
-            var parties = new List<RegisterParty>
-            {
-                new() { PartyId = 12345, PartyUuid = partyUuid, OrganizationIdentifier = OrgNumber.ToString() }
-            };
-
-            _factory.RegisterClientMock
-                .Setup(r => r.GetPartyUuids(It.Is<string[]>(arr => arr.Length == 1 && arr[0] == OrgNumber.ToString()), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(parties);
 
             _factory
                 .ProfessionalNotificationsRepositoryMock
@@ -1344,12 +1325,46 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
 
         private void SetupAuthHandler(Guid partyGuid, int UserId, bool access = true, int orgNo = 0)
         {
-            _factory.RegisterClientMock
-                .Setup(x => x.GetPartyId(partyGuid, It.IsAny<CancellationToken>()))
-                .ReturnsAsync((int)partyGuid.GetHashCode()); // Simulate party ID retrieval
-            _factory.RegisterClientMock
-                .Setup(x => x.GetPartyId(orgNo.ToString(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync((int)partyGuid.GetHashCode()); // Simulate party ID retrieval
+            _factory.RegisterHttpMessageHandler.ChangeHandlerFunction((request, cancellationToken) =>
+            {
+                if (request.RequestUri?.AbsolutePath.EndsWith("v1/parties/identifiers", StringComparison.Ordinal) == true)
+                {
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = JsonContent.Create(new[]
+                        {
+                            new
+                            {
+                                partyId = partyGuid.GetHashCode(),
+                                partyUuid = partyGuid,
+                                orgNumber = orgNo.ToString()
+                            }
+                        })
+                    });
+                }
+
+                if (request.RequestUri?.AbsolutePath.EndsWith("v2/internal/parties/query", StringComparison.Ordinal) == true)
+                {
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = JsonContent.Create(new
+                        {
+                            data = new[]
+                            {
+                                new
+                                {
+                                    partyId = 12345,
+                                    partyUuid = partyGuid,
+                                    organizationIdentifier = orgNo.ToString()
+                                }
+                            }
+                        })
+                    });
+                }
+
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+            });
+
             _factory.AuthorizationClientMock
                 .Setup(x => x.ValidateSelectedParty(UserId, It.IsAny<int>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(access);

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/RegisterHttpMessageHandlerHelpers.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/RegisterHttpMessageHandlerHelpers.cs
@@ -1,0 +1,358 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Altinn.Register.Contracts;
+
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Primitives;
+
+namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers;
+
+internal static class RegisterHttpMessageHandlerHelpers
+{
+    internal static void SetupRegisterPartyIdLookup(ProfileWebApplicationFactory<Program> factory, Guid partyUuid, int partyId)
+    {
+        factory.RegisterHttpMessageHandler.ChangeHandlerFunction((request, token) =>
+        {
+            if (request.Method == HttpMethod.Get
+                && request.RequestUri?.AbsolutePath.EndsWith("v1/parties/identifiers", StringComparison.Ordinal) == true
+                && request.RequestUri.Query.Contains(partyUuid.ToString(), StringComparison.OrdinalIgnoreCase))
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = JsonContent.Create(new[]
+                    {
+                        new
+                        {
+                            partyId,
+                            partyUuid,
+                            orgNumber = string.Empty,
+                        }
+                    })
+                });
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        });
+    }
+
+    internal static void SetupRegisterPartyLookupForAuthorization(ProfileWebApplicationFactory<Program> factory, Guid partyUuid, int identifiersPartyId, string organizationNumber, int partyQueryPartyId = 12345)
+    {
+        factory.RegisterHttpMessageHandler.ChangeHandlerFunction((request, token) =>
+        {
+            if (request.Method == HttpMethod.Get
+                && request.RequestUri?.AbsolutePath.EndsWith("v1/parties/identifiers", StringComparison.Ordinal) == true)
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = JsonContent.Create(new[]
+                    {
+                        new
+                        {
+                            partyId = identifiersPartyId,
+                            partyUuid,
+                            orgNumber = organizationNumber,
+                        }
+                    })
+                });
+            }
+
+            if (request.Method == HttpMethod.Post
+                && request.RequestUri?.AbsolutePath.EndsWith("v2/internal/parties/query", StringComparison.Ordinal) == true)
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = JsonContent.Create(new
+                    {
+                        data = new[]
+                        {
+                            new
+                            {
+                                partyId = partyQueryPartyId,
+                                partyUuid,
+                                organizationIdentifier = organizationNumber,
+                            }
+                        }
+                    })
+                });
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        });
+    }
+
+    internal static void SetupRegisterMainUnitLookup(ProfileWebApplicationFactory<Program> factory, string parentOrgNumber)
+    {
+        factory.RegisterHttpMessageHandler.ChangeHandlerFunction((request, token) =>
+        {
+            if (request.Method == HttpMethod.Post
+                && request.RequestUri?.AbsolutePath.EndsWith("v2/internal/parties/main-units", StringComparison.Ordinal) == true)
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = JsonContent.Create(new { data = new[] { new { organizationIdentifier = parentOrgNumber } } })
+                });
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        });
+    }
+
+    internal static void SetupRegisterUserPartyByUserIdLookup(ProfileWebApplicationFactory<Program> factory, int userId, Party userParty, HttpStatusCode statusCode = HttpStatusCode.OK)
+    {
+        string expectedIdentifier = $"urn:altinn:user:id:{userId}";
+        SetupRegisterUserPartyLookup(factory, expectedIdentifier, userParty, statusCode);
+    }
+
+    internal static void SetupRegisterUserPartyByUsernameLookup(ProfileWebApplicationFactory<Program> factory, string username, Party userParty, HttpStatusCode statusCode = HttpStatusCode.OK)
+    {
+        string expectedIdentifier = $"urn:altinn:party:username:{username}";
+        SetupRegisterUserPartyLookup(factory, expectedIdentifier, userParty, statusCode);
+    }
+
+    internal static void SetupRegisterPartyQueryLookup(ProfileWebApplicationFactory<Program> factory, IReadOnlyDictionary<Guid, string> organizationNumbersByPartyUuid)
+    {
+        factory.RegisterHttpMessageHandler.ChangeHandlerFunction(async (request, token) =>
+        {
+            HttpResponseMessage partyQueryResponse = await TryCreatePartyQueryResponseAsync(request, token, organizationNumbersByPartyUuid, HttpStatusCode.OK);
+            return partyQueryResponse ?? new HttpResponseMessage(HttpStatusCode.NotFound);
+        });
+    }
+
+    internal static void SetupRegisterIdentifiersLookup(ProfileWebApplicationFactory<Program> factory, IReadOnlyDictionary<Guid, string> organizationNumbersByPartyUuid)
+    {
+        factory.RegisterHttpMessageHandler.ChangeHandlerFunction((request, token) =>
+        {
+            HttpResponseMessage identifiersResponse = TryCreateIdentifiersResponse(request, organizationNumbersByPartyUuid);
+            return Task.FromResult(identifiersResponse ?? new HttpResponseMessage(HttpStatusCode.NotFound));
+        });
+    }
+
+    internal static Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> CreateCombinedRegisterPartyQueryAndIdentifiersHandler(IReadOnlyDictionary<Guid, string> organizationNumbersByPartyUuid)
+    {
+        return CreateCombinedRegisterPartyQueryAndIdentifiersHandler(organizationNumbersByPartyUuid, HttpStatusCode.OK);
+    }
+
+    internal static Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> CreateCombinedRegisterPartyQueryAndIdentifiersHandler(IReadOnlyDictionary<Guid, string> organizationNumbersByPartyUuid, HttpStatusCode partyQueryStatusCode)
+    {
+        return async (request, token) =>
+        {
+            HttpResponseMessage partyQueryResponse = await TryCreatePartyQueryResponseAsync(request, token, organizationNumbersByPartyUuid, partyQueryStatusCode);
+            if (partyQueryResponse is not null)
+            {
+                return partyQueryResponse;
+            }
+
+            HttpResponseMessage identifiersResponse = TryCreateIdentifiersResponse(request, organizationNumbersByPartyUuid);
+            if (identifiersResponse is not null)
+            {
+                return identifiersResponse;
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        };
+    }
+
+    internal static void SetupRegisterOrganizationNumberLookup(ProfileWebApplicationFactory<Program> factory, IReadOnlyDictionary<Guid, string> organizationNumbersByPartyUuid)
+    {
+        SetupRegisterIdentifiersLookup(factory, organizationNumbersByPartyUuid);
+    }
+
+    internal static void SetupRegisterPartyQueryLookup(ProfileWebApplicationFactory<Program> factory, Func<string[], List<Party>> responseFactory)
+    {
+        SetupRegisterPartyQueryLookupCore(factory, responseFactory);
+    }
+
+    internal static void SetupRegisterPartyQueryLookup(ProfileWebApplicationFactory<Program> factory, Func<string[], List<Core.Unit.ContactPoints.Party>> responseFactory)
+    {
+        SetupRegisterPartyQueryLookupCore(factory, responseFactory);
+    }
+
+    internal static Guid[] GetUuidsFromIdentifiersQuery(string query)
+    {
+        Dictionary<string, StringValues> queryValues = QueryHelpers.ParseQuery(query);
+        if (!queryValues.TryGetValue("uuids", out StringValues uuidQueryValues))
+        {
+            return [];
+        }
+
+        return uuidQueryValues
+            .SelectMany(value => value.Split(',', StringSplitOptions.RemoveEmptyEntries))
+            .Select(value => Guid.TryParse(value, out Guid parsed) ? parsed : Guid.Empty)
+            .Where(value => value != Guid.Empty)
+            .ToArray();
+    }
+
+    private static void SetupRegisterUserPartyLookup(ProfileWebApplicationFactory<Program> factory, string expectedIdentifier, Party userParty, HttpStatusCode statusCode)
+    {
+        factory.RegisterHttpMessageHandler.ChangeHandlerFunction(async (request, token) =>
+        {
+            if (request.Method != HttpMethod.Post
+                || request.RequestUri?.AbsolutePath.EndsWith("v2/internal/parties/query", StringComparison.Ordinal) != true)
+            {
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+            }
+
+            if (statusCode != HttpStatusCode.OK)
+            {
+                return new HttpResponseMessage(statusCode);
+            }
+
+            if (request.Content == null)
+            {
+                return new HttpResponseMessage(HttpStatusCode.BadRequest);
+            }
+
+            await using var stream = await request.Content.ReadAsStreamAsync(token);
+            using JsonDocument jsonDocument = await JsonDocument.ParseAsync(stream, cancellationToken: token);
+
+            bool hasMatch = false;
+            if (jsonDocument.RootElement.TryGetProperty("data", out JsonElement dataElement) && dataElement.ValueKind == JsonValueKind.Array)
+            {
+                foreach (JsonElement element in dataElement.EnumerateArray())
+                {
+                    if (element.ValueKind == JsonValueKind.String && string.Equals(element.GetString(), expectedIdentifier, StringComparison.Ordinal))
+                    {
+                        hasMatch = true;
+                        break;
+                    }
+                }
+            }
+
+            if (!hasMatch)
+            {
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(new
+                {
+                    data = userParty is null ? [] : new[] { userParty }
+                })
+            };
+        });
+    }
+
+    private static void SetupRegisterPartyQueryLookupCore<TParty>(ProfileWebApplicationFactory<Program> factory, Func<string[], List<TParty>> responseFactory)
+    {
+        factory.RegisterHttpMessageHandler.ChangeHandlerFunction(async (request, token) =>
+        {
+            if (request.Method != HttpMethod.Post
+                || request.RequestUri?.AbsolutePath.EndsWith("v2/internal/parties/query", StringComparison.Ordinal) != true)
+            {
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+            }
+
+            if (request.Content == null)
+            {
+                return new HttpResponseMessage(HttpStatusCode.BadRequest);
+            }
+
+            string[] orgNumbers = await GetRequestedOrganizationNumbersFromQueryAsync(request, token);
+            List<TParty> parties = responseFactory(orgNumbers);
+            if (parties == null)
+            {
+                return new HttpResponseMessage(HttpStatusCode.InternalServerError);
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(new { data = parties })
+            };
+        });
+    }
+
+    private static async Task<HttpResponseMessage> TryCreatePartyQueryResponseAsync(HttpRequestMessage request, CancellationToken token, IReadOnlyDictionary<Guid, string> organizationNumbersByPartyUuid, HttpStatusCode partyQueryStatusCode)
+    {
+        if (request.Method != HttpMethod.Post
+            || request.RequestUri?.AbsolutePath.EndsWith("v2/internal/parties/query", StringComparison.Ordinal) != true)
+        {
+            return null;
+        }
+
+        if (partyQueryStatusCode != HttpStatusCode.OK)
+        {
+            return new HttpResponseMessage(partyQueryStatusCode);
+        }
+
+        string[] requestedOrgNumbers = await GetRequestedOrganizationNumbersFromQueryAsync(request, token);
+        var responseData = organizationNumbersByPartyUuid
+            .Where(entry => requestedOrgNumbers.Length == 0 || requestedOrgNumbers.Contains(entry.Value, StringComparer.Ordinal))
+            .Select((entry, index) => new
+            {
+                partyId = index + 1,
+                partyUuid = entry.Key,
+                organizationIdentifier = entry.Value,
+            })
+            .ToArray();
+
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = JsonContent.Create(new { data = responseData })
+        };
+    }
+
+    private static HttpResponseMessage TryCreateIdentifiersResponse(HttpRequestMessage request, IReadOnlyDictionary<Guid, string> organizationNumbersByPartyUuid)
+    {
+        if (request.Method != HttpMethod.Get
+            || request.RequestUri?.AbsolutePath.EndsWith("v1/parties/identifiers", StringComparison.Ordinal) != true)
+        {
+            return null;
+        }
+
+        Guid[] uuids = GetUuidsFromIdentifiersQuery(request.RequestUri.Query);
+        var responseData = uuids
+            .Where(partyUuid => organizationNumbersByPartyUuid.ContainsKey(partyUuid))
+            .Select((partyUuid, index) => new
+            {
+                partyId = index + 1,
+                partyUuid,
+                orgNumber = organizationNumbersByPartyUuid[partyUuid],
+            })
+            .ToArray();
+
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = JsonContent.Create(responseData)
+        };
+    }
+
+    private static async Task<string[]> GetRequestedOrganizationNumbersFromQueryAsync(HttpRequestMessage request, CancellationToken token)
+    {
+        if (request.Content == null)
+        {
+            return [];
+        }
+
+        await using var stream = await request.Content.ReadAsStreamAsync(token);
+        using JsonDocument jsonDocument = await JsonDocument.ParseAsync(stream, cancellationToken: token);
+        if (!jsonDocument.RootElement.TryGetProperty("data", out JsonElement dataElement) || dataElement.ValueKind != JsonValueKind.Array)
+        {
+            return [];
+        }
+
+        return dataElement
+            .EnumerateArray()
+            .Where(element => element.ValueKind == JsonValueKind.String)
+            .Select(element => element.GetString())
+            .Where(value => !string.IsNullOrEmpty(value))
+            .Select(value => ExtractOrganizationNumberFromUrn(value!))
+            .ToArray();
+    }
+
+    private static string ExtractOrganizationNumberFromUrn(string urn)
+    {
+        int separatorIndex = urn.LastIndexOf(':');
+        return separatorIndex >= 0
+            ? urn[(separatorIndex + 1)..]
+            : urn;
+    }
+}

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/RegisterHttpMessageHandlerHelpers.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/RegisterHttpMessageHandlerHelpers.cs
@@ -17,29 +17,29 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers;
 
 internal static class RegisterHttpMessageHandlerHelpers
 {
+    private const string IdentifiersPath = "v1/parties/identifiers";
+    private const string PartyQueryPath = "v2/internal/parties/query";
+    private const string MainUnitsPath = "v2/internal/parties/main-units";
+
     internal static void SetupRegisterPartyIdLookup(ProfileWebApplicationFactory<Program> factory, Guid partyUuid, int partyId)
     {
         factory.RegisterHttpMessageHandler.ChangeHandlerFunction((request, token) =>
         {
-            if (request.Method == HttpMethod.Get
-                && request.RequestUri?.AbsolutePath.EndsWith("v1/parties/identifiers", StringComparison.Ordinal) == true
+            if (IsIdentifiersRequest(request)
                 && request.RequestUri.Query.Contains(partyUuid.ToString(), StringComparison.OrdinalIgnoreCase))
             {
-                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                return Task.FromResult(OkJson(new[]
                 {
-                    Content = JsonContent.Create(new[]
+                    new
                     {
-                        new
-                        {
-                            partyId,
-                            partyUuid,
-                            orgNumber = string.Empty,
-                        }
-                    })
-                });
+                        partyId,
+                        partyUuid,
+                        orgNumber = string.Empty,
+                    }
+                }));
             }
 
-            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+            return Task.FromResult(NotFound());
         });
     }
 
@@ -47,44 +47,36 @@ internal static class RegisterHttpMessageHandlerHelpers
     {
         factory.RegisterHttpMessageHandler.ChangeHandlerFunction((request, token) =>
         {
-            if (request.Method == HttpMethod.Get
-                && request.RequestUri?.AbsolutePath.EndsWith("v1/parties/identifiers", StringComparison.Ordinal) == true)
+            if (IsIdentifiersRequest(request))
             {
-                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                return Task.FromResult(OkJson(new[]
                 {
-                    Content = JsonContent.Create(new[]
+                    new
+                    {
+                        partyId = identifiersPartyId,
+                        partyUuid,
+                        orgNumber = organizationNumber,
+                    }
+                }));
+            }
+
+            if (IsPartyQueryRequest(request))
+            {
+                return Task.FromResult(OkJson(new
+                {
+                    data = new[]
                     {
                         new
                         {
-                            partyId = identifiersPartyId,
+                            partyId = partyQueryPartyId,
                             partyUuid,
-                            orgNumber = organizationNumber,
+                            organizationIdentifier = organizationNumber,
                         }
-                    })
-                });
+                    }
+                }));
             }
 
-            if (request.Method == HttpMethod.Post
-                && request.RequestUri?.AbsolutePath.EndsWith("v2/internal/parties/query", StringComparison.Ordinal) == true)
-            {
-                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
-                {
-                    Content = JsonContent.Create(new
-                    {
-                        data = new[]
-                        {
-                            new
-                            {
-                                partyId = partyQueryPartyId,
-                                partyUuid,
-                                organizationIdentifier = organizationNumber,
-                            }
-                        }
-                    })
-                });
-            }
-
-            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+            return Task.FromResult(NotFound());
         });
     }
 
@@ -92,16 +84,12 @@ internal static class RegisterHttpMessageHandlerHelpers
     {
         factory.RegisterHttpMessageHandler.ChangeHandlerFunction((request, token) =>
         {
-            if (request.Method == HttpMethod.Post
-                && request.RequestUri?.AbsolutePath.EndsWith("v2/internal/parties/main-units", StringComparison.Ordinal) == true)
+            if (IsMainUnitsRequest(request))
             {
-                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
-                {
-                    Content = JsonContent.Create(new { data = new[] { new { organizationIdentifier = parentOrgNumber } } })
-                });
+                return Task.FromResult(OkJson(new { data = new[] { new { organizationIdentifier = parentOrgNumber } } }));
             }
 
-            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+            return Task.FromResult(NotFound());
         });
     }
 
@@ -121,8 +109,8 @@ internal static class RegisterHttpMessageHandlerHelpers
     {
         factory.RegisterHttpMessageHandler.ChangeHandlerFunction(async (request, token) =>
         {
-            HttpResponseMessage partyQueryResponse = await TryCreatePartyQueryResponseAsync(request, token, organizationNumbersByPartyUuid, HttpStatusCode.OK);
-            return partyQueryResponse ?? new HttpResponseMessage(HttpStatusCode.NotFound);
+            HttpResponseMessage partyQueryResponse = await TryCreatePartyQueryResponseAsync(request, organizationNumbersByPartyUuid, HttpStatusCode.OK, token);
+            return partyQueryResponse ?? NotFound();
         });
     }
 
@@ -131,7 +119,7 @@ internal static class RegisterHttpMessageHandlerHelpers
         factory.RegisterHttpMessageHandler.ChangeHandlerFunction((request, token) =>
         {
             HttpResponseMessage identifiersResponse = TryCreateIdentifiersResponse(request, organizationNumbersByPartyUuid);
-            return Task.FromResult(identifiersResponse ?? new HttpResponseMessage(HttpStatusCode.NotFound));
+            return Task.FromResult(identifiersResponse ?? NotFound());
         });
     }
 
@@ -144,7 +132,7 @@ internal static class RegisterHttpMessageHandlerHelpers
     {
         return async (request, token) =>
         {
-            HttpResponseMessage partyQueryResponse = await TryCreatePartyQueryResponseAsync(request, token, organizationNumbersByPartyUuid, partyQueryStatusCode);
+            HttpResponseMessage partyQueryResponse = await TryCreatePartyQueryResponseAsync(request, organizationNumbersByPartyUuid, partyQueryStatusCode, token);
             if (partyQueryResponse is not null)
             {
                 return partyQueryResponse;
@@ -156,7 +144,7 @@ internal static class RegisterHttpMessageHandlerHelpers
                 return identifiersResponse;
             }
 
-            return new HttpResponseMessage(HttpStatusCode.NotFound);
+            return NotFound();
         };
     }
 
@@ -194,10 +182,9 @@ internal static class RegisterHttpMessageHandlerHelpers
     {
         factory.RegisterHttpMessageHandler.ChangeHandlerFunction(async (request, token) =>
         {
-            if (request.Method != HttpMethod.Post
-                || request.RequestUri?.AbsolutePath.EndsWith("v2/internal/parties/query", StringComparison.Ordinal) != true)
+            if (!IsPartyQueryRequest(request))
             {
-                return new HttpResponseMessage(HttpStatusCode.NotFound);
+                return NotFound();
             }
 
             if (statusCode != HttpStatusCode.OK)
@@ -228,16 +215,13 @@ internal static class RegisterHttpMessageHandlerHelpers
 
             if (!hasMatch)
             {
-                return new HttpResponseMessage(HttpStatusCode.NotFound);
+                return NotFound();
             }
 
-            return new HttpResponseMessage(HttpStatusCode.OK)
+            return OkJson(new
             {
-                Content = JsonContent.Create(new
-                {
-                    data = userParty is null ? [] : new[] { userParty }
-                })
-            };
+                data = userParty is null ? [] : new[] { userParty }
+            });
         });
     }
 
@@ -245,10 +229,9 @@ internal static class RegisterHttpMessageHandlerHelpers
     {
         factory.RegisterHttpMessageHandler.ChangeHandlerFunction(async (request, token) =>
         {
-            if (request.Method != HttpMethod.Post
-                || request.RequestUri?.AbsolutePath.EndsWith("v2/internal/parties/query", StringComparison.Ordinal) != true)
+            if (!IsPartyQueryRequest(request))
             {
-                return new HttpResponseMessage(HttpStatusCode.NotFound);
+                return NotFound();
             }
 
             if (request.Content == null)
@@ -263,17 +246,13 @@ internal static class RegisterHttpMessageHandlerHelpers
                 return new HttpResponseMessage(HttpStatusCode.InternalServerError);
             }
 
-            return new HttpResponseMessage(HttpStatusCode.OK)
-            {
-                Content = JsonContent.Create(new { data = parties })
-            };
+            return OkJson(new { data = parties });
         });
     }
 
-    private static async Task<HttpResponseMessage> TryCreatePartyQueryResponseAsync(HttpRequestMessage request, CancellationToken token, IReadOnlyDictionary<Guid, string> organizationNumbersByPartyUuid, HttpStatusCode partyQueryStatusCode)
+    private static async Task<HttpResponseMessage> TryCreatePartyQueryResponseAsync(HttpRequestMessage request, IReadOnlyDictionary<Guid, string> organizationNumbersByPartyUuid, HttpStatusCode partyQueryStatusCode, CancellationToken token)
     {
-        if (request.Method != HttpMethod.Post
-            || request.RequestUri?.AbsolutePath.EndsWith("v2/internal/parties/query", StringComparison.Ordinal) != true)
+        if (!IsPartyQueryRequest(request))
         {
             return null;
         }
@@ -294,16 +273,12 @@ internal static class RegisterHttpMessageHandlerHelpers
             })
             .ToArray();
 
-        return new HttpResponseMessage(HttpStatusCode.OK)
-        {
-            Content = JsonContent.Create(new { data = responseData })
-        };
+        return OkJson(new { data = responseData });
     }
 
     private static HttpResponseMessage TryCreateIdentifiersResponse(HttpRequestMessage request, IReadOnlyDictionary<Guid, string> organizationNumbersByPartyUuid)
     {
-        if (request.Method != HttpMethod.Get
-            || request.RequestUri?.AbsolutePath.EndsWith("v1/parties/identifiers", StringComparison.Ordinal) != true)
+        if (!IsIdentifiersRequest(request))
         {
             return null;
         }
@@ -319,10 +294,7 @@ internal static class RegisterHttpMessageHandlerHelpers
             })
             .ToArray();
 
-        return new HttpResponseMessage(HttpStatusCode.OK)
-        {
-            Content = JsonContent.Create(responseData)
-        };
+        return OkJson(responseData);
     }
 
     private static async Task<string[]> GetRequestedOrganizationNumbersFromQueryAsync(HttpRequestMessage request, CancellationToken token)
@@ -346,6 +318,37 @@ internal static class RegisterHttpMessageHandlerHelpers
             .Where(value => !string.IsNullOrEmpty(value))
             .Select(value => ExtractOrganizationNumberFromUrn(value!))
             .ToArray();
+    }
+
+    private static bool IsIdentifiersRequest(HttpRequestMessage request)
+    {
+        return request.Method == HttpMethod.Get
+            && request.RequestUri?.AbsolutePath.EndsWith(IdentifiersPath, StringComparison.Ordinal) == true;
+    }
+
+    private static bool IsPartyQueryRequest(HttpRequestMessage request)
+    {
+        return request.Method == HttpMethod.Post
+            && request.RequestUri?.AbsolutePath.EndsWith(PartyQueryPath, StringComparison.Ordinal) == true;
+    }
+
+    private static bool IsMainUnitsRequest(HttpRequestMessage request)
+    {
+        return request.Method == HttpMethod.Post
+            && request.RequestUri?.AbsolutePath.EndsWith(MainUnitsPath, StringComparison.Ordinal) == true;
+    }
+
+    private static HttpResponseMessage OkJson<T>(T payload)
+    {
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = JsonContent.Create(payload)
+        };
+    }
+
+    private static HttpResponseMessage NotFound()
+    {
+        return new HttpResponseMessage(HttpStatusCode.NotFound);
     }
 
     private static string ExtractOrganizationNumberFromUrn(string urn)

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/UnitContactPointControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/UnitContactPointControllerTests.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Json;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -29,9 +31,7 @@ public class UnitContactPointControllerTests : IClassFixture<ProfileWebApplicati
     {
         _factory = factory;
 
-        _factory.RegisterClientMock.Reset();
-        _factory.RegisterClientMock.Setup(s => s.GetPartyUuids(It.IsAny<string[]>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((string[] orgNumbers, CancellationToken _) => GetRegisterResponse(orgNumbers));
+        SetupRegisterPartyUuidsLookup(orgNumbers => GetRegisterResponse(orgNumbers));
 
         _factory.ProfessionalNotificationsRepositoryMock.Setup(s => s.GetAllNotificationAddressesForPartyAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((Guid partyUuid, CancellationToken _) => GetRepositoryResponse(partyUuid.ToString()));
@@ -167,8 +167,7 @@ public class UnitContactPointControllerTests : IClassFixture<ProfileWebApplicati
             ResourceId = "app_ttd_apps-test"
         };
 
-        _factory.RegisterClientMock.Setup(s => s.GetPartyUuids(It.IsAny<string[]>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((string[] orgNumbers, CancellationToken _) => null);
+        SetupRegisterPartyUuidsLookup(_ => null);
 
         var client = _factory.CreateClient();
 
@@ -179,6 +178,49 @@ public class UnitContactPointControllerTests : IClassFixture<ProfileWebApplicati
 
         // Assert
         Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+    }
+
+    private void SetupRegisterPartyUuidsLookup(Func<string[], List<Party>?> responseFactory)
+    {
+        _factory.RegisterHttpMessageHandler.ChangeHandlerFunction(async (request, token) =>
+        {
+            if (request.Method == HttpMethod.Post
+                && request.RequestUri?.AbsolutePath.EndsWith("v2/internal/parties/query", StringComparison.Ordinal) == true)
+            {
+                if (request.Content == null)
+                {
+                    return new HttpResponseMessage(HttpStatusCode.BadRequest);
+                }
+
+                await using var stream = await request.Content.ReadAsStreamAsync(token);
+                using JsonDocument jsonDocument = await JsonDocument.ParseAsync(stream, cancellationToken: token);
+
+                string[] orgNumbers = [];
+                if (jsonDocument.RootElement.TryGetProperty("data", out JsonElement dataElement) && dataElement.ValueKind == JsonValueKind.Array)
+                {
+                    orgNumbers = dataElement
+                        .EnumerateArray()
+                        .Where(element => element.ValueKind == JsonValueKind.String)
+                        .Select(element => element.GetString())
+                        .Where(value => !string.IsNullOrWhiteSpace(value))
+                        .Select(value => value[(value.LastIndexOf(':') + 1)..])
+                        .ToArray();
+                }
+
+                List<Party>? parties = responseFactory(orgNumbers);
+                if (parties == null)
+                {
+                    return new HttpResponseMessage(HttpStatusCode.InternalServerError);
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = JsonContent.Create(new { data = parties })
+                };
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        });
     }
 
     private HttpRequestMessage CreateHttpRequestMessage(UnitContactPointLookup input)

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/UnitContactPointControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/UnitContactPointControllerTests.cs
@@ -207,7 +207,7 @@ public class UnitContactPointControllerTests : IClassFixture<ProfileWebApplicati
                         .ToArray();
                 }
 
-                List<Party>? parties = responseFactory(orgNumbers);
+                List<Party> parties = responseFactory(orgNumbers);
                 if (parties == null)
                 {
                     return new HttpResponseMessage(HttpStatusCode.InternalServerError);

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/UnitContactPointControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/UnitContactPointControllerTests.cs
@@ -31,7 +31,7 @@ public class UnitContactPointControllerTests : IClassFixture<ProfileWebApplicati
     {
         _factory = factory;
 
-        SetupRegisterPartyUuidsLookup(orgNumbers => GetRegisterResponse(orgNumbers));
+        RegisterHttpMessageHandlerHelpers.SetupRegisterPartyQueryLookup(_factory, orgNumbers => GetRegisterResponse(orgNumbers));
 
         _factory.ProfessionalNotificationsRepositoryMock.Setup(s => s.GetAllNotificationAddressesForPartyAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((Guid partyUuid, CancellationToken _) => GetRepositoryResponse(partyUuid.ToString()));
@@ -167,7 +167,7 @@ public class UnitContactPointControllerTests : IClassFixture<ProfileWebApplicati
             ResourceId = "app_ttd_apps-test"
         };
 
-        SetupRegisterPartyUuidsLookup(_ => null);
+        RegisterHttpMessageHandlerHelpers.SetupRegisterPartyQueryLookup(_factory, _ => (List<Party>)null);
 
         var client = _factory.CreateClient();
 
@@ -178,49 +178,6 @@ public class UnitContactPointControllerTests : IClassFixture<ProfileWebApplicati
 
         // Assert
         Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
-    }
-
-    private void SetupRegisterPartyUuidsLookup(Func<string[], List<Party>> responseFactory)
-    {
-        _factory.RegisterHttpMessageHandler.ChangeHandlerFunction(async (request, token) =>
-        {
-            if (request.Method == HttpMethod.Post
-                && request.RequestUri?.AbsolutePath.EndsWith("v2/internal/parties/query", StringComparison.Ordinal) == true)
-            {
-                if (request.Content == null)
-                {
-                    return new HttpResponseMessage(HttpStatusCode.BadRequest);
-                }
-
-                await using var stream = await request.Content.ReadAsStreamAsync(token);
-                using JsonDocument jsonDocument = await JsonDocument.ParseAsync(stream, cancellationToken: token);
-
-                string[] orgNumbers = [];
-                if (jsonDocument.RootElement.TryGetProperty("data", out JsonElement dataElement) && dataElement.ValueKind == JsonValueKind.Array)
-                {
-                    orgNumbers = dataElement
-                        .EnumerateArray()
-                        .Where(element => element.ValueKind == JsonValueKind.String)
-                        .Select(element => element.GetString())
-                        .Where(value => !string.IsNullOrWhiteSpace(value))
-                        .Select(value => value[(value.LastIndexOf(':') + 1)..])
-                        .ToArray();
-                }
-
-                List<Party> parties = responseFactory(orgNumbers);
-                if (parties == null)
-                {
-                    return new HttpResponseMessage(HttpStatusCode.InternalServerError);
-                }
-
-                return new HttpResponseMessage(HttpStatusCode.OK)
-                {
-                    Content = JsonContent.Create(new { data = parties })
-                };
-            }
-
-            return new HttpResponseMessage(HttpStatusCode.NotFound);
-        });
     }
 
     private HttpRequestMessage CreateHttpRequestMessage(UnitContactPointLookup input)

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/UnitContactPointControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/UnitContactPointControllerTests.cs
@@ -180,7 +180,7 @@ public class UnitContactPointControllerTests : IClassFixture<ProfileWebApplicati
         Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
     }
 
-    private void SetupRegisterPartyUuidsLookup(Func<string[], List<Party>?> responseFactory)
+    private void SetupRegisterPartyUuidsLookup(Func<string[], List<Party>> responseFactory)
     {
         _factory.RegisterHttpMessageHandler.ChangeHandlerFunction(async (request, token) =>
         {

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/UserProfileInternalControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/UserProfileInternalControllerTests.cs
@@ -13,7 +13,6 @@ using Altinn.Profile.Models;
 using Altinn.Profile.Tests.Testdata;
 using Altinn.Register.Contracts;
 using Altinn.Register.Contracts.Testing;
-using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.Configuration;
 using Moq;
 using Xunit;
@@ -35,8 +34,13 @@ public class UserProfileInternalControllerTests : IClassFixture<ProfileWebApplic
     {
         _factory = factory;
         _factory.MemoryCache.Clear();
-        _factory.RegisterClientMock.Reset();
         _factory.InMemoryConfigurationCollection.Clear();
+        _factory.ProfileSettingsRepositoryMock.Reset();
+
+        _factory.SblBridgeHttpMessageHandler.ChangeHandlerFunction((request, token) =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound)));
+        _factory.RegisterHttpMessageHandler.ChangeHandlerFunction((request, token) =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound)));
     }
 
     [Fact]
@@ -547,12 +551,9 @@ public class UserProfileInternalControllerTests : IClassFixture<ProfileWebApplic
             IsDeleted = false,
         };
 
-        _factory.RegisterClientMock
-            .Setup(m => m.GetUserParty(userId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(registerPerson);
+        SetupRegisterUserPartyByUserIdLookup(userId, registerPerson);
 
-        EnableRegisterAsPrimary();
-        HttpClient client = _factory.CreateClient();
+        HttpClient client = CreateClientWithRegisterAsPrimary(true);
 
         HttpRequestMessage httpRequestMessage = CreatePostRequest("/profile/api/v1/internal/user/", new UserProfileLookup { UserId = userId });
 
@@ -570,7 +571,6 @@ public class UserProfileInternalControllerTests : IClassFixture<ProfileWebApplic
         Assert.Equal("Register Person", actualUser.Party.Name);
         Assert.Equal("14836498780", actualUser.Party.SSN);
 
-        _factory.RegisterClientMock.Verify(m => m.GetUserParty(userId, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -587,12 +587,9 @@ public class UserProfileInternalControllerTests : IClassFixture<ProfileWebApplic
             return new HttpResponseMessage() { Content = JsonContent.Create(userProfile) };
         });
 
-        _factory.RegisterClientMock
-            .Setup(m => m.GetUserPartyByUsername(username, It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new HttpRequestException("Register unavailable"));
-        
-        EnableRegisterAsPrimary();
-        HttpClient client = _factory.CreateClient();
+        SetupRegisterUserPartyByUsernameLookup(username, null, HttpStatusCode.InternalServerError);
+
+        HttpClient client = CreateClientWithRegisterAsPrimary(true);
 
         HttpRequestMessage httpRequestMessage = CreatePostRequest("/profile/api/v1/internal/user/", new UserProfileLookup { Username = username });
 
@@ -606,9 +603,122 @@ public class UserProfileInternalControllerTests : IClassFixture<ProfileWebApplic
         Assert.EndsWith($"sblbridge/profile/api/users/?username={username}", sblRequest.RequestUri.ToString());
     }
 
-    private void EnableRegisterAsPrimary()
+    private void SetupRegisterUserPartyByUserIdLookup(int userId, Party? userParty, HttpStatusCode statusCode = HttpStatusCode.OK)
     {
-        _factory.InMemoryConfigurationCollection["CoreSettings:RegisterAsPrimaryUserProfileSource"] = "true";
+        _factory.RegisterHttpMessageHandler.ChangeHandlerFunction(async (request, token) =>
+        {
+            if (request.Method != HttpMethod.Post
+                || request.RequestUri?.AbsolutePath.EndsWith("v2/internal/parties/query", StringComparison.Ordinal) != true)
+            {
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+            }
+
+            if (statusCode != HttpStatusCode.OK)
+            {
+                return new HttpResponseMessage(statusCode);
+            }
+
+            if (request.Content == null)
+            {
+                return new HttpResponseMessage(HttpStatusCode.BadRequest);
+            }
+
+            await using var stream = await request.Content.ReadAsStreamAsync(token);
+            using JsonDocument jsonDocument = await JsonDocument.ParseAsync(stream, cancellationToken: token);
+
+            string expectedIdentifier = $"urn:altinn:user:id:{userId}";
+            bool hasMatch = false;
+            if (jsonDocument.RootElement.TryGetProperty("data", out JsonElement dataElement) && dataElement.ValueKind == JsonValueKind.Array)
+            {
+                foreach (JsonElement element in dataElement.EnumerateArray())
+                {
+                    if (element.ValueKind == JsonValueKind.String && string.Equals(element.GetString(), expectedIdentifier, StringComparison.Ordinal))
+                    {
+                        hasMatch = true;
+                        break;
+                    }
+                }
+            }
+
+            if (!hasMatch)
+            {
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(new
+                {
+                    data = userParty is null ? [] : new[] { userParty }
+                })
+            };
+        });
+    }
+
+    private void SetupRegisterUserPartyByUsernameLookup(string username, Party? userParty, HttpStatusCode statusCode = HttpStatusCode.OK)
+    {
+        _factory.RegisterHttpMessageHandler.ChangeHandlerFunction(async (request, token) =>
+        {
+            if (request.Method != HttpMethod.Post
+                || request.RequestUri?.AbsolutePath.EndsWith("v2/internal/parties/query", StringComparison.Ordinal) != true)
+            {
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+            }
+
+            if (statusCode != HttpStatusCode.OK)
+            {
+                return new HttpResponseMessage(statusCode);
+            }
+
+            if (request.Content == null)
+            {
+                return new HttpResponseMessage(HttpStatusCode.BadRequest);
+            }
+
+            await using var stream = await request.Content.ReadAsStreamAsync(token);
+            using JsonDocument jsonDocument = await JsonDocument.ParseAsync(stream, cancellationToken: token);
+
+            string expectedIdentifier = $"urn:altinn:party:username:{username}";
+            bool hasMatch = false;
+            if (jsonDocument.RootElement.TryGetProperty("data", out JsonElement dataElement) && dataElement.ValueKind == JsonValueKind.Array)
+            {
+                foreach (JsonElement element in dataElement.EnumerateArray())
+                {
+                    if (element.ValueKind == JsonValueKind.String && string.Equals(element.GetString(), expectedIdentifier, StringComparison.Ordinal))
+                    {
+                        hasMatch = true;
+                        break;
+                    }
+                }
+            }
+
+            if (!hasMatch)
+            {
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(new
+                {
+                    data = userParty is null ? [] : new[] { userParty }
+                })
+            };
+        });
+    }
+
+    private HttpClient CreateClientWithRegisterAsPrimary(bool enabled)
+    {
+        return _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureAppConfiguration((_, config) =>
+            {
+                config.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["CoreSettings:RegisterAsPrimaryUserProfileSource"] = enabled ? "true" : "false"
+                });
+            });
+        }).CreateClient();
     }
 
     private static HttpRequestMessage CreatePostRequest(string requestUri, UserProfileLookup lookupRequest)

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/UserProfileInternalControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/UserProfileInternalControllerTests.cs
@@ -570,7 +570,6 @@ public class UserProfileInternalControllerTests : IClassFixture<ProfileWebApplic
         Assert.NotNull(actualUser);
         Assert.Equal("Register Person", actualUser.Party.Name);
         Assert.Equal("14836498780", actualUser.Party.SSN);
-
     }
 
     [Fact]
@@ -603,7 +602,7 @@ public class UserProfileInternalControllerTests : IClassFixture<ProfileWebApplic
         Assert.EndsWith($"sblbridge/profile/api/users/?username={username}", sblRequest.RequestUri.ToString());
     }
 
-    private void SetupRegisterUserPartyByUserIdLookup(int userId, Party? userParty, HttpStatusCode statusCode = HttpStatusCode.OK)
+    private void SetupRegisterUserPartyByUserIdLookup(int userId, Party userParty, HttpStatusCode statusCode = HttpStatusCode.OK)
     {
         _factory.RegisterHttpMessageHandler.ChangeHandlerFunction(async (request, token) =>
         {
@@ -655,7 +654,7 @@ public class UserProfileInternalControllerTests : IClassFixture<ProfileWebApplic
         });
     }
 
-    private void SetupRegisterUserPartyByUsernameLookup(string username, Party? userParty, HttpStatusCode statusCode = HttpStatusCode.OK)
+    private void SetupRegisterUserPartyByUsernameLookup(string username, Party userParty, HttpStatusCode statusCode = HttpStatusCode.OK)
     {
         _factory.RegisterHttpMessageHandler.ChangeHandlerFunction(async (request, token) =>
         {
@@ -713,7 +712,7 @@ public class UserProfileInternalControllerTests : IClassFixture<ProfileWebApplic
         {
             builder.ConfigureAppConfiguration((_, config) =>
             {
-                config.AddInMemoryCollection(new Dictionary<string, string?>
+                config.AddInMemoryCollection(new Dictionary<string, string>
                 {
                     ["CoreSettings:RegisterAsPrimaryUserProfileSource"] = enabled ? "true" : "false"
                 });
@@ -725,13 +724,6 @@ public class UserProfileInternalControllerTests : IClassFixture<ProfileWebApplic
     {
         HttpRequestMessage httpRequestMessage = new(HttpMethod.Post, requestUri);
         httpRequestMessage.Content = new StringContent(JsonSerializer.Serialize(lookupRequest), Encoding.UTF8, "application/json");
-        return httpRequestMessage;
-    }
-
-    private static HttpRequestMessage CreatePostRequest(string requestUri, List<Guid> listRequest)
-    {
-        HttpRequestMessage httpRequestMessage = new(HttpMethod.Post, requestUri);
-        httpRequestMessage.Content = new StringContent(JsonSerializer.Serialize(listRequest), Encoding.UTF8, "application/json");
         return httpRequestMessage;
     }
 }

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/UserProfileInternalControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/UserProfileInternalControllerTests.cs
@@ -551,7 +551,7 @@ public class UserProfileInternalControllerTests : IClassFixture<ProfileWebApplic
             IsDeleted = false,
         };
 
-        SetupRegisterUserPartyByUserIdLookup(userId, registerPerson);
+        RegisterHttpMessageHandlerHelpers.SetupRegisterUserPartyByUserIdLookup(_factory, userId, registerPerson);
 
         HttpClient client = CreateClientWithRegisterAsPrimary(true);
 
@@ -586,7 +586,7 @@ public class UserProfileInternalControllerTests : IClassFixture<ProfileWebApplic
             return new HttpResponseMessage() { Content = JsonContent.Create(userProfile) };
         });
 
-        SetupRegisterUserPartyByUsernameLookup(username, null, HttpStatusCode.InternalServerError);
+        RegisterHttpMessageHandlerHelpers.SetupRegisterUserPartyByUsernameLookup(_factory, username, null, HttpStatusCode.InternalServerError);
 
         HttpClient client = CreateClientWithRegisterAsPrimary(true);
 
@@ -600,110 +600,6 @@ public class UserProfileInternalControllerTests : IClassFixture<ProfileWebApplic
         Assert.NotNull(sblRequest);
         Assert.Equal(HttpMethod.Get, sblRequest.Method);
         Assert.EndsWith($"sblbridge/profile/api/users/?username={username}", sblRequest.RequestUri.ToString());
-    }
-
-    private void SetupRegisterUserPartyByUserIdLookup(int userId, Party userParty, HttpStatusCode statusCode = HttpStatusCode.OK)
-    {
-        _factory.RegisterHttpMessageHandler.ChangeHandlerFunction(async (request, token) =>
-        {
-            if (request.Method != HttpMethod.Post
-                || request.RequestUri?.AbsolutePath.EndsWith("v2/internal/parties/query", StringComparison.Ordinal) != true)
-            {
-                return new HttpResponseMessage(HttpStatusCode.NotFound);
-            }
-
-            if (statusCode != HttpStatusCode.OK)
-            {
-                return new HttpResponseMessage(statusCode);
-            }
-
-            if (request.Content == null)
-            {
-                return new HttpResponseMessage(HttpStatusCode.BadRequest);
-            }
-
-            await using var stream = await request.Content.ReadAsStreamAsync(token);
-            using JsonDocument jsonDocument = await JsonDocument.ParseAsync(stream, cancellationToken: token);
-
-            string expectedIdentifier = $"urn:altinn:user:id:{userId}";
-            bool hasMatch = false;
-            if (jsonDocument.RootElement.TryGetProperty("data", out JsonElement dataElement) && dataElement.ValueKind == JsonValueKind.Array)
-            {
-                foreach (JsonElement element in dataElement.EnumerateArray())
-                {
-                    if (element.ValueKind == JsonValueKind.String && string.Equals(element.GetString(), expectedIdentifier, StringComparison.Ordinal))
-                    {
-                        hasMatch = true;
-                        break;
-                    }
-                }
-            }
-
-            if (!hasMatch)
-            {
-                return new HttpResponseMessage(HttpStatusCode.NotFound);
-            }
-
-            return new HttpResponseMessage(HttpStatusCode.OK)
-            {
-                Content = JsonContent.Create(new
-                {
-                    data = userParty is null ? [] : new[] { userParty }
-                })
-            };
-        });
-    }
-
-    private void SetupRegisterUserPartyByUsernameLookup(string username, Party userParty, HttpStatusCode statusCode = HttpStatusCode.OK)
-    {
-        _factory.RegisterHttpMessageHandler.ChangeHandlerFunction(async (request, token) =>
-        {
-            if (request.Method != HttpMethod.Post
-                || request.RequestUri?.AbsolutePath.EndsWith("v2/internal/parties/query", StringComparison.Ordinal) != true)
-            {
-                return new HttpResponseMessage(HttpStatusCode.NotFound);
-            }
-
-            if (statusCode != HttpStatusCode.OK)
-            {
-                return new HttpResponseMessage(statusCode);
-            }
-
-            if (request.Content == null)
-            {
-                return new HttpResponseMessage(HttpStatusCode.BadRequest);
-            }
-
-            await using var stream = await request.Content.ReadAsStreamAsync(token);
-            using JsonDocument jsonDocument = await JsonDocument.ParseAsync(stream, cancellationToken: token);
-
-            string expectedIdentifier = $"urn:altinn:party:username:{username}";
-            bool hasMatch = false;
-            if (jsonDocument.RootElement.TryGetProperty("data", out JsonElement dataElement) && dataElement.ValueKind == JsonValueKind.Array)
-            {
-                foreach (JsonElement element in dataElement.EnumerateArray())
-                {
-                    if (element.ValueKind == JsonValueKind.String && string.Equals(element.GetString(), expectedIdentifier, StringComparison.Ordinal))
-                    {
-                        hasMatch = true;
-                        break;
-                    }
-                }
-            }
-
-            if (!hasMatch)
-            {
-                return new HttpResponseMessage(HttpStatusCode.NotFound);
-            }
-
-            return new HttpResponseMessage(HttpStatusCode.OK)
-            {
-                Content = JsonContent.Create(new
-                {
-                    data = userParty is null ? [] : new[] { userParty }
-                })
-            };
-        });
     }
 
     private HttpClient CreateClientWithRegisterAsPrimary(bool enabled)

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/UsersControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/UsersControllerTests.cs
@@ -45,7 +45,7 @@ public class UsersControllerTests : IClassFixture<ProfileWebApplicationFactory<P
         _factory.InMemoryConfigurationCollection.Clear();
         _factory.MemoryCache.Clear();
         _factory.PersonServiceMock.Reset();
-        _factory.RegisterClientMock.Reset();
+        _factory.ProfileSettingsRepositoryMock.Reset();
         _factory.UserContactInfoRepositoryMock.Reset();
     }
 
@@ -75,8 +75,7 @@ public class UsersControllerTests : IClassFixture<ProfileWebApplicationFactory<P
                 PreselectedPartyUuid = preselectedPartyUuid,
             });
 
-        _factory.RegisterClientMock.Setup(m => m.GetPartyId(preselectedPartyUuid, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(123456);
+        SetupRegisterPartyIdLookup(preselectedPartyUuid, 123456);
 
         HttpClient client = _factory.CreateClient();
 
@@ -240,8 +239,7 @@ public class UsersControllerTests : IClassFixture<ProfileWebApplicationFactory<P
         _factory.PersonServiceMock.Setup(m => m.GetContactPreferencesAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync([new PersonContactPreferences { Email = "test@mail.com", NationalIdentityNumber = "1", MobileNumber = "+4798765432", IsReserved = true }]);
 
-        _factory.RegisterClientMock.Setup(m => m.GetPartyId(preselectedPartyUuid, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(123456);
+        SetupRegisterPartyIdLookup(preselectedPartyUuid, 123456);
 
         HttpRequestMessage httpRequestMessage = CreateGetRequest(UserId, $"/profile/api/v1/users/{UserId}");
 
@@ -432,6 +430,9 @@ public class UsersControllerTests : IClassFixture<ProfileWebApplicationFactory<P
 
         // Arrange
         const int UserId = 2516356;
+
+        _factory.RegisterHttpMessageHandler.ChangeHandlerFunction((request, token) =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound)));
 
         HttpRequestMessage? sblRequest = null;
         _factory.SblBridgeHttpMessageHandler.ChangeHandlerFunction(async (request, token) =>
@@ -917,9 +918,7 @@ public class UsersControllerTests : IClassFixture<ProfileWebApplicationFactory<P
             IsDeleted = false,
         };
 
-        _factory.RegisterClientMock
-            .Setup(m => m.GetUserParty(userId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(registerPerson);
+        SetupRegisterUserPartyByUserIdLookup(userId, registerPerson);
 
         _factory.ProfileSettingsRepositoryMock
             .Setup(m => m.GetProfileSettings(It.IsAny<int>(), It.IsAny<CancellationToken>()))
@@ -948,7 +947,6 @@ public class UsersControllerTests : IClassFixture<ProfileWebApplicationFactory<P
         Assert.Equal("Register Person", actualUser.Party.Name);
         Assert.Equal("14836498780", actualUser.Party.SSN);
 
-        _factory.RegisterClientMock.Verify(m => m.GetUserParty(userId, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -965,9 +963,7 @@ public class UsersControllerTests : IClassFixture<ProfileWebApplicationFactory<P
             return new HttpResponseMessage() { Content = JsonContent.Create(userProfile) };
         });
 
-        _factory.RegisterClientMock
-            .Setup(m => m.GetUserParty(userId, It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new HttpRequestException("Register unavailable"));
+        SetupRegisterUserPartyByUserIdLookup(userId, null, HttpStatusCode.InternalServerError);
 
         _factory.ProfileSettingsRepositoryMock
             .Setup(m => m.GetProfileSettings(It.IsAny<int>(), It.IsAny<CancellationToken>()))
@@ -1026,7 +1022,6 @@ public class UsersControllerTests : IClassFixture<ProfileWebApplicationFactory<P
         Assert.NotNull(sblRequest); // fallback path must call legacy
         Assert.EndsWith($"users/{userId}", sblRequest!.RequestUri?.ToString());
 
-        _factory.RegisterClientMock.Verify(m => m.GetUserParty(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
@@ -1045,9 +1040,7 @@ public class UsersControllerTests : IClassFixture<ProfileWebApplicationFactory<P
 
         SelfIdentifiedUser selfIdentifiedFromRegister = await TestDataLoader.Load<SelfIdentifiedUser>("siuser-input");
 
-        _factory.RegisterClientMock
-            .Setup(m => m.GetUserParty(userId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(selfIdentifiedFromRegister);
+        SetupRegisterUserPartyByUserIdLookup(userId, selfIdentifiedFromRegister);
 
         _factory.ProfileSettingsRepositoryMock
             .Setup(m => m.GetProfileSettings(It.IsAny<int>(), It.IsAny<CancellationToken>()))
@@ -1131,6 +1124,84 @@ public class UsersControllerTests : IClassFixture<ProfileWebApplicationFactory<P
 
         _factory.UserContactInfoRepositoryMock.Verify(m => m.Get(UserId, It.IsAny<CancellationToken>()), Times.Once);
         _factory.PersonServiceMock.Verify(m => m.GetContactPreferencesAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    private void SetupRegisterPartyIdLookup(Guid partyUuid, int partyId)
+    {
+        _factory.RegisterHttpMessageHandler.ChangeHandlerFunction((request, token) =>
+        {
+            if (request.Method == HttpMethod.Get
+                && request.RequestUri?.AbsolutePath.EndsWith("v1/parties/identifiers", StringComparison.Ordinal) == true
+                && request.RequestUri.Query.Contains(partyUuid.ToString(), StringComparison.OrdinalIgnoreCase))
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = JsonContent.Create(new[]
+                    {
+                        new
+                        {
+                            partyId,
+                            partyUuid,
+                            orgNumber = string.Empty
+                        }
+                    })
+                });
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        });
+    }
+
+    private void SetupRegisterUserPartyByUserIdLookup(int userId, Party? userParty, HttpStatusCode statusCode = HttpStatusCode.OK)
+    {
+        _factory.RegisterHttpMessageHandler.ChangeHandlerFunction(async (request, token) =>
+        {
+            if (request.Method != HttpMethod.Post
+                || request.RequestUri?.AbsolutePath.EndsWith("v2/internal/parties/query", StringComparison.Ordinal) != true)
+            {
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+            }
+
+            if (statusCode != HttpStatusCode.OK)
+            {
+                return new HttpResponseMessage(statusCode);
+            }
+
+            if (request.Content == null)
+            {
+                return new HttpResponseMessage(HttpStatusCode.BadRequest);
+            }
+
+            await using var stream = await request.Content.ReadAsStreamAsync(token);
+            using JsonDocument jsonDocument = await JsonDocument.ParseAsync(stream, cancellationToken: token);
+
+            string expectedIdentifier = $"urn:altinn:user:id:{userId}";
+            bool hasMatch = false;
+            if (jsonDocument.RootElement.TryGetProperty("data", out JsonElement dataElement) && dataElement.ValueKind == JsonValueKind.Array)
+            {
+                foreach (JsonElement element in dataElement.EnumerateArray())
+                {
+                    if (element.ValueKind == JsonValueKind.String && string.Equals(element.GetString(), expectedIdentifier, StringComparison.Ordinal))
+                    {
+                        hasMatch = true;
+                        break;
+                    }
+                }
+            }
+
+            if (!hasMatch)
+            {
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(new
+                {
+                    data = userParty is null ? [] : new[] { userParty }
+                })
+            };
+        });
     }
 
     private static HttpRequestMessage CreateGetRequest(int userId, string requestUri)

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/UsersControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/UsersControllerTests.cs
@@ -946,7 +946,6 @@ public class UsersControllerTests : IClassFixture<ProfileWebApplicationFactory<P
         Assert.NotNull(actualUser);
         Assert.Equal("Register Person", actualUser.Party.Name);
         Assert.Equal("14836498780", actualUser.Party.SSN);
-
     }
 
     [Fact]
@@ -1021,7 +1020,6 @@ public class UsersControllerTests : IClassFixture<ProfileWebApplicationFactory<P
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         Assert.NotNull(sblRequest); // fallback path must call legacy
         Assert.EndsWith($"users/{userId}", sblRequest!.RequestUri?.ToString());
-
     }
 
     [Fact]

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/UsersControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/UsersControllerTests.cs
@@ -75,7 +75,7 @@ public class UsersControllerTests : IClassFixture<ProfileWebApplicationFactory<P
                 PreselectedPartyUuid = preselectedPartyUuid,
             });
 
-        SetupRegisterPartyIdLookup(preselectedPartyUuid, 123456);
+        RegisterHttpMessageHandlerHelpers.SetupRegisterPartyIdLookup(_factory, preselectedPartyUuid, 123456);
 
         HttpClient client = _factory.CreateClient();
 
@@ -239,7 +239,7 @@ public class UsersControllerTests : IClassFixture<ProfileWebApplicationFactory<P
         _factory.PersonServiceMock.Setup(m => m.GetContactPreferencesAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync([new PersonContactPreferences { Email = "test@mail.com", NationalIdentityNumber = "1", MobileNumber = "+4798765432", IsReserved = true }]);
 
-        SetupRegisterPartyIdLookup(preselectedPartyUuid, 123456);
+        RegisterHttpMessageHandlerHelpers.SetupRegisterPartyIdLookup(_factory, preselectedPartyUuid, 123456);
 
         HttpRequestMessage httpRequestMessage = CreateGetRequest(UserId, $"/profile/api/v1/users/{UserId}");
 
@@ -918,7 +918,7 @@ public class UsersControllerTests : IClassFixture<ProfileWebApplicationFactory<P
             IsDeleted = false,
         };
 
-        SetupRegisterUserPartyByUserIdLookup(userId, registerPerson);
+        RegisterHttpMessageHandlerHelpers.SetupRegisterUserPartyByUserIdLookup(_factory, userId, registerPerson);
 
         _factory.ProfileSettingsRepositoryMock
             .Setup(m => m.GetProfileSettings(It.IsAny<int>(), It.IsAny<CancellationToken>()))
@@ -962,7 +962,7 @@ public class UsersControllerTests : IClassFixture<ProfileWebApplicationFactory<P
             return new HttpResponseMessage() { Content = JsonContent.Create(userProfile) };
         });
 
-        SetupRegisterUserPartyByUserIdLookup(userId, null, HttpStatusCode.InternalServerError);
+        RegisterHttpMessageHandlerHelpers.SetupRegisterUserPartyByUserIdLookup(_factory, userId, null, HttpStatusCode.InternalServerError);
 
         _factory.ProfileSettingsRepositoryMock
             .Setup(m => m.GetProfileSettings(It.IsAny<int>(), It.IsAny<CancellationToken>()))
@@ -1038,7 +1038,7 @@ public class UsersControllerTests : IClassFixture<ProfileWebApplicationFactory<P
 
         SelfIdentifiedUser selfIdentifiedFromRegister = await TestDataLoader.Load<SelfIdentifiedUser>("siuser-input");
 
-        SetupRegisterUserPartyByUserIdLookup(userId, selfIdentifiedFromRegister);
+        RegisterHttpMessageHandlerHelpers.SetupRegisterUserPartyByUserIdLookup(_factory, userId, selfIdentifiedFromRegister);
 
         _factory.ProfileSettingsRepositoryMock
             .Setup(m => m.GetProfileSettings(It.IsAny<int>(), It.IsAny<CancellationToken>()))
@@ -1122,84 +1122,6 @@ public class UsersControllerTests : IClassFixture<ProfileWebApplicationFactory<P
 
         _factory.UserContactInfoRepositoryMock.Verify(m => m.Get(UserId, It.IsAny<CancellationToken>()), Times.Once);
         _factory.PersonServiceMock.Verify(m => m.GetContactPreferencesAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()), Times.Never);
-    }
-
-    private void SetupRegisterPartyIdLookup(Guid partyUuid, int partyId)
-    {
-        _factory.RegisterHttpMessageHandler.ChangeHandlerFunction((request, token) =>
-        {
-            if (request.Method == HttpMethod.Get
-                && request.RequestUri?.AbsolutePath.EndsWith("v1/parties/identifiers", StringComparison.Ordinal) == true
-                && request.RequestUri.Query.Contains(partyUuid.ToString(), StringComparison.OrdinalIgnoreCase))
-            {
-                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
-                {
-                    Content = JsonContent.Create(new[]
-                    {
-                        new
-                        {
-                            partyId,
-                            partyUuid,
-                            orgNumber = string.Empty
-                        }
-                    })
-                });
-            }
-
-            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
-        });
-    }
-
-    private void SetupRegisterUserPartyByUserIdLookup(int userId, Party? userParty, HttpStatusCode statusCode = HttpStatusCode.OK)
-    {
-        _factory.RegisterHttpMessageHandler.ChangeHandlerFunction(async (request, token) =>
-        {
-            if (request.Method != HttpMethod.Post
-                || request.RequestUri?.AbsolutePath.EndsWith("v2/internal/parties/query", StringComparison.Ordinal) != true)
-            {
-                return new HttpResponseMessage(HttpStatusCode.NotFound);
-            }
-
-            if (statusCode != HttpStatusCode.OK)
-            {
-                return new HttpResponseMessage(statusCode);
-            }
-
-            if (request.Content == null)
-            {
-                return new HttpResponseMessage(HttpStatusCode.BadRequest);
-            }
-
-            await using var stream = await request.Content.ReadAsStreamAsync(token);
-            using JsonDocument jsonDocument = await JsonDocument.ParseAsync(stream, cancellationToken: token);
-
-            string expectedIdentifier = $"urn:altinn:user:id:{userId}";
-            bool hasMatch = false;
-            if (jsonDocument.RootElement.TryGetProperty("data", out JsonElement dataElement) && dataElement.ValueKind == JsonValueKind.Array)
-            {
-                foreach (JsonElement element in dataElement.EnumerateArray())
-                {
-                    if (element.ValueKind == JsonValueKind.String && string.Equals(element.GetString(), expectedIdentifier, StringComparison.Ordinal))
-                    {
-                        hasMatch = true;
-                        break;
-                    }
-                }
-            }
-
-            if (!hasMatch)
-            {
-                return new HttpResponseMessage(HttpStatusCode.NotFound);
-            }
-
-            return new HttpResponseMessage(HttpStatusCode.OK)
-            {
-                Content = JsonContent.Create(new
-                {
-                    data = userParty is null ? [] : new[] { userParty }
-                })
-            };
-        });
     }
 
     private static HttpRequestMessage CreateGetRequest(int userId, string requestUri)

--- a/test/Altinn.Profile.Tests/IntegrationTests/ProfileWebApplicationFactory.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/ProfileWebApplicationFactory.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using Altinn.Common.AccessToken.Services;
+using Altinn.Common.AccessTokenClient.Services;
 using Altinn.Common.PEP.Interfaces;
 using Altinn.Profile.Core;
 using Altinn.Profile.Core.Integrations;
@@ -16,6 +17,7 @@ using Altinn.Profile.Core.Unit.ContactPoints;
 using Altinn.Profile.Integrations.Authorization;
 using Altinn.Profile.Integrations.ContactRegister;
 using Altinn.Profile.Integrations.OrganizationNotificationAddressRegistry;
+using Altinn.Profile.Integrations.Register;
 using Altinn.Profile.Integrations.SblBridge;
 using Altinn.Profile.Integrations.SblBridge.User.Profile;
 using Altinn.Profile.Tests.IntegrationTests.Mocks;
@@ -63,14 +65,20 @@ public sealed class ProfileWebApplicationFactory<TProgram> : WebApplicationFacto
 
     public Mock<IProfessionalNotificationsRepository> ProfessionalNotificationsRepositoryMock { get; set; } = new();
 
-    public Mock<IRegisterClient> RegisterClientMock { get; set; } = new();
+    public Mock<IAccessTokenGenerator> AccessTokenGeneratorMock { get; set; } = new();
 
     public Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> MessageHandlerFunc { get; set; } =
         (request, cancellationToken) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
 
+    public DelegatingHandlerStub RegisterHttpMessageHandler { get; set; } = new();
+
     public DelegatingHandlerStub SblBridgeHttpMessageHandler { get; set; } = new();
 
+    public Mock<IOptions<RegisterSettings>> RegisterSettingsOptions { get; set; } = new();
+
     public Mock<IOptions<SblBridgeSettings>> SblBridgeSettingsOptions { get; set; } = new();
+
+    public Mock<ILogger<RegisterClient>> RegisterClientLogger { get; set; } = new();
 
     public Mock<ILogger<UserProfileClient>> UserProfileClientLogger { get; set; } = new();
 
@@ -88,11 +96,20 @@ public sealed class ProfileWebApplicationFactory<TProgram> : WebApplicationFacto
 
     public ProfileWebApplicationFactory()
     {
+        RegisterSettingsOptions.Setup(rso => rso.Value).Returns(
+            new RegisterSettings
+            {
+                ApiRegisterEndpoint = "https://at22.altinn.cloud/register/"
+            });
+
         SblBridgeSettingsOptions.Setup(gso => gso.Value).Returns(
             new SblBridgeSettings
             {
                 ApiProfileEndpoint = "https://at22.altinn.cloud/sblbridge/profile/api/"
             });
+
+        AccessTokenGeneratorMock.Setup(atg => atg.GenerateAccessToken("platform", "profile"))
+            .Returns("test-token");
     }
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)
@@ -150,7 +167,6 @@ public sealed class ProfileWebApplicationFactory<TProgram> : WebApplicationFacto
             services.AddSingleton(OrganizationNotificationAddressUpdateClientMock.Object);
             services.AddSingleton(PartyGroupRepositoryMock.Object);
             services.AddSingleton(ProfessionalNotificationsRepositoryMock.Object);
-            services.AddSingleton(RegisterClientMock.Object);
             services.AddSingleton(ProfileSettingsRepositoryMock.Object);
             services.AddSingleton(AddressVerificationRepositoryMock.Object);
             services.AddSingleton(NotificationsClientMock.Object);
@@ -168,7 +184,14 @@ public sealed class ProfileWebApplicationFactory<TProgram> : WebApplicationFacto
             });
 
             // Using the real/actual implementations, but with a mocked message handler.
-            // Haven't found any other ways of injecting a mocked message handler to simulate SBL Bridge.
+            // Haven't found any other ways of injecting a mocked message handler to simulate external services.
+            services.AddSingleton<IRegisterClient>(
+                new RegisterClient(
+                    new HttpClient(RegisterHttpMessageHandler),
+                    RegisterSettingsOptions.Object,
+                    AccessTokenGeneratorMock.Object,
+                    RegisterClientLogger.Object));
+
             services.AddSingleton<IUserProfileClient>(
                 new UserProfileClient(
                     new HttpClient(SblBridgeHttpMessageHandler),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #948 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refactored integration test suites to stub external register lookups via HTTP request interception rather than client-level mocks.
  * Added shared helpers to configure party/organization-number and main-unit lookup responses, including combined query/identifier handling.
  * Updated multiple controller tests to use the new lookup stubs and adjusted fixture setup/reset behavior.
  * Enhanced the integration test web app factory with new publicly exposed test hooks for access-token generation and register HTTP handler configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->