### PR TITLE
Add new connection string for application insights

### DIFF
--- a/src/Altinn.Profile/Program.cs
+++ b/src/Altinn.Profile/Program.cs
@@ -222,14 +222,12 @@ void ConfigureServices(IServiceCollection services, IConfiguration config)
 
 static void AddAzureMonitorTelemetryExporters(IServiceCollection services, IConfiguration config)
 {
-    var instrumentationKey = config.GetValue<string>("ApplicationInsights:InstrumentationKey");
+    var applicationInsightsConnectionString = config.GetValue<string>("ApplicationInsights:ConnectionString");
 
-    if (string.IsNullOrEmpty(instrumentationKey))
+    if (string.IsNullOrEmpty(applicationInsightsConnectionString))
     {
         return;
     }
-
-    var applicationInsightsConnectionString = string.Format("InstrumentationKey={0}", instrumentationKey);
 
     services.Configure<OpenTelemetryLoggerOptions>(logging => logging.AddAzureMonitorLogExporter(o =>
     {

--- a/src/Altinn.Profile/Program.cs
+++ b/src/Altinn.Profile/Program.cs
@@ -224,7 +224,7 @@ static void AddAzureMonitorTelemetryExporters(IServiceCollection services, IConf
 {
     var applicationInsightsConnectionString = config.GetValue<string>("ApplicationInsights:ConnectionString");
 
-    if (string.IsNullOrEmpty(applicationInsightsConnectionString))
+    if (string.IsNullOrWhiteSpace(applicationInsightsConnectionString))
     {
         return;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #1010 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Azure Monitor telemetry configuration by using the configured Application Insights connection string directly.
  * Telemetry export remains enabled only when a valid connection string is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->