### PR TITLE
Correspondence access to notifications settings

### DIFF
--- a/src/Altinn.Profile.Core/Unit.ContactPoints/UnitContactPointService.cs
+++ b/src/Altinn.Profile.Core/Unit.ContactPoints/UnitContactPointService.cs
@@ -17,7 +17,7 @@ namespace Altinn.Profile.Core.Unit.ContactPoints
         /// <inheritdoc/>
         public async Task<UnitContactPointsList> GetUserRegisteredContactPoints(string[] orgNumbers, string resourceId, CancellationToken cancellationToken)
         {
-            var partyList = await _registerClient.GetPartyUuids(orgNumbers, cancellationToken);
+            IReadOnlyList<Party>? partyList = await _registerClient.GetPartyUuids(orgNumbers, cancellationToken);
 
             if (partyList == null)
             {
@@ -33,6 +33,9 @@ namespace Altinn.Profile.Core.Unit.ContactPoints
             {
                 return result;
             }
+
+            // Make sure the resourceId is simplified down to the resource ID by removing any urn:altinn:resource: prefix if it exists
+            resourceId = ResourceIdFormatter.GetSanitizedResourceId(resourceId);
 
             foreach (var party in partyList)
             {

--- a/src/Altinn.Profile.Core/Unit.ContactPoints/UnitContactPointService.cs
+++ b/src/Altinn.Profile.Core/Unit.ContactPoints/UnitContactPointService.cs
@@ -1,4 +1,6 @@
-﻿using Altinn.Profile.Core.Integrations;
+﻿using System.Reflection.Metadata.Ecma335;
+
+using Altinn.Profile.Core.Integrations;
 using Altinn.Profile.Core.ProfessionalNotificationAddresses;
 
 namespace Altinn.Profile.Core.Unit.ContactPoints
@@ -15,9 +17,19 @@ namespace Altinn.Profile.Core.Unit.ContactPoints
         private readonly IRegisterClient _registerClient = registerClient;
 
         /// <inheritdoc/>
-        public async Task<UnitContactPointsList> GetUserRegisteredContactPoints(string[] orgNumbers, string resourceId, CancellationToken cancellationToken)
+        public async Task<UnitContactPointsList> GetUserRegisteredContactPoints(
+            string[] orgNumbers, string resourceId, CancellationToken cancellationToken)
         {
-            IReadOnlyList<Party>? partyList = await _registerClient.GetPartyUuids(orgNumbers, cancellationToken);
+            IEnumerable<string> organizationNumbers = orgNumbers.Where(
+                o => !string.IsNullOrWhiteSpace(o)).Select(o => o.Trim()).Distinct();
+
+            if (!organizationNumbers.Any())
+            {
+                return new UnitContactPointsList { ContactPointsList = [] };
+            }
+            
+            IReadOnlyList<Party>? partyList = await _registerClient.GetPartyUuids(
+                [.. organizationNumbers], cancellationToken);
 
             if (partyList == null)
             {

--- a/src/Altinn.Profile.Core/Unit.ContactPoints/UnitContactPointService.cs
+++ b/src/Altinn.Profile.Core/Unit.ContactPoints/UnitContactPointService.cs
@@ -1,6 +1,4 @@
-﻿using System.Reflection.Metadata.Ecma335;
-
-using Altinn.Profile.Core.Integrations;
+﻿using Altinn.Profile.Core.Integrations;
 using Altinn.Profile.Core.ProfessionalNotificationAddresses;
 
 namespace Altinn.Profile.Core.Unit.ContactPoints

--- a/src/Altinn.Profile/Authorization/AuthConstants.cs
+++ b/src/Altinn.Profile/Authorization/AuthConstants.cs
@@ -39,5 +39,10 @@
         /// Policy name for either end user access to the Altinn portal or read access to notification settings
         /// </summary>
         public const string ScopeEnduserOrNotificationSettingsRead = "ScopeEnduserOrNotificationSettingsRead";
+
+        /// <summary>
+        /// Policy name for the policy that checks that the caller has included the correct Correspondence scope.
+        /// </summary>
+        public const string CorrespondenceAccess = "CorrespondenceAccess";
     }
 }

--- a/src/Altinn.Profile/Controllers/CorrespondenceController.cs
+++ b/src/Altinn.Profile/Controllers/CorrespondenceController.cs
@@ -77,6 +77,8 @@ public class CorrespondenceController : ControllerBase
     /// request body. If the organization has no notification addresses registered, the main unit address will be
     /// returned if it exists.
     /// </summary>
+    /// <param name="orgContactPointLookup">The search criteria.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
     /// <returns>Returns an overview of the user registered notification addresses for the provided organization</returns>
     [HttpPost("units/contactpoint/lookup")]
     [ProducesResponseType(StatusCodes.Status200OK)]

--- a/src/Altinn.Profile/Controllers/CorrespondenceController.cs
+++ b/src/Altinn.Profile/Controllers/CorrespondenceController.cs
@@ -109,45 +109,7 @@ public class CorrespondenceController : ControllerBase
 
         var organizations = await _notificationAddressService.GetOrganizationNotificationAddresses(orgContactPointLookup.OrganizationNumbers, cancellationToken, true);
 
-        OrgNotificationAddressesResponse result = MapResult(organizations);
+        OrgNotificationAddressesResponse result = OrgNotificationAddressesResponse.Create(organizations);
         return Ok(result);
-    }
-
-    private static OrgNotificationAddressesResponse MapResult(IEnumerable<Organization> organizations)
-    {
-        var orgContacts = new OrgNotificationAddressesResponse();
-        foreach (var organization in organizations)
-        {
-            var contactPoints = new NotificationAddresses
-            {
-                OrganizationNumber = organization.OrganizationNumber,
-                AddressOrigin = organization.AddressOrigin,
-            };
-
-            if (organization.NotificationAddresses?.Count > 0)
-            {
-                foreach (var notificationAddress in organization.NotificationAddresses)
-                {
-                    if (notificationAddress.IsSoftDeleted == true || notificationAddress.HasRegistryAccepted == false)
-                    {
-                        continue;
-                    }
-
-                    switch (notificationAddress.AddressType)
-                    {
-                        case AddressType.Email:
-                            contactPoints.EmailList.Add(notificationAddress.FullAddress);
-                            break;
-                        case AddressType.SMS:
-                            contactPoints.MobileNumberList.Add(notificationAddress.FullAddress);
-                            break;
-                    }
-                }
-            }
-
-            orgContacts.ContactPointsList.Add(contactPoints);
-        }
-
-        return orgContacts;
     }
 }

--- a/src/Altinn.Profile/Controllers/CorrespondenceController.cs
+++ b/src/Altinn.Profile/Controllers/CorrespondenceController.cs
@@ -69,14 +69,8 @@ public class CorrespondenceController : ControllerBase
             return BadRequest(ModelState);
         }
 
