### PR TITLE
Add bruno for new dashboard nin operation

### DIFF
--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/DashboardContactInformationControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/DashboardContactInformationControllerTests.cs
@@ -155,7 +155,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
         {
             // Arrange
             string orgNumber = "888888888";
-            
+
             SetupPartyQueryLookup(new Dictionary<Guid, string> { { Guid.NewGuid(), orgNumber } }, HttpStatusCode.PartialContent);
 
             HttpClient client = _factory.CreateClient();
@@ -164,7 +164,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
 
             // Act
             HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
-           
+
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
@@ -814,7 +814,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
             string encodedCountryCode = Uri.EscapeDataString(countryCode);
 
             HttpClient client = _factory.CreateClient();
-            
+
             HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, $"/profile/api/v1/dashboard/organizations/contactinformation/phoneNumber/{phoneNumber}?countrycode={encodedCountryCode}");
             httpRequestMessage = CreateAuthorizedRequestWithoutScope(httpRequestMessage);
 
@@ -940,7 +940,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
                     LastChanged = _testTime.AddDays(-1)
                 }
             };
-            
+
             _factory.ProfessionalNotificationsRepositoryMock
                 .Setup(r => r.GetAllContactInfoByPhoneNumberAsync(phoneNumber, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(contactInfosFromRepo);
@@ -1014,7 +1014,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
         [InlineData("004798765432", null)] // Number with 00 prefix
         [InlineData("12345", "+47")] // 5 digits with country code added
         [InlineData("987654321234546", "0047")] // 15 digits with country code
-        [InlineData("8798765432", null)]        
+        [InlineData("8798765432", null)]
         public async Task GetContactInformationByPhoneNumber_WithVariousPhoneNumberFormats_ReturnsOkWithUsers(string phoneNumber, string countryCode)
         {
             // Arrange
@@ -1059,7 +1059,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
             new Dictionary<int, Party>
             {
                 [1001] = registerPerson
-            }, 
+            },
             new Dictionary<Guid, string>
             {
                 [partyUuid] = orgNumber
@@ -1108,7 +1108,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.API.Controllers
                 ? $"/profile/api/v1/dashboard/organizations/contactinformation/phoneNumber/{searchPhoneNumber}"
                 : $"/profile/api/v1/dashboard/organizations/contactinformation/phoneNumber/{searchPhoneNumber}?countrycode={Uri.EscapeDataString(countryCode)}";
 
-            HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, $"/profile/api/v1/dashboard/organizations/contactinformation/phoneNumber/{searchPhoneNumber}");
+            HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, requestUrl);
             httpRequestMessage = CreateAuthorizedRequestWithScope(httpRequestMessage);
 
             // Act

--- a/test/Bruno/Profile/Dashboard/GetAllNotificationAddressesForAnOrg.bru
+++ b/test/Bruno/Profile/Dashboard/GetAllNotificationAddressesForAnOrg.bru
@@ -1,5 +1,5 @@
 meta {
-  name: GetAllNotificationAddressesForAnOrg
+  name: All Notification Addresses For An Org
   type: http
   seq: 1
 }

--- a/test/Bruno/Profile/Dashboard/GetContactInformationByEmailAddress.bru
+++ b/test/Bruno/Profile/Dashboard/GetContactInformationByEmailAddress.bru
@@ -1,7 +1,7 @@
 meta {
   name: GetContactInformationByEmailAddress
   type: http
-  seq: 3
+  seq: 4
 }
 
 get {

--- a/test/Bruno/Profile/Dashboard/GetContactInformationByEmailAddress.bru
+++ b/test/Bruno/Profile/Dashboard/GetContactInformationByEmailAddress.bru
@@ -1,5 +1,5 @@
 meta {
-  name: GetContactInformationByEmailAddress
+  name: Organization Contact Information By Email Address
   type: http
   seq: 4
 }

--- a/test/Bruno/Profile/Dashboard/GetContactInformationByNin.bru
+++ b/test/Bruno/Profile/Dashboard/GetContactInformationByNin.bru
@@ -38,7 +38,7 @@ tests {
     expect(contact).to.have.property('emailLastUpdatedOrVerified');
     expect(contact).to.have.property('phoneNumber');
     expect(contact).to.have.property('phoneNumberLastUpdatedOrVerified');
-    // emailAddress and phoneNumber should have either null or string value, and when there's a value the ..LastUpdatedOrVerified field should be string (actually datetime)
+    // emailAddress and phoneNumber should have either null or string value, and when there's a value the ..LastUpdatedOrVerified field should be string (actually datetime).
     if (contact.emailAddress !== null) {
       expect(contact.emailAddress).to.be.a('string');
       expect(contact.emailLastUpdatedOrVerified).to.be.a('string');
@@ -83,7 +83,7 @@ docs {
     "nationalIdentityNumber": "01010112345",
     "isReserved": true,
     "emailAddress": null,
-    "emailLastUpdatedOrVerified": null,
+    "emailLastUpdatedOrVerified": "2025-01-10T11:30:00Z",
     "phoneNumber": "+4798765432",
     "phoneNumberLastUpdatedOrVerified": "2025-01-15T14:20:00Z"
   }
@@ -96,7 +96,7 @@ docs {
     "emailAddress": "jane.smith@example.com",
     "emailLastUpdatedOrVerified": "2025-01-10T11:30:00Z",
     "phoneNumber": null,
-    "phoneNumberLastUpdatedOrVerified": "2025-01-15T15:30:00Z"
+    "phoneNumberLastUpdatedOrVerified": null
   }
   ```
   
@@ -107,6 +107,8 @@ docs {
     - equivalent for email
     - holds `null` if the user has not yet registered a value for that address type
     - may have a value for cases where the user has added and then removed the address
+  - `emailLastUpdatedOrVerified` may have a value even though `emailAddress` is null, if the user has intentionally removed a previous email address from their contact information settings
+    - Does not apply for `phoneNumber`, as that field cannot be removed once set (only updated to a different valid number)
   
   ## Status Codes
   

--- a/test/Bruno/Profile/Dashboard/GetContactInformationByNin.bru
+++ b/test/Bruno/Profile/Dashboard/GetContactInformationByNin.bru
@@ -1,0 +1,116 @@
+meta {
+  name: GetContactInformationByNin
+  type: http
+  seq: 7
+}
+
+get {
+  url: {{ProfileBaseAddress}}/api/v1/dashboard/users/contactinformation
+  body: none
+  auth: inherit
+}
+
+headers {
+  NationalIdentityNumber: 18874198354
+}
+
+script:pre-request {
+  await bru.runRequest("TokenGenerator/Application Owner Profile scope")
+}
+
+tests {
+  test("should return 200 OK", function() {
+    expect(res.getStatus()).to.equal(200);
+  });
+  
+  test("should return a single object", function() {
+    const body = res.getBody();
+    expect(body).to.be.an('object');
+  });
+  
+  test("each contact should have required fields", function() {
+    const contact = res.getBody();
+    expect(contact).to.have.property('nationalIdentityNumber');
+    expect(contact.nationalIdentityNumber).to.be.a('string');
+    expect(contact).to.have.property('isReserved');
+    expect(contact.isReserved).to.be.a('boolean');
+    expect(contact).to.have.property('emailAddress');
+    expect(contact).to.have.property('emailLastUpdatedOrVerified');
+    expect(contact).to.have.property('phoneNumber');
+    expect(contact).to.have.property('phoneNumberLastUpdatedOrVerified');
+    // emailAddress and phoneNumber should have either null or string value, and when there's a value the ..LastUpdatedOrVerified field should be string (actually datetime)
+    if (contact.emailAddress !== null) {
+      expect(contact.emailAddress).to.be.a('string');
+      expect(contact.emailLastUpdatedOrVerified).to.be.a('string');
+    }
+    if (contact.phoneNumber !== null) {
+      expect(contact.phoneNumber).to.be.a('string');
+      expect(contact.phoneNumberLastUpdatedOrVerified).to.be.a('string');
+    }
+  });
+}
+
+docs {
+  # Get Contact Information by National identity number
+  
+  Retrieves personal contact information that the user has registered in the national registry (KRR)
+  
+  ## Purpose
+  
+  Used by the Support Dashboard to view "Your contact information for organization" - this is **user-registered** contact data, NOT organization registry data.
+  
+  ## Key Differences from Other Dashboard Endpoints
+  
+  | Aspect | This Endpoint | Other Dashboard Endpoints |
+  |--------|---------------|---------------------------|
+  | Data Source | User-registered contact info in KRR | Other |
+  | Includes SSN/Name | ✅ Yes | - |
+  | User Count | 1 | N/A |
+  | Timestamp | One per address entry | - |
+  
+  ## Authentication
+  
+  Requires Dashboard Maskinporten scope: `altinn:profile.support.admin`
+  
+  ## Parameters
+  
+  - `NationalIdentityNumber` (header): 11-digit NIN / SSN
+  
+  ## Response Examples
+  
+  ```json
+  {
+    "nationalIdentityNumber": "01010112345",
+    "isReserved": true,
+    "emailAddress": null,
+    "emailLastUpdatedOrVerified": null,
+    "phoneNumber": "+4798765432",
+    "phoneNumberLastUpdatedOrVerified": "2025-01-15T14:20:00Z"
+  }
+  ```
+  
+  ```json
+  {
+    "nationalIdentityNumber": "01010198765",
+    "isReserved": false,
+    "emailAddress": "jane.smith@example.com",
+    "emailLastUpdatedOrVerified": "2025-01-10T11:30:00Z",
+    "phoneNumber": null,
+    "phoneNumberLastUpdatedOrVerified": "2025-01-15T15:30:00Z"
+  }
+  ```
+  
+  ## Features
+  
+  - Returns the contact information that the given user (identified by NIN) has registered in the national common contact register (KRR)
+  - `phoneNumberLastUpdatedOrVerified` reflects the last time that the user updated or verified their phone number (whichever operation was performed most recently).
+    - equivalent for email
+    - holds `null` if the user has not yet registered a value for that address type
+  
+  ## Status Codes
+  
+  - **200 OK**: Successfully retrieved user contact information
+  - **403 Forbidden**: Missing required scope
+  - **404 Not Found**: User with the provided National Identity Number does not exist
+  
+}

--- a/test/Bruno/Profile/Dashboard/GetContactInformationByNin.bru
+++ b/test/Bruno/Profile/Dashboard/GetContactInformationByNin.bru
@@ -106,10 +106,12 @@ docs {
   - `phoneNumberLastUpdatedOrVerified` reflects the last time that the user updated or verified their phone number (whichever operation was performed most recently).
     - equivalent for email
     - holds `null` if the user has not yet registered a value for that address type
+    - may have a value for cases where the user has added and then removed the address
   
   ## Status Codes
   
   - **200 OK**: Successfully retrieved user contact information
+  - **400 Bad Request**: Invalid request parameters (invalid NIN header value)
   - **403 Forbidden**: Missing required scope
   - **404 Not Found**: User with the provided National Identity Number does not exist
   

--- a/test/Bruno/Profile/Dashboard/GetContactInformationByNin.bru
+++ b/test/Bruno/Profile/Dashboard/GetContactInformationByNin.bru
@@ -1,5 +1,5 @@
 meta {
-  name: GetContactInformationByNin
+  name: User Contact Information By Nin
   type: http
   seq: 7
 }

--- a/test/Bruno/Profile/Dashboard/GetContactInformationByOrgNumber.bru
+++ b/test/Bruno/Profile/Dashboard/GetContactInformationByOrgNumber.bru
@@ -1,5 +1,5 @@
 meta {
-  name: GetContactInformationByOrgNumber
+  name: Organization Contact Information By OrgNumber
   type: http
   seq: 5
 }

--- a/test/Bruno/Profile/Dashboard/GetContactInformationByOrgNumber.bru
+++ b/test/Bruno/Profile/Dashboard/GetContactInformationByOrgNumber.bru
@@ -1,7 +1,7 @@
 meta {
   name: GetContactInformationByOrgNumber
   type: http
-  seq: 3
+  seq: 5
 }
 
 get {

--- a/test/Bruno/Profile/Dashboard/GetContactInformationByPhoneNumber.bru
+++ b/test/Bruno/Profile/Dashboard/GetContactInformationByPhoneNumber.bru
@@ -1,7 +1,7 @@
 meta {
   name: GetContactInformationByPhoneNumber
   type: http
-  seq: 3
+  seq: 6
 }
 
 get {

--- a/test/Bruno/Profile/Dashboard/GetContactInformationByPhoneNumber.bru
+++ b/test/Bruno/Profile/Dashboard/GetContactInformationByPhoneNumber.bru
@@ -1,5 +1,5 @@
 meta {
-  name: GetContactInformationByPhoneNumber
+  name: Organization Contact Information By Phone Number
   type: http
   seq: 6
 }

--- a/test/Bruno/Profile/Dashboard/GetNotificationAddressesByEmailAddress.bru
+++ b/test/Bruno/Profile/Dashboard/GetNotificationAddressesByEmailAddress.bru
@@ -1,5 +1,5 @@
 meta {
-  name: GetNotificationAddressesByEmailAddress
+  name: Organization Notification Addresses By Email Address
   type: http
   seq: 2
 }

--- a/test/Bruno/Profile/Dashboard/GetNotificationAddressesByPhoneNumber.bru
+++ b/test/Bruno/Profile/Dashboard/GetNotificationAddressesByPhoneNumber.bru
@@ -1,7 +1,7 @@
 meta {
   name: GetNotificationAddressesByPhoneNumber
   type: http
-  seq: 2
+  seq: 3
 }
 
 get {

--- a/test/Bruno/Profile/Dashboard/GetNotificationAddressesByPhoneNumber.bru
+++ b/test/Bruno/Profile/Dashboard/GetNotificationAddressesByPhoneNumber.bru
@@ -1,5 +1,5 @@
 meta {
-  name: GetNotificationAddressesByPhoneNumber
+  name: Organization Notification Addresses By Phone Number
   type: http
   seq: 3
 }


### PR DESCRIPTION
Other changes:
- Give unique folder sequence (`meta.seq`) to each Bruno file in the Dashboard folder
- Take an unused variable (`requestUrl`) into use in `DashboardContactInformationControllerTests.GetContactInformationByPhoneNumber_WithInvalidPhoneNumberFormat_ReturnsBadRequest`, to add a `countryCode` query param to the test-request URL if the Theory supplies a value for it

Related issue: #980 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a new end-to-end dashboard contact-information test for lookups by national identity number, including response field validation and documentation.

* **Tests**
  * Improved and aligned dashboard contact-information tests for phone number variations and ensured the invalid-format cases hit the correct endpoint.

* **Chores**
  * Updated metadata (names/sequence ordering) for several existing dashboard request tests to keep them consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->