### PR TITLE
Migrate from Newtonsoft.Json to System.Text.Json

### DIFF
--- a/test/Altinn.Profile.Tests/IntegrationTests/Mocks/PepWithPDPAuthorizationMockSI.cs
+++ b/test/Altinn.Profile.Tests/IntegrationTests/Mocks/PepWithPDPAuthorizationMockSI.cs
@@ -3,9 +3,11 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Security.Claims;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
+
 using Altinn.Authorization.ABAC;
 using Altinn.Authorization.ABAC.Constants;
 using Altinn.Authorization.ABAC.Utils;
@@ -14,7 +16,6 @@ using Altinn.Authorization.ABAC.Xacml.JsonProfile;
 using Altinn.Common.PEP.Helpers;
 using Altinn.Common.PEP.Interfaces;
 using Altinn.Profile.Tests.IntegrationTests.Utils;
-using Newtonsoft.Json;
 
 namespace Altinn.Profile.Tests.IntegrationTests.Mocks
 {
@@ -231,7 +232,7 @@ namespace Altinn.Profile.Tests.IntegrationTests.Mocks
             if (File.Exists(rolesPath))
             {
                 string content = File.ReadAllText(rolesPath);
-                roles = JsonConvert.DeserializeObject<List<Role>>(content);
+                roles = JsonSerializer.Deserialize<List<Role>>(content);
             }
 
             return Task.FromResult(roles);


### PR DESCRIPTION
## Description
All tests failed because of a reference to Newtonsoft.Json which was not installed. I migrated the logic from `Newtonsoft.Json` to `System.Text.Json`

## Related Issue(s)
- #https://github.com/Altinn/team-core-private/issues/518

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test authorization mock data handling to improve compatibility when loading role information.
  * No user-facing functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->