-        var organizationNumbers = unitContactPointLookup.OrganizationNumbers.Where(o => !string.IsNullOrWhiteSpace(o)).Select(o => o.Trim()).Distinct();
-        if (!organizationNumbers.Any())
-        {
-            return Ok(new UnitContactPointsList { ContactPointsList = [] });
-        }
-
-        var result = await _contactPointsService.GetUserRegisteredContactPoints(
-            [.. organizationNumbers], unitContactPointLookup.ResourceId, cancellationToken);
+        UnitContactPointsList result = await _contactPointsService.GetUserRegisteredContactPoints(
+            [.. unitContactPointLookup.OrganizationNumbers], unitContactPointLookup.ResourceId, cancellationToken);
 
         return Ok(result);
     }
@@ -98,8 +92,9 @@ public class CorrespondenceController : ControllerBase
             return ValidationProblem(ModelState);
         }
 
-        var organizations = await _notificationAddressService.GetOrganizationNotificationAddresses(
-            orgContactPointLookup.OrganizationNumbers, cancellationToken, true);
+        IEnumerable<Organization> organizations = 
+            await _notificationAddressService.GetOrganizationNotificationAddresses(
+                orgContactPointLookup.OrganizationNumbers, cancellationToken, true);
 
         OrgNotificationAddressesResponse result = OrgNotificationAddressesResponse.Create(organizations);
         return Ok(result);

--- a/src/Altinn.Profile/Controllers/CorrespondenceController.cs
+++ b/src/Altinn.Profile/Controllers/CorrespondenceController.cs
@@ -69,31 +69,22 @@ public class CorrespondenceController : ControllerBase
             return BadRequest(ModelState);
         }
 
-        try
+        var organizationNumbers = unitContactPointLookup.OrganizationNumbers.Where(o => !string.IsNullOrWhiteSpace(o)).Select(o => o.Trim()).Distinct();
+        if (!organizationNumbers.Any())
         {
-            var organizationNumbers = unitContactPointLookup.OrganizationNumbers.Where(o => !string.IsNullOrWhiteSpace(o)).Select(o => o.Trim()).Distinct();
-            if (!organizationNumbers.Any())
-            {
-                return Ok(new UnitContactPointsList { ContactPointsList = [] });
-            }
+            return Ok(new UnitContactPointsList { ContactPointsList = [] });
+        }
 
-            var result = await _contactPointsService.GetUserRegisteredContactPoints(
-                [.. organizationNumbers], unitContactPointLookup.ResourceId, cancellationToken);
-            return Ok(result);
-        }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
-            throw;
-        }
-        catch (Exception)
-        {
-            return Problem("Could not retrieve contact points");
-        }
+        var result = await _contactPointsService.GetUserRegisteredContactPoints(
+            [.. organizationNumbers], unitContactPointLookup.ResourceId, cancellationToken);
+
+        return Ok(result);
     }
 
     /// <summary>
-    /// Endpoint looking up the notification addresses for the organization provided in the lookup object in the request body.
-    /// If the organization has no notification addresses registered, the main unit address will be returned if it exists.
+    /// Endpoint looking up the notification addresses for the organization provided in the lookup object in the
+    /// request body. If the organization has no notification addresses registered, the main unit address will be
+    /// returned if it exists.
     /// </summary>
     /// <returns>Returns an overview of the user registered notification addresses for the provided organization</returns>
     [HttpPost("units/contactpoint/lookup")]
@@ -107,7 +98,8 @@ public class CorrespondenceController : ControllerBase
             return ValidationProblem(ModelState);
         }
 
-        var organizations = await _notificationAddressService.GetOrganizationNotificationAddresses(orgContactPointLookup.OrganizationNumbers, cancellationToken, true);
+        var organizations = await _notificationAddressService.GetOrganizationNotificationAddresses(
+            orgContactPointLookup.OrganizationNumbers, cancellationToken, true);
 
         OrgNotificationAddressesResponse result = OrgNotificationAddressesResponse.Create(organizations);
         return Ok(result);

--- a/src/Altinn.Profile/Controllers/CorrespondenceController.cs
+++ b/src/Altinn.Profile/Controllers/CorrespondenceController.cs
@@ -71,14 +71,14 @@ public class CorrespondenceController : ControllerBase
 
         try
         {
-            var resourceId = ResourceIdFormatter.GetSanitizedResourceId(unitContactPointLookup.ResourceId);
             var organizationNumbers = unitContactPointLookup.OrganizationNumbers.Where(o => !string.IsNullOrWhiteSpace(o)).Select(o => o.Trim()).Distinct();
             if (!organizationNumbers.Any())
             {
                 return Ok(new UnitContactPointsList { ContactPointsList = [] });
             }
 
-            var result = await _contactPointsService.GetUserRegisteredContactPoints([.. organizationNumbers], resourceId, cancellationToken);
+            var result = await _contactPointsService.GetUserRegisteredContactPoints(
+                [.. organizationNumbers], unitContactPointLookup.ResourceId, cancellationToken);
             return Ok(result);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)

