### PR TITLE
Use updated dotnet image w/ patched libraries

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,4 +1,4 @@
 vulnerabilities:
-  - id: CVE-2026-45447 # libcrypto3/libssl3
-    statement: Not exploitable - application does not have a call to OpenSSL's PKCS7_verify()
-    expired_at: 2026-06-25 # revisit in 1 week
+  # - id: CVE-2026-45447 # libcrypto3/libssl3
+  #   statement: Not exploitable - application does not have a call to OpenSSL's PKCS7_verify()
+  #   expired_at: 2026-06-25 # revisit in 1 week

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:10.0.301-alpine3.23@sha256:fac7cce841f78faa4bca416fb4c636d1a129c09abd9b50e9b45664b95fd008a0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0.301-alpine3.23@sha256:940f919ae84dd92ccd4aab7686fa5b777870b006c9360351039e16bcaad73d89 AS build
 WORKDIR /app
 
 COPY src/Altinn.Profile/*.csproj ./src/Altinn.Profile/
@@ -11,7 +11,7 @@ RUN dotnet restore ./src/Altinn.Profile/Altinn.Profile.csproj
 COPY src ./src
 RUN dotnet publish -c Release -o /app_output ./src/Altinn.Profile/Altinn.Profile.csproj
 
-FROM mcr.microsoft.com/dotnet/aspnet:10.0.9-alpine3.23@sha256:f03685b2735e0d3d25d6c60672e74b21bb6334f1402f71bae2d2cf02307163cd AS final
+FROM mcr.microsoft.com/dotnet/aspnet:10.0.9-alpine3.23@sha256:57bd717ac18ff6c8a39cc0ee4a76c1f15adc46df50434c73eff0c3f1df4c88f0 AS final
 EXPOSE 5030
 WORKDIR /app
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container base image versions to newer pinned builds.
  * Adjusted vulnerability ignore settings to use a commented template instead of an active exception.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->