### PR TITLE
Swap paths for the two endpoints in CorrespondenceController

### DIFF
--- a/src/Altinn.Profile/Controllers/CorrespondenceController.cs
+++ b/src/Altinn.Profile/Controllers/CorrespondenceController.cs
@@ -55,7 +55,7 @@ public class CorrespondenceController : ControllerBase
     /// <returns>
     /// Returns a list of user-registered notification addresses for the provided units.
     /// </returns>
-    [HttpPost("organizations/notificationaddresses/lookup")]
+    [HttpPost("units/contactpoint/lookup")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<UnitContactPointsList>> GetUserRegisteredContactPoints(
@@ -80,7 +80,7 @@ public class CorrespondenceController : ControllerBase
     /// <param name="orgContactPointLookup">The search criteria.</param>
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
     /// <returns>Returns an overview of the user registered notification addresses for the provided organization</returns>
-    [HttpPost("units/contactpoint/lookup")]
+    [HttpPost("organizations/notificationaddresses/lookup")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<OrgNotificationAddressesResponse>> GetOrganizationRegisteredContactPoints(

--- a/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/CorrespondenceControllerTests.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/API/Controllers/CorrespondenceControllerTests.cs
@@ -55,7 +55,7 @@ public class CorrespondenceControllerTests : IClassFixture<ProfileWebApplication
         // Arrange
         string token = PrincipalUtil.GetOrgToken("digdir", 4, "altinn:profile/correspondence.notificationsettings.read");
 
-        HttpRequestMessage httpRequestMessage = new(HttpMethod.Post, "/profile/api/v1/correspondence/organizations/notificationaddresses/lookup")
+        HttpRequestMessage httpRequestMessage = new(HttpMethod.Post, "/profile/api/v1/correspondence/units/contactpoint/lookup")
         {
             Content = new StringContent(input, System.Text.Encoding.UTF8, "application/json")
         };
@@ -82,7 +82,7 @@ public class CorrespondenceControllerTests : IClassFixture<ProfileWebApplication
 
         string token = PrincipalUtil.GetOrgToken("digdir", 4, "altinn:profile/correspondence.notificationsettings.read");
 
-        HttpRequestMessage httpRequestMessage = new(HttpMethod.Post, "/profile/api/v1/correspondence/organizations/notificationaddresses/lookup")
+        HttpRequestMessage httpRequestMessage = new(HttpMethod.Post, "/profile/api/v1/correspondence/units/contactpoint/lookup")
         {
             Content = JsonContent.Create(input)
         };
@@ -111,7 +111,7 @@ public class CorrespondenceControllerTests : IClassFixture<ProfileWebApplication
         // Arrange
         string token = PrincipalUtil.GetOrgToken("digdir", 4, "altinn:profile/correspondence.notificationsettings.read");
 
-        HttpRequestMessage httpRequestMessage = new(HttpMethod.Post, "/profile/api/v1/correspondence/units/contactpoint/lookup")
+        HttpRequestMessage httpRequestMessage = new(HttpMethod.Post, "/profile/api/v1/correspondence/organizations/notificationaddresses/lookup")
         {
             Content = new StringContent(input, System.Text.Encoding.UTF8, "application/json")
         };
@@ -137,7 +137,7 @@ public class CorrespondenceControllerTests : IClassFixture<ProfileWebApplication
 
         string token = PrincipalUtil.GetOrgToken("digdir", 4, "altinn:profile/correspondence.notificationsettings.read");
 
-        HttpRequestMessage httpRequestMessage = new(HttpMethod.Post, "/profile/api/v1/correspondence/units/contactpoint/lookup")
+        HttpRequestMessage httpRequestMessage = new(HttpMethod.Post, "/profile/api/v1/correspondence/organizations/notificationaddresses/lookup")
         {
             Content = JsonContent.Create(input)
         };


### PR DESCRIPTION
## Description
Swapping the paths for the two endpoints in the CorrespondenceController. The new endpoints will with this match the endpoints available for Notifications.

## Related Issue(s)
- #899 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [ ] Manual testing done (required)

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the contact point lookup request paths so user and organization endpoints now resolve to the intended API routes.
  * Updated related integration coverage to match the new request URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->