--- a/src/Altinn.Profile/Controllers/CorrespondenceController.cs
+++ b/src/Altinn.Profile/Controllers/CorrespondenceController.cs
@@ -1,0 +1,153 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Altinn.Profile.Authorization;
+using Altinn.Profile.Core.OrganizationNotificationAddresses;
+using Altinn.Profile.Core.ProfessionalNotificationAddresses;
+using Altinn.Profile.Core.Unit.ContactPoints;
+using Altinn.Profile.Models;
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+using static Altinn.Profile.Models.OrgNotificationAddressesResponse;
+
+namespace Altinn.Profile.Controllers;
+
+/// <summary>
+/// Controller for handling correspondence-related operations.
+/// </summary>
+[ApiController]
+[Authorize]
+[Authorize(Policy = AuthConstants.CorrespondenceAccess)]
+[Route("profile/api/v1/correspondence/notificationsettings")]
+[Produces("application/json")]
+public class CorrespondenceController : ControllerBase
+{
+    private readonly IUnitContactPointsService _contactPointsService;
+    private readonly IOrganizationNotificationAddressesService _notificationAddressService;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CorrespondenceController"/> class.
+    /// </summary>
+    /// <param name="contactPointsService">
+    /// A service implementation of <see cref="IUnitContactPointsService"/> that handles business logic
+    /// related to professional notification addresses.
+    /// </param>
+    /// <param name="notificationAddressService">
+    /// A service implementation of <see cref="IOrganizationNotificationAddressesService"/> that handles business logic
+    /// related to organization notification addresses.
+    /// </param>
+    public CorrespondenceController(IUnitContactPointsService contactPointsService, IOrganizationNotificationAddressesService notificationAddressService)
+    {
+        _contactPointsService = contactPointsService;
+        _notificationAddressService = notificationAddressService;
+    }
+
+    /// <summary>
+    /// Endpoint for looking up user-registered notification addresses for the provided organizations and the
+    /// given resource id.
+    /// </summary>
+    /// <param name="unitContactPointLookup">The search criteria.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>
+    /// Returns a list of user-registered notification addresses for the provided units.
+    /// </returns>
+    [HttpPost("users/contactpoint/lookup")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<UnitContactPointsList>> PostLookup(
+        [FromBody][Required] UnitContactPointLookup unitContactPointLookup, CancellationToken cancellationToken)
+    {
+        if (!ModelState.IsValid)
+        {
+            return BadRequest(ModelState);
+        }
+
+        try
+        {
+            var resourceId = ResourceIdFormatter.GetSanitizedResourceId(unitContactPointLookup.ResourceId);
+            var organizationNumbers = unitContactPointLookup.OrganizationNumbers.Where(o => !string.IsNullOrWhiteSpace(o)).Select(o => o.Trim()).Distinct();
+            if (!organizationNumbers.Any())
+            {
+                return Ok(new UnitContactPointsList { ContactPointsList = [] });
+            }
+
+            var result = await _contactPointsService.GetUserRegisteredContactPoints([.. organizationNumbers], resourceId, cancellationToken);
+            return Ok(result);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception)
+        {
+            return Problem("Could not retrieve contact points");
+        }
+    }
+
+    /// <summary>
+    /// Endpoint looking up the notification addresses for the organization provided in the lookup object in the request body.
+    /// If the organization has no notification addresses registered, the main unit address will be returned if it exists.
+    /// </summary>
+    /// <returns>Returns an overview of the user registered notification addresses for the provided organization</returns>
+    [HttpPost("units/contactpoint/lookup")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<OrgNotificationAddressesResponse>> PostLookup(
+        [FromBody][Required] OrgNotificationAddressRequest orgContactPointLookup, CancellationToken cancellationToken)
+    {
+        if (!ModelState.IsValid)
+        {
+            return ValidationProblem(ModelState);
+        }
+
+        var organizations = await _notificationAddressService.GetOrganizationNotificationAddresses(orgContactPointLookup.OrganizationNumbers, cancellationToken, true);
+
+        OrgNotificationAddressesResponse result = MapResult(organizations);
+        return Ok(result);
+    }
+
+    private static OrgNotificationAddressesResponse MapResult(IEnumerable<Organization> organizations)
+    {
+        var orgContacts = new OrgNotificationAddressesResponse();
+        foreach (var organization in organizations)
+        {
+            var contactPoints = new NotificationAddresses
+            {
+                OrganizationNumber = organization.OrganizationNumber,
+                AddressOrigin = organization.AddressOrigin,
+            };
+
+            if (organization.NotificationAddresses?.Count > 0)
+            {
+                foreach (var notificationAddress in organization.NotificationAddresses)
+                {
+                    if (notificationAddress.IsSoftDeleted == true || notificationAddress.HasRegistryAccepted == false)
+                    {
+                        continue;
+                    }
+
+                    switch (notificationAddress.AddressType)
+                    {
+                        case AddressType.Email:
+                            contactPoints.EmailList.Add(notificationAddress.FullAddress);
+                            break;
+                        case AddressType.SMS:
+                            contactPoints.MobileNumberList.Add(notificationAddress.FullAddress);
+                            break;
+                    }
+                }
+            }
+
+            orgContacts.ContactPointsList.Add(contactPoints);
+        }
+
+        return orgContacts;
+    }
+}

--- a/src/Altinn.Profile/Controllers/CorrespondenceController.cs
+++ b/src/Altinn.Profile/Controllers/CorrespondenceController.cs
@@ -1,21 +1,18 @@
-﻿using System;
+﻿#nullable enable
+
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
 using Altinn.Profile.Authorization;
 using Altinn.Profile.Core.OrganizationNotificationAddresses;
-using Altinn.Profile.Core.ProfessionalNotificationAddresses;
 using Altinn.Profile.Core.Unit.ContactPoints;
 using Altinn.Profile.Models;
 
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-
-using static Altinn.Profile.Models.OrgNotificationAddressesResponse;
 
 namespace Altinn.Profile.Controllers;
 
@@ -25,7 +22,7 @@ namespace Altinn.Profile.Controllers;
 [ApiController]
 [Authorize]
 [Authorize(Policy = AuthConstants.CorrespondenceAccess)]
-[Route("profile/api/v1/correspondence/notificationsettings")]
+[Route("profile/api/v1/correspondence")]
 [Produces("application/json")]
 public class CorrespondenceController : ControllerBase
 {
@@ -58,15 +55,15 @@ public class CorrespondenceController : ControllerBase
     /// <returns>
     /// Returns a list of user-registered notification addresses for the provided units.
     /// </returns>
-    [HttpPost("users/contactpoint/lookup")]
+    [HttpPost("organizations/notificationaddresses/lookup")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    public async Task<ActionResult<UnitContactPointsList>> PostLookup(
+    public async Task<ActionResult<UnitContactPointsList>> GetUserRegisteredContactPoints(
         [FromBody][Required] UnitContactPointLookup unitContactPointLookup, CancellationToken cancellationToken)
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            return ValidationProblem(ModelState);
         }
 
         UnitContactPointsList result = await _contactPointsService.GetUserRegisteredContactPoints(
@@ -84,7 +81,7 @@ public class CorrespondenceController : ControllerBase
     [HttpPost("units/contactpoint/lookup")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    public async Task<ActionResult<OrgNotificationAddressesResponse>> PostLookup(
+    public async Task<ActionResult<OrgNotificationAddressesResponse>> GetOrganizationRegisteredContactPoints(
         [FromBody][Required] OrgNotificationAddressRequest orgContactPointLookup, CancellationToken cancellationToken)
     {
         if (!ModelState.IsValid)

--- a/src/Altinn.Profile/Controllers/OrgNotificationAddressController.cs
+++ b/src/Altinn.Profile/Controllers/OrgNotificationAddressController.cs
@@ -45,46 +45,8 @@ namespace Altinn.Profile.Controllers
 
             var organizations = await _notificationAddressService.GetOrganizationNotificationAddresses(orgContactPointLookup.OrganizationNumbers, cancellationToken, true);
 
-            OrgNotificationAddressesResponse result = MapResult(organizations);
+            OrgNotificationAddressesResponse result = OrgNotificationAddressesResponse.Create(organizations);
             return Ok(result);
-        }
-
-        private static OrgNotificationAddressesResponse MapResult(IEnumerable<Organization> organizations)
-        {
-            var orgContacts = new OrgNotificationAddressesResponse();
-            foreach (var organization in organizations)
-            {
-                var contactPoints = new NotificationAddresses
-                {
-                    OrganizationNumber = organization.OrganizationNumber,
-                    AddressOrigin = organization.AddressOrigin,
-                };
-
-                if (organization.NotificationAddresses?.Count > 0)
-                {
-                    foreach (var notificationAddress in organization.NotificationAddresses)
-                    {
-                        if (notificationAddress.IsSoftDeleted == true || notificationAddress.HasRegistryAccepted == false)
-                        {
-                            continue;
-                        }
-
-                        switch (notificationAddress.AddressType)
-                        {
-                            case AddressType.Email:
-                                contactPoints.EmailList.Add(notificationAddress.FullAddress);
-                                break;
-                            case AddressType.SMS:
-                                contactPoints.MobileNumberList.Add(notificationAddress.FullAddress);
-                                break;
-                        }
-                    }
-                }
-
-                orgContacts.ContactPointsList.Add(contactPoints);
-            }
-
-            return orgContacts;
         }
     }
 }

--- a/src/Altinn.Profile/Controllers/UnitContactPointController.cs
+++ b/src/Altinn.Profile/Controllers/UnitContactPointController.cs
@@ -65,14 +65,8 @@ public class UnitContactPointController : ControllerBase
 
         try
         {
-            var organizationNumbers = unitContactPointLookup.OrganizationNumbers.Where(o => !string.IsNullOrWhiteSpace(o)).Select(o => o.Trim()).Distinct();
-            if (!organizationNumbers.Any())
-            {
-                return Ok(new UnitContactPointsList { ContactPointsList = [] });
-            }
-
             var result = await _contactPointsService.GetUserRegisteredContactPoints(
-                [.. organizationNumbers], unitContactPointLookup.ResourceId, cancellationToken);
+                [.. unitContactPointLookup.OrganizationNumbers], unitContactPointLookup.ResourceId, cancellationToken);
             return Ok(result);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)

--- a/src/Altinn.Profile/Controllers/UnitContactPointController.cs
+++ b/src/Altinn.Profile/Controllers/UnitContactPointController.cs
@@ -84,30 +84,4 @@ public class UnitContactPointController : ControllerBase
             return Problem("Could not retrieve contact points");
         }
     }
-
-    /// <summary>
-    /// Normalizes a resource identifier value by removing the leading
-    /// 'urn:altinn:resource:' prefix if it is present.
-    /// </summary>
-    /// <param name="resourceId">
-    /// The raw resource identifier (may be a plain slug like 'tax-report', or
-    /// a full attribute value starting with 'urn:altinn:resource:').
-    /// Can be <c>null</c> or whitespace.
-    /// </param>
-    /// <returns>
-    /// The resource identifier without the 'urn:altinn:resource:' prefix, or
-    /// <see cref="string.Empty"/> when the input is <c>null</c> or whitespace.
-    /// </returns>
-    private static string GetSanitizedResourceId(string resourceId)
-    {
-        var trimmedResourceId = resourceId?.Trim();
-        if (string.IsNullOrWhiteSpace(trimmedResourceId))
-        {
-            return string.Empty;
-        }
-
-        const string prefix = "urn:altinn:resource:";
-
-        return trimmedResourceId.StartsWith(prefix, StringComparison.Ordinal) ? trimmedResourceId[prefix.Length..] : trimmedResourceId;
-    }
 }

--- a/src/Altinn.Profile/Controllers/UnitContactPointController.cs
+++ b/src/Altinn.Profile/Controllers/UnitContactPointController.cs
@@ -65,14 +65,14 @@ public class UnitContactPointController : ControllerBase
 
         try
         {
-            var resourceId = GetSanitizedResourceId(unitContactPointLookup.ResourceId);
             var organizationNumbers = unitContactPointLookup.OrganizationNumbers.Where(o => !string.IsNullOrWhiteSpace(o)).Select(o => o.Trim()).Distinct();
             if (!organizationNumbers.Any())
             {
                 return Ok(new UnitContactPointsList { ContactPointsList = [] });
             }
 
-            var result = await _contactPointsService.GetUserRegisteredContactPoints([.. organizationNumbers], resourceId, cancellationToken);
+            var result = await _contactPointsService.GetUserRegisteredContactPoints(
+                [.. organizationNumbers], unitContactPointLookup.ResourceId, cancellationToken);
             return Ok(result);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)

--- a/src/Altinn.Profile/Models/OrgNotificationAddressesResponse.cs
+++ b/src/Altinn.Profile/Models/OrgNotificationAddressesResponse.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
 
+using Altinn.Profile.Core.OrganizationNotificationAddresses;
+
 namespace Altinn.Profile.Models;
 
 /// <summary>
@@ -42,5 +44,48 @@ public class OrgNotificationAddressesResponse
         /// Gets or sets a list of official email addresses
         /// </summary>
         public List<string> EmailList { get; set; } = [];
+    }
+
+    /// <summary>
+    /// Creates a new instance of <see cref="OrgNotificationAddressesResponse"/> from a list of <see cref="Organization"/>.
+    /// </summary>
+    /// <param name="organizations">A list of organizations to create the response from.</param>
+    /// <returns>A new instance of <see cref="OrgNotificationAddressesResponse"/> containing the notification addresses for the provided organizations.</returns>
+    public static OrgNotificationAddressesResponse Create(IEnumerable<Organization> organizations)
+    {
+        var orgContacts = new OrgNotificationAddressesResponse();
+        foreach (var organization in organizations)
+        {
+            var contactPoints = new NotificationAddresses
+            {
+                OrganizationNumber = organization.OrganizationNumber,
+                AddressOrigin = organization.AddressOrigin,
+            };
+
+            if (organization.NotificationAddresses?.Count > 0)
+            {
+                foreach (var notificationAddress in organization.NotificationAddresses)
+                {
+                    if (notificationAddress.IsSoftDeleted == true || notificationAddress.HasRegistryAccepted == false)
+                    {
+                        continue;
+                    }
+
+                    switch (notificationAddress.AddressType)
+                    {
+                        case AddressType.Email:
+                            contactPoints.EmailList.Add(notificationAddress.FullAddress);
+                            break;
+                        case AddressType.SMS:
+                            contactPoints.MobileNumberList.Add(notificationAddress.FullAddress);
+                            break;
+                    }
+                }
+            }
+
+            orgContacts.ContactPointsList.Add(contactPoints);
+        }
+
+        return orgContacts;
     }
 }

