### PR TITLE
Expose resource include list to dashboard

### DIFF
--- a/src/Altinn.Profile.Core/ProfessionalNotificationAddresses/ProfessionalNotificationsService.cs
+++ b/src/Altinn.Profile.Core/ProfessionalNotificationAddresses/ProfessionalNotificationsService.cs
@@ -163,16 +163,7 @@ namespace Altinn.Profile.Core.ProfessionalNotificationAddresses
                             return;
                         }
 
-                        results.Add(new UserPartyContactInfoWithIdentity
-                        {
-                            NationalIdentityNumber = profile.Party.SSN,
-                            Name = profile.Party.Name,
-                            EmailAddress = contactInfo.EmailAddress,
-                            PhoneNumber = contactInfo.PhoneNumber,
-                            OrganizationNumber = organizationNumber,
-                            LastChanged = contactInfo.LastChanged,
-                            ResourceIncludeList = contactInfo.GetResourceIncludeList()
-                        });
+                        results.Add(new UserPartyContactInfoWithIdentity(contactInfo, profile.Party.Name, profile.Party.SSN, organizationNumber));
                     },
                     _ =>
                     {
@@ -234,16 +225,7 @@ namespace Altinn.Profile.Core.ProfessionalNotificationAddresses
                             return;
                         }
 
-                        results.Add(new UserPartyContactInfoWithIdentity
-                        {
-                            NationalIdentityNumber = profile.Party.SSN,
-                            Name = profile.Party.Name,
-                            EmailAddress = contactInfo.EmailAddress,
-                            PhoneNumber = contactInfo.PhoneNumber,
-                            OrganizationNumber = orgNumber,
-                            LastChanged = contactInfo.LastChanged,
-                            ResourceIncludeList = contactInfo.GetResourceIncludeList()
-                        });
+                        results.Add(new UserPartyContactInfoWithIdentity(contactInfo, profile.Party.Name, profile.Party.SSN, orgNumber));
                     },
                     _ =>
                     {

--- a/src/Altinn.Profile.Core/ProfessionalNotificationAddresses/ProfessionalNotificationsService.cs
+++ b/src/Altinn.Profile.Core/ProfessionalNotificationAddresses/ProfessionalNotificationsService.cs
@@ -170,7 +170,8 @@ namespace Altinn.Profile.Core.ProfessionalNotificationAddresses
                             EmailAddress = contactInfo.EmailAddress,
                             PhoneNumber = contactInfo.PhoneNumber,
                             OrganizationNumber = organizationNumber,
-                            LastChanged = contactInfo.LastChanged
+                            LastChanged = contactInfo.LastChanged,
+                            ResourceIncludeList = contactInfo.GetResourceIncludeList()
                         });
                     },
                     _ =>
@@ -240,7 +241,8 @@ namespace Altinn.Profile.Core.ProfessionalNotificationAddresses
                             EmailAddress = contactInfo.EmailAddress,
                             PhoneNumber = contactInfo.PhoneNumber,
                             OrganizationNumber = orgNumber,
-                            LastChanged = contactInfo.LastChanged
+                            LastChanged = contactInfo.LastChanged,
+                            ResourceIncludeList = contactInfo.GetResourceIncludeList()
                         });
                     },
                     _ =>

--- a/src/Altinn.Profile.Core/ProfessionalNotificationAddresses/UserPartyContactInfoWithIdentity.cs
+++ b/src/Altinn.Profile.Core/ProfessionalNotificationAddresses/UserPartyContactInfoWithIdentity.cs
@@ -37,4 +37,9 @@ public class UserPartyContactInfoWithIdentity
     /// Date of last change (UTC)
     /// </summary>
     public DateTime LastChanged { get; set; }
+
+    /// <summary>
+    /// List of resources to get notifications for. This is a list of resource IDs with the prefix "urn:altinn:resource:".
+    /// </summary>
+    public List<string>? ResourceIncludeList { get; set; }
 }

--- a/src/Altinn.Profile.Core/ProfessionalNotificationAddresses/UserPartyContactInfoWithIdentity.cs
+++ b/src/Altinn.Profile.Core/ProfessionalNotificationAddresses/UserPartyContactInfoWithIdentity.cs
@@ -5,41 +5,48 @@ namespace Altinn.Profile.Core.ProfessionalNotificationAddresses;
 /// Used by Dashboard endpoints to display contact information with user identity.
 /// This also includes the organization number the user is acting on behalf of.
 /// </summary>
