### PR TITLE
Return 400 and problem details for invalid org number from brreg

### DIFF
--- a/src/Altinn.Profile.Integrations/OrganizationNotificationAddressRegistry/InvalidOrgNumberException.cs
+++ b/src/Altinn.Profile.Integrations/OrganizationNotificationAddressRegistry/InvalidOrgNumberException.cs
@@ -1,0 +1,36 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Altinn.Profile.Integrations.OrganizationNotificationAddressRegistry;
+
+/// <summary>
+/// Represents errors that occur during the syncing of changes to organizations notification addresses
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class InvalidOrgNumberException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InvalidOrgNumberException"/> class.
+    /// </summary>
+    public InvalidOrgNumberException() : base()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InvalidOrgNumberException"/> class
+    /// with a specified error message.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    public InvalidOrgNumberException(string message) : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InvalidOrgNumberException  "/> class
+    /// with a specified error message and a reference to the inner exception that is the cause of this exception.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    /// <param name="inner">The exception that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
+    public InvalidOrgNumberException(string message, Exception inner) : base(message, inner)
+    {
+    }
+}

--- a/src/Altinn.Profile.Integrations/OrganizationNotificationAddressRegistry/InvalidOrgNumberException.cs
+++ b/src/Altinn.Profile.Integrations/OrganizationNotificationAddressRegistry/InvalidOrgNumberException.cs
@@ -25,7 +25,7 @@ public class InvalidOrgNumberException : Exception
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="InvalidOrgNumberException  "/> class
+    /// Initializes a new instance of the <see cref="InvalidOrgNumberException"/> class
     /// with a specified error message and a reference to the inner exception that is the cause of this exception.
     /// </summary>
     /// <param name="message">The error message that explains the reason for the exception.</param>