--- a/src/Altinn.Profile/Program.cs
+++ b/src/Altinn.Profile/Program.cs
@@ -2,7 +2,6 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Reflection;
-using System.Threading;
 using System.Threading.Tasks;
 
 using Altinn.Common.AccessToken;
@@ -196,6 +195,7 @@ void ConfigureServices(IServiceCollection services, IConfiguration config)
     services.AddAuthorizationBuilder()
         .AddPolicy(AuthConstants.PlatformAccess, policy => policy.Requirements.Add(new AccessTokenRequirement()))
         .AddPolicy(AuthConstants.SupportDashboardAccess, policy => policy.Requirements.Add(new ScopeAccessRequirement("altinn:profile.support.admin")))
+        .AddPolicy(AuthConstants.CorrespondenceAccess, policy => policy.Requirements.Add(new ScopeAccessRequirement("altinn:profile/correspondence.notificationsettings.read")))
         .AddPolicy(AuthConstants.OrgNotificationAddress_Read, policy => policy.Requirements.Add(new ResourceAccessRequirement("read", "altinn-profil-api-varslingsdaresser-for-virksomheter")))
         .AddPolicy(AuthConstants.OrgNotificationAddress_Write, policy => policy.Requirements.Add(new ResourceAccessRequirement("write", "altinn-profil-api-varslingsdaresser-for-virksomheter")))
         .AddPolicy(AuthConstants.UserPartyAccess, policy => policy.Requirements.Add(new PartyAccessRequirement()))

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/CorrespondenceControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/CorrespondenceControllerTests.cs
@@ -1,0 +1,257 @@
+﻿#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Altinn.Profile.Core.OrganizationNotificationAddresses;
+using Altinn.Profile.Core.ProfessionalNotificationAddresses;
+using Altinn.Profile.Core.Unit.ContactPoints;
+using Altinn.Profile.Models;
+using Altinn.Profile.Tests.IntegrationTests.Mocks;
+using Altinn.Profile.Tests.IntegrationTests.Utils;
+
+using Moq;
+
+using Xunit;
+
+namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers;
+
+public class CorrespondenceControllerTests : IClassFixture<ProfileWebApplicationFactory<Program>>
+{
+    private readonly ProfileWebApplicationFactory<Program> _factory;
+
+    private readonly JsonSerializerOptions _serializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true
+    };
+
+    public CorrespondenceControllerTests(ProfileWebApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+
+        RegisterHttpMessageHandlerHelpers.SetupRegisterPartyQueryLookup(_factory, orgNumbers => GetRegisterResponse(orgNumbers));
+
+        _factory.ProfessionalNotificationsRepositoryMock.Setup(s => s.GetAllNotificationAddressesForPartyAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Guid partyUuid, CancellationToken _) => GetRepositoryResponse(partyUuid.ToString()));
+        _factory.OrganizationNotificationAddressRepositoryMock.Setup(s => s.GetOrganizationsAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((List<string> orgNumbers, CancellationToken _) => GetRepositoryResponse(orgNumbers));
+    }
+
+    [Theory]
+    [InlineData("not deserialiable to input model")]
+    [InlineData("{\"organizationNumbers\":null,\"resourceId\":\"resurs\"}")]
+    [InlineData("{\"organizationNumbers\":[],\"resourceId\":\"resurs\"}")]
+    [InlineData("{\"organizationNumbers\":[\"565445454\"],\"resourceId\":null}")]
+    public async Task GetUserRegisteredContactPoints_InvalidInputValues_ReturnsBadRequest(string input)
+    {
+        // Arrange
+        string token = PrincipalUtil.GetOrgToken("digdir", 4, "altinn:profile/correspondence.notificationsettings.read");
+
+        HttpRequestMessage httpRequestMessage = new(HttpMethod.Post, "/profile/api/v1/correspondence/organizations/notificationaddresses/lookup")
+        {
+            Content = new StringContent(input, System.Text.Encoding.UTF8, "application/json")
+        };
+        httpRequestMessage.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        HttpClient client = _factory.CreateClient();
+
+        // Act
+        HttpResponseMessage actual = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, actual.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetUserRegisteredContactPoints_ReturnsOk()
+    {
+        // Arrange
+        UnitContactPointLookup input = new()
+        {
+            OrganizationNumbers = ["123456789"],
+            ResourceId = "app_ttd_apps-test"
+        };
+
+        string token = PrincipalUtil.GetOrgToken("digdir", 4, "altinn:profile/correspondence.notificationsettings.read");
+
+        HttpRequestMessage httpRequestMessage = new(HttpMethod.Post, "/profile/api/v1/correspondence/organizations/notificationaddresses/lookup")
+        {
+            Content = JsonContent.Create(input)
+        };
+        httpRequestMessage.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        HttpClient client = _factory.CreateClient();
+
+        // Act
+        HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        UnitContactPointsList? actual = JsonSerializer.Deserialize<UnitContactPointsList>(responseContent, _serializerOptions);
+        Assert.Single(actual!.ContactPointsList);
+    }
+
+    [Theory]
+    [InlineData("not deserialiable to input model")]
+    [InlineData("{}")]
+    [InlineData("{\"organizationNumbers\":null}")]
+    [InlineData("{\"organizationNumbers\":[]}")]
+    [InlineData("{\"organizationNumbers\":[\" \"]}")]
+    public async Task GetOrganizationRegisteredContactPoints_InvalidInputValues_ReturnsBadRequest(string input)
+    {
+        // Arrange
+        string token = PrincipalUtil.GetOrgToken("digdir", 4, "altinn:profile/correspondence.notificationsettings.read");
+
+        HttpRequestMessage httpRequestMessage = new(HttpMethod.Post, "/profile/api/v1/correspondence/units/contactpoint/lookup")
+        {
+            Content = new StringContent(input, System.Text.Encoding.UTF8, "application/json")
+        };
+        httpRequestMessage.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        HttpClient client = _factory.CreateClient();
+
+        // Act
+        HttpResponseMessage actual = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, actual.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetOrganizationRegisteredContactPoints_ReturnsOk()
+    {
+        // Arrange
+        OrgNotificationAddressRequest input = new()
+        {
+            OrganizationNumbers = ["123456789"]
+        };
+
+        string token = PrincipalUtil.GetOrgToken("digdir", 4, "altinn:profile/correspondence.notificationsettings.read");
+
+        HttpRequestMessage httpRequestMessage = new(HttpMethod.Post, "/profile/api/v1/correspondence/units/contactpoint/lookup")
+        {
+            Content = JsonContent.Create(input)
+        };
+        httpRequestMessage.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        HttpClient client = _factory.CreateClient();
+
+        // Act
+        HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        OrgNotificationAddressesResponse? actual = 
+            JsonSerializer.Deserialize<OrgNotificationAddressesResponse>(responseContent, _serializerOptions);
+        Assert.Single(actual!.ContactPointsList);
+    }
+
+    private static List<UserPartyContactInfo> GetRepositoryResponse(string partyUuid)
+    {
+        switch (partyUuid)
+        {
+            case "8baab949-07f9-4ac5-b8cb-af6208b59092":
+                return
+                    [
+                        new UserPartyContactInfo()
+                    {
+                        UserId = 20001,
+                        EmailAddress = "user@email.com",
+                        PhoneNumber = "98765432",
+                        PartyUuid = Guid.Parse("8baab949-07f9-4ac5-b8cb-af6208b59092"),
+                    }
+                    ];
+            case "f81d7b22-4acb-4d59-b544-ef028f183ebc":
+                return
+                    [
+                        new UserPartyContactInfo()
+                    {
+                        UserId = 20002,
+                        EmailAddress = "user2@email.com",
+                        PhoneNumber = "98765432",
+                        PartyUuid = Guid.Parse("f81d7b22-4acb-4d59-b544-ef028f183ebc"),
+                        UserPartyContactInfoResources = [
+                            new UserPartyContactInfoResource()
+                            {
+                                ResourceId = "app_ttd_storage-end-to-end"
+                            }
+                        ]
+                    }
+                    ];
+            default:
+                return [];
+        }
+    }
+
+    private static List<Organization> GetRepositoryResponse(List<string> organizationNumbers)
+    {
+        var organizations = new List<Organization>();
+
+        foreach (var org in organizationNumbers)
+        {
+            organizations.Add(new Organization()
+            {
+                OrganizationNumber = org,
+                NotificationAddresses = [
+                    new NotificationAddress()
+                    {
+                        AddressType = AddressType.Email,
+                        FullAddress = "navn@navnesen.no"
+                    },
+                    new NotificationAddress()
+                    {
+                        AddressType = AddressType.SMS,
+                        FullAddress = "+4798765432"
+                    }
+                ]
+            });
+        }
+
+        return organizations;
+    }
+
+    private static List<Party> GetRegisterResponse(string[] orgNo)
+    {
+        var parties = new List<Party>();
+        foreach (var org in orgNo)
+        {
+            var party = GetPartyUuidForOrgNo(org);
+            if (party != null)
+            {
+                parties.Add(party);
+            }
+        }
+
+        return parties;
+    }
+
+    private static Party? GetPartyUuidForOrgNo(string orgNo)
+    {
+        return orgNo switch
+        {
+            "123456789" => new Party()
+            {
+                PartyId = 50001,
+                OrganizationIdentifier = "123456789",
+                PartyUuid = Guid.Parse("8baab949-07f9-4ac5-b8cb-af6208b59092"),
+            },
+            "111111111" => new Party()
+            {
+                PartyId = 50002,
+                OrganizationIdentifier = "111111111",
+                PartyUuid = Guid.Parse("f81d7b22-4acb-4d59-b544-ef028f183ebc"),
+            },
+            _ => null,
+        };
+    }
+}

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/UnitContactPointControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/UnitContactPointControllerTests.cs
@@ -226,61 +226,7 @@ public class UnitContactPointControllerTests : IClassFixture<ProfileWebApplicati
         }
     }
 