-public class UserPartyContactInfoWithIdentity
+/// <remarks>
+/// Create UserPartyContactInfoWithIdentity from UserPartyContactInfo and UserProfile
+/// </remarks>
+/// <param name="userPartyContactInfo">The user party contact info</param>
+/// <param name="name">The name of the user</param>
+/// <param name="ssn">The national identity number (SSN/D-number) of the user</param>
+/// <param name="organizationNumber">The organization number the user is acting on behalf of</param>
+public class UserPartyContactInfoWithIdentity(UserPartyContactInfo userPartyContactInfo, string name, string? ssn, string? organizationNumber)
 {
     /// <summary>
     /// The national identity number (SSN/D-number) of the user
     /// </summary>
-    public string? NationalIdentityNumber { get; set; }
+    public string? NationalIdentityNumber { get; set; } = ssn;
 
     /// <summary>
     /// The name of the user
     /// </summary>
-    public required string Name { get; set; }
+    public string Name { get; set; } = name;
 
     /// <summary>
     /// The email address. May be null if no email address is set.
     /// </summary>
-    public string? EmailAddress { get; set; }
+    public string? EmailAddress { get; set; } = userPartyContactInfo.EmailAddress;
 
     /// <summary>
     /// The phone number. May be null if no phone number is set.
     /// </summary>
-    public string? PhoneNumber { get; set; }
+    public string? PhoneNumber { get; set; } = userPartyContactInfo.PhoneNumber;
 
     /// <summary>
     /// The organization number the user is acting on behalf of.
     /// May be null if no organization number is set.
     /// </summary>
-    public string? OrganizationNumber { get; set; }
+    public string? OrganizationNumber { get; set; } = organizationNumber;
 
     /// <summary>
     /// Date of last change (UTC)
     /// </summary>
-    public DateTime LastChanged { get; set; }
+    public DateTime LastChanged { get; set; } = userPartyContactInfo.LastChanged;
 
     /// <summary>
     /// List of resources to get notifications for. This is a list of resource IDs with the prefix "urn:altinn:resource:".
     /// </summary>
-    public List<string>? ResourceIncludeList { get; set; }
+    public List<string>? ResourceIncludeList { get; set; } = userPartyContactInfo.GetResourceIncludeList();
 }

--- a/src/Altinn.Profile/Controllers/DashboardController.cs
+++ b/src/Altinn.Profile/Controllers/DashboardController.cs
@@ -296,7 +296,8 @@ namespace Altinn.Profile.Controllers
                 Email = c.EmailAddress,
                 Phone = c.PhoneNumber,
                 OrganizationNumber = c.OrganizationNumber,
-                LastChanged = c.LastChanged
+                LastChanged = c.LastChanged,
+                ResourceIncludeList = c.ResourceIncludeList,
             })];
         }
     }

--- a/src/Altinn.Profile/Models/DashboardUserContactInformationResponse.cs
+++ b/src/Altinn.Profile/Models/DashboardUserContactInformationResponse.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using System;
+using System.Collections.Generic;
 
 namespace Altinn.Profile.Models
 {
@@ -38,6 +39,13 @@ namespace Altinn.Profile.Models
         /// May be null if no organization number is set.
         /// </summary>
         public string? OrganizationNumber { get; set; }
+
+        /// <summary>
+        /// Gets or sets the list of resources the user is subscribed to for notifications.
+        /// This is a list of resource IDs with the prefix "urn:altinn:resource:".
+        /// May be null if no resources are set.
+        /// </summary>
+        public List<string>? ResourceIncludeList { get; set; }
 
         /// <summary>
         /// Gets or sets the timestamp when this contact information was last changed.

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/DashboardContactInformationControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/DashboardContactInformationControllerTests.cs
@@ -77,7 +77,11 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
                     PartyUuid = partyUuid,
                     EmailAddress = "user2@example.com",
                     PhoneNumber = "+4798765433",
-                    LastChanged = _testTime.AddDays(-1)
+                    LastChanged = _testTime.AddDays(-1),
+                    UserPartyContactInfoResources =
+                    [
+                        new() { ResourceId = "app_example" }
+                    ]
                 }
             };
             _factory.ProfessionalNotificationsRepositoryMock