--- a/src/Altinn.Profile.Integrations/OrganizationNotificationAddressRegistry/OrganizationNotificationAddressHttpClient.cs
+++ b/src/Altinn.Profile.Integrations/OrganizationNotificationAddressRegistry/OrganizationNotificationAddressHttpClient.cs
@@ -151,6 +151,11 @@ public class OrganizationNotificationAddressHttpClient(
 
         if (responseObject.BoolResult != true || responseObject.AddressID == null)
         {
+            if (responseObject.Details?.Contains("is not a valid norwegian organization number") == true)
+            {
+                throw new InvalidOrgNumberException(responseObject.Status + ": " + responseObject.Details);
+            }
+
             throw new OrganizationNotificationAddressChangesException(responseObject.Status + ": " + responseObject.Details);
         }
 

--- a/src/Altinn.Profile.Integrations/OrganizationNotificationAddressRegistry/OrganizationNotificationAddressHttpClient.cs
+++ b/src/Altinn.Profile.Integrations/OrganizationNotificationAddressRegistry/OrganizationNotificationAddressHttpClient.cs
@@ -151,7 +151,7 @@ public class OrganizationNotificationAddressHttpClient(
 
         if (responseObject.BoolResult != true || responseObject.AddressID == null)
         {
-            if (responseObject.Details?.Contains("is not a valid norwegian organization number") == true)
+            if (responseObject.Details?.Contains("is not a valid norwegian organization number", StringComparison.OrdinalIgnoreCase) == true)
             {
                 throw new InvalidOrgNumberException(responseObject.Status + ": " + responseObject.Details);
             }

--- a/src/Altinn.Profile/Controllers/OrganizationsController.cs
+++ b/src/Altinn.Profile/Controllers/OrganizationsController.cs
@@ -100,6 +100,7 @@ namespace Altinn.Profile.Controllers
         [ProducesResponseType(typeof(NotificationAddressResponse), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(NotificationAddressResponse), StatusCodes.Status201Created)]
         [ProducesResponseType(typeof(ValidationProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
         public async Task<ActionResult<NotificationAddressResponse>> CreateNotificationAddress([FromRoute] string organizationNumber, [FromBody][Required] NotificationAddressRequest request, CancellationToken cancellationToken)
         {

--- a/src/Altinn.Profile/Controllers/OrganizationsController.cs
+++ b/src/Altinn.Profile/Controllers/OrganizationsController.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 
 using Altinn.Profile.Authorization;
 using Altinn.Profile.Core.OrganizationNotificationAddresses;
+using Altinn.Profile.Integrations.OrganizationNotificationAddressRegistry;
 using Altinn.Profile.Mappers;
 using Altinn.Profile.Models.OrganizationNotificationAddresses;
 
@@ -114,16 +115,28 @@ namespace Altinn.Profile.Controllers
 
             var notificationAddress = NotificationAddressRequestMapper.ToInternalModel(request);
 
-            var (newNotificationAddress, isNew) = await _notificationAddressService.CreateNotificationAddress(organizationNumber, notificationAddress, cancellationToken);
-
-            var response = OrganizationResponseMapper.ToNotificationAddressResponse(newNotificationAddress);
-
-            if (isNew)
+            try
             {
-                return CreatedAtAction(nameof(GetMandatoryNotificationAddress), new { organizationNumber, newNotificationAddress.NotificationAddressID }, response);
-            }
+                var (newNotificationAddress, isNew) = await _notificationAddressService.CreateNotificationAddress(organizationNumber, notificationAddress, cancellationToken);
 
-            return Ok(response);
+                var response = OrganizationResponseMapper.ToNotificationAddressResponse(newNotificationAddress);
+
+                if (isNew)
+                {
+                    return CreatedAtAction(nameof(GetMandatoryNotificationAddress), new { organizationNumber, newNotificationAddress.NotificationAddressID }, response);
+                }
+
+                return Ok(response);
+            }
+            catch (InvalidOrgNumberException)
+            {
+                return new BadRequestObjectResult(new ProblemDetails
+                {
+                    Title = "Invalid Organization Number",
+                    Detail = "The provided organization number is not valid in enhetsregisteret.",
+                    Status = StatusCodes.Status400BadRequest
+                });
+            }
         }
 
         /// <summary>

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/OrganizationsControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/OrganizationsControllerTests.cs
@@ -12,6 +12,7 @@ using Altinn.Authorization.ABAC.Xacml.JsonProfile;
 using Altinn.Common.PEP.Interfaces;
 
 using Altinn.Profile.Core.OrganizationNotificationAddresses;
+using Altinn.Profile.Integrations.OrganizationNotificationAddressRegistry;
 using Altinn.Profile.Models.OrganizationNotificationAddresses;
 using Altinn.Profile.Tests.IntegrationTests.Utils;
 
@@ -537,6 +538,77 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
             Assert.NotNull(actual.Errors["Phone"]);
             Assert.True(actual.Errors.TryGetValue("Phone", out var phoneMessage));
             Assert.Contains("The field Phone must match the regular expression", phoneMessage[0]);
+        }
+
+        [Fact]
+        public async Task CreateMandatory_WhenWrongFormatOfOrgNumber_ReturnsBadRequest()
+        {
+            // Arrange
+            var orgNo = "123456789";
+            const int UserId = 2516356;
+
+            _factory.PdpMock
+                .Setup(pdp => pdp.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>()))
+                .ReturnsAsync(new XacmlJsonResponse { Response = [new XacmlJsonResult { Decision = "Permit" }] });
+            _factory.OrganizationNotificationAddressUpdateClientMock
+                .Setup(c => c.CreateNewNotificationAddress(It.IsAny<NotificationAddress>(), It.IsAny<string>()))
+                .ThrowsAsync(new InvalidOrgNumberException("VALIDATION_ERROR"));
+
+            HttpClient client = _factory.CreateClient();
+
+            var input = new NotificationAddressRequest { Email = "ok@test.com" };
+            HttpRequestMessage httpRequestMessage = new(HttpMethod.Post, $"/profile/api/v1/organizations/{orgNo}/notificationaddresses/mandatory")
+            {
+                Content = new StringContent(JsonSerializer.Serialize(input, _serializerOptions), System.Text.Encoding.UTF8, "application/json")
+            };
+            httpRequestMessage = CreateAuthorizedRequest(UserId, httpRequestMessage);
+
+            // Act
+            HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            var actual = JsonSerializer.Deserialize<HttpValidationProblemDetails>(responseContent, _serializerOptions);
+
+            Assert.IsType<HttpValidationProblemDetails>(actual);
+            Assert.Equal(400, actual.Status);
+            Assert.Equal("Invalid Organization Number", actual.Title);
+        }
+
+        [Fact]
+        public async Task CreateMandatory_WhenValidationError_ReturnsInternalServerError()
+        {
+            // Arrange
+            var orgNo = "123456789";
+            const int UserId = 2516356;
+
+            _factory.PdpMock
+                .Setup(pdp => pdp.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>()))
+                .ReturnsAsync(new XacmlJsonResponse { Response = [new XacmlJsonResult { Decision = "Permit" }] });
+            _factory.OrganizationNotificationAddressUpdateClientMock
+                .Setup(c => c.CreateNewNotificationAddress(It.IsAny<NotificationAddress>(), It.IsAny<string>()))
+                .ThrowsAsync(new OrganizationNotificationAddressChangesException("VALIDATION_ERROR"));
+
+            HttpClient client = _factory.CreateClient();
+
+            var input = new NotificationAddressRequest { Email = "ok@test.com" };
+            HttpRequestMessage httpRequestMessage = new(HttpMethod.Post, $"/profile/api/v1/organizations/{orgNo}/notificationaddresses/mandatory")
+            {
+                Content = new StringContent(JsonSerializer.Serialize(input, _serializerOptions), System.Text.Encoding.UTF8, "application/json")
+            };
+            httpRequestMessage = CreateAuthorizedRequest(UserId, httpRequestMessage);
+
+            // Act
+            HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            var actual = JsonSerializer.Deserialize<HttpValidationProblemDetails>(responseContent, _serializerOptions);
+
+            Assert.IsType<HttpValidationProblemDetails>(actual);
+            Assert.Equal(500, actual.Status);
         }
 
         [Fact]

--- a/test/Altinn.Profile.Tests/Profile.Integrations/OrganizationNotificationAddressTests/OrganizationNotificationAddressHttpClientTests.cs
+++ b/test/Altinn.Profile.Tests/Profile.Integrations/OrganizationNotificationAddressTests/OrganizationNotificationAddressHttpClientTests.cs
@@ -189,6 +189,50 @@ public class OrganizationNotificationAddressHttpClientTests
     }
 
     [Fact]
+    public async Task CreateAddress_WhenSomethingGoesWrong_ThrowsException()
+    {
+        // Arrange
+        var response = new RegistryResponse { BoolResult = false, Status = "ERROR" };
+        var mockResponse = new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.OK,
+            Content = JsonContent.Create(response)
+        };
+
+        var client = CreateHttpClient(mockResponse);
+
+        var notificationAddress = new NotificationAddress() { AddressType = AddressType.Email, Address = "test", Domain = "test.com" };
+
+        // Act
+        await Assert.ThrowsAsync<OrganizationNotificationAddressChangesException>(async () => await client.CreateNewNotificationAddress(notificationAddress, "123456789"));
+
+        // Assert
+        _messageHandler.VerifyAll();
+    }
+
+    [Fact]
+    public async Task CreateAddress_WhenOrgNumberNotValid_ThrowsException()
+    {
+        // Arrange
+        var response = new RegistryResponse { BoolResult = false, Status = "VALIDATION_ERROR", Details = "JSON data error at /Kontaktinformasjon/kontaktinformasjonForEnhet/enhetsidentifikator: 012345678 is not a valid norwegian organization number" };
+        var mockResponse = new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.OK,
+            Content = JsonContent.Create(response)
+        };
+
+        var client = CreateHttpClient(mockResponse);
+
+        var notificationAddress = new NotificationAddress() { AddressType = AddressType.Email, Address = "test", Domain = "test.com" };
+
+        // Act
+        await Assert.ThrowsAsync<InvalidOrgNumberException>(async () => await client.CreateNewNotificationAddress(notificationAddress, "012345678"));
+
+        // Assert
+        _messageHandler.VerifyAll();
+    }
+
+    [Fact]
     public async Task UpdateAddress_WhenSomethingGoesWrong_ThrowsException()
     {
         // Arrange

--- a/test/Bruno/Profile/Organizations Notification Addresses/Email address.bru
+++ b/test/Bruno/Profile/Organizations Notification Addresses/Email address.bru
@@ -15,3 +15,7 @@ body:json {
       "email": "wvjckqug@sharklasers.com"
   }
 }