-    public class MockedUnitContactPointsService : IClassFixture<ProfileWebApplicationFactory<Program>>
-    {
-        private readonly ProfileWebApplicationFactory<Program> _factory;
-
-        private readonly JsonSerializerOptions _serializerOptions = new()
-        {
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-            PropertyNameCaseInsensitive = true
-        };
-
-        public MockedUnitContactPointsService(ProfileWebApplicationFactory<Program> factory)
-        {
-            _factory = factory;
-            _factory.UnitContactPointsServiceMock ??= new Mock<IUnitContactPointsService>();
-            _factory.UnitContactPointsServiceMock.Reset();
-        }
-
-        [Fact]
-        public async Task PostLookup_RemovesUrnPrefixFromResourceId()
-        {
-            // Arrange
-            var originalResourceId = "urn:altinn:resource:app_ttd_storage-end-to-end";
-            var expectedSanitizedResourceId = "app_ttd_storage-end-to-end";
-            var input = new UnitContactPointLookup
-            {
-                OrganizationNumbers = ["111111111"],
-                ResourceId = originalResourceId
-            };
-
-            string actualResourceId = null;
-
-            _factory.UnitContactPointsServiceMock.Setup(s => s.GetUserRegisteredContactPoints(
-                    It.Is<string[]>(arr => arr.Length == 1 && arr[0] == "111111111"),
-                    It.Is<string>(r => r == expectedSanitizedResourceId),
-                    It.IsAny<CancellationToken>()))
-                .Callback((string[] orgs, string resourceId, CancellationToken _) => actualResourceId = resourceId)
-                .ReturnsAsync(new UnitContactPointsList { ContactPointsList = new List<UnitContactPoints>() });
-
-            var client = _factory.CreateClient();
-
-            var httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, "/profile/api/v1/units/contactpoint/lookup")
-            {
-                Content = new StringContent(JsonSerializer.Serialize(input, _serializerOptions), System.Text.Encoding.UTF8, "application/json")
-            };
-
-            // Act
-            var response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
-
-            // Assert
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            Assert.Equal(expectedSanitizedResourceId, actualResourceId);
-        }
-    }
-
-    public static List<Party> GetRegisterResponse(string[] orgNo)
+    private static List<Party> GetRegisterResponse(string[] orgNo)
     {
         var parties = new List<Party>();
         foreach (var org in orgNo)
@@ -295,7 +241,7 @@ public class UnitContactPointControllerTests : IClassFixture<ProfileWebApplicati
         return parties;
     }
 