@@ -105,6 +109,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
             Assert.Equal("user1@example.com", user1.Email);
             Assert.Equal("+4798765432", user1.Phone);
             Assert.Equal(_testTime, user1.LastChanged);
+            Assert.Null(user1.ResourceIncludeList);
 
             var user2 = result.FirstOrDefault(u => u.NationalIdentityNumber == "09814499976");
             Assert.NotNull(user2);
@@ -112,6 +117,9 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
             Assert.Equal("user2@example.com", user2.Email);
             Assert.Equal("+4798765433", user2.Phone);
             Assert.Equal(_testTime.AddDays(-1), user2.LastChanged);
+            Assert.NotNull(user2.ResourceIncludeList);
+            Assert.Single(user2.ResourceIncludeList);
+            Assert.Equal("urn:altinn:resource:app_example", user2.ResourceIncludeList.First());
         }
 
         [Fact]
@@ -512,7 +520,11 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
                     PartyUuid = partyUuid2,
                     EmailAddress = email,
                     PhoneNumber = "+4798765433",
-                    LastChanged = _testTime.AddDays(-1)
+                    LastChanged = _testTime.AddDays(-1),
+                    UserPartyContactInfoResources =
+                    [
+                        new() { ResourceId = "app_example" }
+                    ]
                 }
             };
 
@@ -543,6 +555,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
             Assert.Equal("+4798765432", user1.Phone);
             Assert.Equal(orgNumber1, user1.OrganizationNumber);
             Assert.Equal(_testTime, user1.LastChanged);
+            Assert.Null(user1.ResourceIncludeList);
 
             var user2 = result.FirstOrDefault(u => u.NationalIdentityNumber == "09814499976");
             Assert.NotNull(user2);
@@ -551,6 +564,9 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
             Assert.Equal("+4798765433", user2.Phone);
             Assert.Equal(orgNumber2, user2.OrganizationNumber);
             Assert.Equal(_testTime.AddDays(-1), user2.LastChanged);
+            Assert.NotNull(user2.ResourceIncludeList);
+            Assert.Single(user2.ResourceIncludeList);
+            Assert.Equal("urn:altinn:resource:app_example", user2.ResourceIncludeList.First());
         }
 
         [Fact]
@@ -712,7 +728,11 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
                     PartyUuid = partyUuid2,
                     EmailAddress = "search@example2.com",
                     PhoneNumber = "+4798765432",
-                    LastChanged = _testTime.AddDays(-1)
+                    LastChanged = _testTime.AddDays(-1),
+                    UserPartyContactInfoResources =
+                    [
+                        new() { ResourceId = "app_example" }
+                    ]
                 }
             };
 
@@ -742,6 +762,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
             Assert.Equal(fullPhoneNumber, user1.Phone);
             Assert.Equal(orgNumber1, user1.OrganizationNumber);
             Assert.Equal(_testTime, user1.LastChanged);
+            Assert.Null(user1.ResourceIncludeList);
 
             var user2 = result.FirstOrDefault(u => u.NationalIdentityNumber == "09814499976");
             Assert.NotNull(user2);
@@ -749,6 +770,9 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
             Assert.Equal(fullPhoneNumber, user2.Phone);
             Assert.Equal(orgNumber2, user2.OrganizationNumber);
             Assert.Equal(_testTime.AddDays(-1), user2.LastChanged);
+            Assert.NotNull(user2.ResourceIncludeList);
+            Assert.Single(user2.ResourceIncludeList);
+            Assert.Equal("urn:altinn:resource:app_example", user2.ResourceIncludeList.First());
         }
 
         [Fact]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- https://github.com/Altinn/altinn-support-dashboard/issues/750

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard contact information API responses now include the user’s notification resource subscription list.
  * Professional notification contact data now carries the list of resources associated with notification retrieval.
* **Tests**
  * Updated integration tests to mock resource subscription data and validate API responses, including scenarios where the list is absent and where it contains specific resource IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->