+
+script:post-response {
+  await bru.runRequest("TokenGenerator/portal user")
+}

--- a/test/Bruno/Profile/Organizations Notification Addresses/Phone number.bru
+++ b/test/Bruno/Profile/Organizations Notification Addresses/Phone number.bru
@@ -16,3 +16,7 @@ body:json {
       "countryCode": "+47"
   }
 }
+
+script:post-response {
+  await bru.runRequest("TokenGenerator/portal user")
+}

--- a/test/Bruno/scripts/usersByEnv.js
+++ b/test/Bruno/scripts/usersByEnv.js
@@ -24,6 +24,15 @@ const usersByEnv = {
       Party_OrgNo: "313605590",
       Party_PartyId: "51519644",
       Party_PartyUuid: "4a1cfef9-82e1-4be9-96b9-b99f116f8350"
+    },
+    user2: {
+      AuthN_UserId: "20909216",
+      AuthN_PartyId: "51778895",
+      AuthN_Pid: "29880297226",
+      AuthN_PartyUuid: "c6292a7e-0786-4bd2-b927-56cf3c77f314",
+      Party_OrgNo: "090090003",
+      Party_PartyId: "51782318",
+      Party_PartyUuid: "bb7b8680-2858-4b5a-ac07-cb7f18cea10c"
     }
     // Add more users for AT23 as needed.
   },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The current solution gives a problem details like this
```
{
  "title": "Invalid Organization Number",
  "status": 400,
  "detail": "The provided organization number is not valid in enhetsregisteret."
}
```
The english name for `enhetsregisteret` is `Central Coordinating Register for Legal Entities`. Would this be more clear or more confusing?

## Related Issue(s)
- #935 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Enhanced error handling for mandatory notification address creation: invalid organization numbers now return a dedicated **400 Bad Request** with a clear Problem Details response.

* **Bug Fixes**
  * Improved registry error interpretation so validation errors are mapped to the correct client-facing error.

* **Tests**
  * Added/extended test coverage for invalid organization number and general downstream failure scenarios, including response status and payload expectations.

* **Documentation**
  * Updated Bruno workflows to run the portal user token generator after responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->