-    public static Party GetPartyUuidForOrgNo(string orgNo)
+    private static Party GetPartyUuidForOrgNo(string orgNo)
     {
         return orgNo switch
         {

--- a/test/Altinn.Profile.Tests/Profile.Core/Unit/UnitContactPointServiceTest.cs
+++ b/test/Altinn.Profile.Tests/Profile.Core/Unit/UnitContactPointServiceTest.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Altinn.Profile.Core.Integrations;
+using Altinn.Profile.Core.ProfessionalNotificationAddresses;
+using Altinn.Profile.Core.Unit.ContactPoints;
+
+using Moq;
+
+using Xunit;
+
+namespace Altinn.Profile.Tests.Profile.Core.Unit;
+
+public sealed class UnitContactPointServiceTest
+{
+    private const string _resourcePrefix = "urn:altinn:resource:";
+
+    [Fact]
+    public async Task GetUserRegisteredContactPoints_ReturnsCorrectlyFilteredUserContactPoints()
+    {
+        // Arrange
+        const string resourceId = "resourceId";
+        const string organizationNumber = "867567862";
+
+        List<Party> partyList = new()
+        {
+            new Party
+            {
+                PartyUuid = Guid.NewGuid(),
+                OrganizationIdentifier = organizationNumber
+            }
+        };
+
+        List<UserPartyContactInfo> userPartyContactInfo = new()
+        {
+            new UserPartyContactInfo
+            {
+                UserId = 1,
+                PartyUuid = partyList[0].PartyUuid,
+                EmailAddress = "navn@navnesen.no",
+                UserPartyContactInfoResources = new List<UserPartyContactInfoResource>
+                {
+                    new UserPartyContactInfoResource
+                    {
+                        ResourceId = resourceId // Stored resource ids are without the urn:altinn:resource prefix
+                    },
+                    new UserPartyContactInfoResource
+                    {
+                        ResourceId = "another-resource-id"
+                    }
+                }
+            },
+            new UserPartyContactInfo
+            {
+                UserId = 2,
+                PartyUuid = partyList[0].PartyUuid,
+                EmailAddress = "not-navn@navnesen.no",
+                UserPartyContactInfoResources = new List<UserPartyContactInfoResource>
+                {
+                    new UserPartyContactInfoResource
+                    {
+                        ResourceId = "another-resource-id"
+                    }
+                }
+            }
+        };
+
+        Mock<IRegisterClient> registerClient = new();
+        registerClient
+            .Setup(x => x.GetPartyUuids(
+                It.Is<string[]>(ids => ids.Length == 1 && ids[0] == organizationNumber),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(partyList);
+
+        Mock<IProfessionalNotificationsRepository> professionalNotificationsRepository = new();
+        professionalNotificationsRepository
+            .Setup(x => x.GetAllNotificationAddressesForPartyAsync(
+                It.Is<Guid>(id => id == partyList[0].PartyUuid),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(userPartyContactInfo);
+
+        UnitContactPointService target = new(professionalNotificationsRepository.Object, registerClient.Object);
+
+        // Act
+        UnitContactPointsList actualUnitContactPointsList = await target.GetUserRegisteredContactPoints(
+            [organizationNumber], _resourcePrefix + resourceId, TestContext.Current.CancellationToken);
+
+        // Assert
+        registerClient.VerifyAll();
+        professionalNotificationsRepository.VerifyAll();
+
+        Assert.Single(actualUnitContactPointsList.ContactPointsList);
+        Assert.Equal("navn@navnesen.no", actualUnitContactPointsList.ContactPointsList[0].UserContactPoints[0].Email);
+    }
+}

--- a/test/Altinn.Profile.Tests/Profile.Core/Unit/UnitContactPointServiceTests.cs
+++ b/test/Altinn.Profile.Tests/Profile.Core/Unit/UnitContactPointServiceTests.cs
@@ -94,4 +94,25 @@ public sealed class UnitContactPointServiceTests
         Assert.Single(actualUnitContactPointsList.ContactPointsList);
         Assert.Equal("navn@navnesen.no", actualUnitContactPointsList.ContactPointsList[0].UserContactPoints[0].Email);
     }
+
+    [Fact]
+    public async Task GetUserRegisteredContactPoints_NoValidOrganizationNumbers_ReturnsEmptyList()
+    {
+        // Arrange
+        const string resourceId = "resourceId";
+        string[] organizationNumbers = [" "];
+
+        Mock<IRegisterClient> registerClient = new();
+        Mock<IProfessionalNotificationsRepository> professionalNotificationsRepository = new();
+
+        UnitContactPointService target = new(professionalNotificationsRepository.Object, registerClient.Object);
+
+        // Act
+        UnitContactPointsList actualUnitContactPointsList = await target.GetUserRegisteredContactPoints(
+            organizationNumbers, _resourcePrefix + resourceId, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.NotNull(actualUnitContactPointsList);
+        Assert.Empty(actualUnitContactPointsList.ContactPointsList);
+    }
 }

--- a/test/Altinn.Profile.Tests/Profile.Core/Unit/UnitContactPointServiceTests.cs
+++ b/test/Altinn.Profile.Tests/Profile.Core/Unit/UnitContactPointServiceTests.cs
@@ -13,7 +13,7 @@ using Xunit;
 
 namespace Altinn.Profile.Tests.Profile.Core.Unit;
 
-public sealed class UnitContactPointServiceTest
+public sealed class UnitContactPointServiceTests
 {
     private const string _resourcePrefix = "urn:altinn:resource:";
 

--- a/test/Altinn.Profile.Tests/Profile.Integrations/OrganizationNotificationAddressTests/DataMapperTests.cs
+++ b/test/Altinn.Profile.Tests/Profile.Integrations/OrganizationNotificationAddressTests/DataMapperTests.cs
@@ -5,8 +5,6 @@ using Altinn.Profile.Integrations.OrganizationNotificationAddressRegistry.Models
 
 using Xunit;
 
-using static Altinn.Profile.Models.OrgNotificationAddressesResponse;
-
 namespace Altinn.Profile.Tests.Profile.Integrations.OrganizationNotificationAddressTests;
 
 public class DataMapperTests

--- a/test/Altinn.Profile.Tests/Profile/Models/OrgNotificationAddressesResponseTests.cs
+++ b/test/Altinn.Profile.Tests/Profile/Models/OrgNotificationAddressesResponseTests.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Altinn.Profile.Core.OrganizationNotificationAddresses;
+using Altinn.Profile.Models;
+
+using Xunit;
+
+namespace Altinn.Profile.Tests.Profile.Models;
+
+public class OrgNotificationAddressesResponseTests
+{
+    [Fact]
+    public void Create_ShouldReturnCorrectResponse()
+    {
+        // Arrange
+        var organizations = new List<Organization>
+        {
+            new Organization
+            {
+                OrganizationNumber = "81234567",
+                NotificationAddresses = new List<NotificationAddress>
+                {
+                    new NotificationAddress
+                    {
+                        Address = "navn",
+                        AddressType = AddressType.Email,
+                        Domain = "navnesen.no",
+                        FullAddress = "navn@navnesen.no"
+                    },
+                    new NotificationAddress
+                    {
+                        Address = "ola.nordmann",
+                        AddressType = AddressType.Email,
+                        Domain = "firma.no",
+                        FullAddress = "ola.nordmann@firma.no"
+                    }
+                }
+            },
+            new Organization
+            {
+                OrganizationNumber = "82345678",
+                NotificationAddresses = new List<NotificationAddress>
+                {
+                    new NotificationAddress
+                    {
+                        Address = "99999999",
+                        AddressType = AddressType.SMS,
+                        Domain = "+47",
+                        FullAddress = "+4799999999"
+                    },
+                    new NotificationAddress
+                    {
+                        Address = "kari.nordmann",
+                        AddressType = AddressType.Email,
+                        Domain = "firma.no",
+                        IsSoftDeleted = true,
+                        FullAddress = "kari.nordmann@firma.no"
+                    }
+                }
+            },
+            new Organization
+            {
+                OrganizationNumber = "83456789",
+                NotificationAddresses = new List<NotificationAddress>
+                {
+                    new NotificationAddress
+                    {
+                        Address = "99999999",
+                        AddressType = AddressType.SMS,
+                        Domain = "+47",
+                        FullAddress = "+4799999999",
+                        HasRegistryAccepted = false
+                    }
+                }
+            },
+            new Organization
+            {
+                OrganizationNumber = "31456789"
+            }
+        };
+
+        // Act
+        OrgNotificationAddressesResponse actual = OrgNotificationAddressesResponse.Create(organizations);
+
+        // Assert
+        Assert.NotNull(actual);
+        Assert.Equal(4, actual.ContactPointsList.Count);
+
+        // Item 1
+        Assert.Equal("81234567", actual.ContactPointsList[0].OrganizationNumber);
+        Assert.Equal("navn@navnesen.no", actual.ContactPointsList[0].EmailList[0]);
+        Assert.Equal("ola.nordmann@firma.no", actual.ContactPointsList[0].EmailList[1]);
+
+        // Item 2
+        Assert.Equal("82345678", actual.ContactPointsList[1].OrganizationNumber);
+        Assert.Equal("+4799999999", actual.ContactPointsList[1].MobileNumberList[0]);
+        Assert.Empty(actual.ContactPointsList[1].EmailList);
+
+        // Item 3
+        Assert.Equal("83456789", actual.ContactPointsList[2].OrganizationNumber);
+        Assert.Empty(actual.ContactPointsList[2].MobileNumberList);
+        Assert.Empty(actual.ContactPointsList[2].EmailList);
+
+        // Item 4
+        Assert.Equal("31456789", actual.ContactPointsList[3].OrganizationNumber);
+        Assert.Empty(actual.ContactPointsList[3].MobileNumberList);
+        Assert.Empty(actual.ContactPointsList[3].EmailList);
+    }
+}


### PR DESCRIPTION
## Description
Adding two endpoints so that the Correspondence services can access contact information for organizations.

## Related Issue(s)
- #899 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added correspondence API endpoints for organization notification address lookup and registered contact points.
  * Introduced `CorrespondenceAccess` authorization policy for correspondence notification settings.
* **Bug Fixes**
  * Improved organization number handling (trim, de-duplicate, ignore invalid values) and returns empty results when none are valid.
  * Enhanced resource ID handling by normalizing/sanitizing before contact-point validation.
* **Tests**
  * Added integration tests for correspondence endpoints and unit tests for contact point filtering/empty results, plus model factory tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->